### PR TITLE
fix: validate profile update fields

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from flask_login import LoginManager, UserMixin, login_user, login_required, log
 from flask_bcrypt import Bcrypt
 from authlib.integrations.flask_client import OAuth
 from dotenv import load_dotenv
+from profile_validation import build_profile_updates
 
 load_dotenv()
 
@@ -852,11 +853,9 @@ def edit_profile():
     data = request.get_json()
     if not data:
         return jsonify({"success": False, "error": "No data"}), 400
-    # Text fields
-    update_fields = {}
-    for field in ['name','bio','location','college','headline','linkedin_url','twitter_url','website_url','resume_url']:
-        if field in data:
-            update_fields[field] = data[field].strip()
+    update_fields, error = build_profile_updates(data)
+    if error:
+        return jsonify({"success": False, "error": error}), 400
     if update_fields:
         db.user.update_one({'_id': current_user.id}, {'$set': update_fields})
         current_user.reload()

--- a/profile_validation.py
+++ b/profile_validation.py
@@ -1,0 +1,41 @@
+from urllib.parse import urlparse
+
+
+PROFILE_FIELD_LIMITS = {
+    'name': 100,
+    'bio': 500,
+    'location': 100,
+    'college': 200,
+    'headline': 150,
+    'linkedin_url': 300,
+    'twitter_url': 300,
+    'website_url': 300,
+    'resume_url': 300,
+}
+PROFILE_URL_FIELDS = {'linkedin_url', 'twitter_url', 'website_url', 'resume_url'}
+
+
+def build_profile_updates(data):
+    update_fields = {}
+    for field, max_length in PROFILE_FIELD_LIMITS.items():
+        if field not in data:
+            continue
+
+        value = data[field]
+        if value is None:
+            update_fields[field] = ''
+            continue
+        if not isinstance(value, str):
+            return None, f'{field} must be text'
+
+        value = value.strip()
+        if len(value) > max_length:
+            return None, f'{field} must be at most {max_length} characters'
+
+        if field in PROFILE_URL_FIELDS and value:
+            parsed = urlparse(value)
+            if parsed.scheme not in {'http', 'https'} or not parsed.netloc:
+                return None, f'Invalid URL for {field}'
+
+        update_fields[field] = value
+    return update_fields, None

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -1,0 +1,37 @@
+from profile_validation import build_profile_updates
+
+
+def test_profile_updates_trim_text_and_accept_https_urls():
+    updates, error = build_profile_updates({
+        'name': '  Saurabh  ',
+        'bio': 'Building AI systems',
+        'website_url': 'https://example.com/portfolio',
+    })
+
+    assert error is None
+    assert updates == {
+        'name': 'Saurabh',
+        'bio': 'Building AI systems',
+        'website_url': 'https://example.com/portfolio',
+    }
+
+
+def test_profile_updates_reject_overlong_text():
+    updates, error = build_profile_updates({'bio': 'x' * 501})
+
+    assert updates is None
+    assert error == 'bio must be at most 500 characters'
+
+
+def test_profile_updates_reject_javascript_urls():
+    updates, error = build_profile_updates({'linkedin_url': 'javascript:alert(1)'})
+
+    assert updates is None
+    assert error == 'Invalid URL for linkedin_url'
+
+
+def test_profile_updates_reject_non_text_values():
+    updates, error = build_profile_updates({'headline': {'nested': 'value'}})
+
+    assert updates is None
+    assert error == 'headline must be text'


### PR DESCRIPTION
# Description

Adds server-side validation for `/edit_profile` so profile fields cannot store arbitrary payloads or unsafe URL schemes. The route now delegates validation to a focused helper that:

- enforces max lengths for all editable profile text fields
- rejects non-text values with a 400 response
- only accepts `http`/`https` URLs for profile links
- blocks unsafe schemes like `javascript:`

Fixes #94

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Tested in Local

Validation run:

```bash
/tmp/450-dsa-profile-tests/bin/python -m pytest tests/test_profile_validation.py -q
python3 -m py_compile app.py profile_validation.py tests/test_profile_validation.py
git diff --check
```