### PR TITLE
feat: export topic notes as markdown

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,13 +5,14 @@ import requests
 import base64
 from datetime import datetime
 from urllib.parse import quote_plus
-from flask import Flask, render_template, request, redirect, url_for, jsonify, flash, session
+from flask import Flask, render_template, request, redirect, url_for, jsonify, flash, session, Response
 from pymongo import MongoClient
 from bson import ObjectId
 from flask_login import LoginManager, UserMixin, login_user, login_required, logout_user, current_user
 from flask_bcrypt import Bcrypt
 from authlib.integrations.flask_client import OAuth
 from dotenv import load_dotenv
+from notes_export import build_topic_notes_markdown, topic_notes_filename
 
 load_dotenv()
 
@@ -718,6 +719,24 @@ def topic(topic_id):
         progress_dict = {}
     
     return render_template('topic.html', topic=topic_doc, questions=questions, progress_dict=progress_dict)
+
+@app.route('/topic/<topic_id>/export-notes')
+@login_required
+def export_topic_notes(topic_id):
+    try:
+        topic_doc = db.topic.find_one({'_id': ObjectId(topic_id)})
+    except Exception:
+        return "Topic not found", 404
+    if not topic_doc:
+        return "Topic not found", 404
+
+    questions = list(db.question.find({'topic': topic_doc['_id']}))
+    markdown = build_topic_notes_markdown(topic_doc['name'], questions, current_user.progress)
+    response = Response(markdown, mimetype='text/markdown')
+    response.headers['Content-Disposition'] = (
+        f'attachment; filename={topic_notes_filename(topic_doc["name"])}'
+    )
+    return response
 
 @app.route('/update_question/<question_id>', methods=['POST'])
 @login_required

--- a/notes_export.py
+++ b/notes_export.py
@@ -1,0 +1,21 @@
+import re
+
+
+def build_topic_notes_markdown(topic_name, questions, progress):
+    lines = [f'# {topic_name} Notes']
+
+    for question in questions:
+        question_id = str(question.get('_id'))
+        note = (progress.get(question_id, {}) or {}).get('notes', '').strip()
+        if not note:
+            continue
+
+        problem = question.get('problem') or 'Untitled Problem'
+        lines.extend(['', f'## {problem}', '', note])
+
+    return '\n'.join(lines) + '\n'
+
+
+def topic_notes_filename(topic_name):
+    slug = re.sub(r'[^a-zA-Z0-9]+', '_', topic_name).strip('_').lower()
+    return f'{slug or "topic"}_notes.md'

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -31,6 +31,10 @@
 .notes-btn-sm { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 8px; padding: 5px 10px; font-size: 0.77rem; font-weight: 600; color: var(--text-secondary); cursor: pointer; transition: all 0.2s; font-family: inherit; }
 .notes-btn-sm:hover { border-color: var(--accent); color: var(--accent); }
 .notes-btn-sm.has-notes { border-color: var(--info); color: var(--info); }
+.topic-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
+.topic-header-main { min-width: 0; }
+.export-notes-btn { display: inline-flex; align-items: center; gap: 7px; padding: 8px 14px; border: 1px solid var(--border-color); border-radius: 8px; background: var(--bg-secondary); color: var(--text-secondary); font-size: 0.82rem; font-weight: 700; text-decoration: none; white-space: nowrap; transition: all 0.2s; }
+.export-notes-btn:hover { border-color: var(--accent); color: var(--accent); text-decoration: none; }
 
 /* Modal */
 .modal-overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.7); z-index: 9999; align-items: center; justify-content: center; }
@@ -45,6 +49,8 @@
 .btn-modal-save:hover { background: var(--accent-hover); }
 
 @media (max-width: 640px) {
+    .topic-header { flex-direction: column; align-items: stretch; }
+    .export-notes-btn { justify-content: center; }
     .q-table thead th:nth-child(1), .q-table tbody td:nth-child(1) { display: none; }
     .q-table { font-size: 0.82rem; }
     .q-table tbody td { padding: 10px 10px; }
@@ -55,8 +61,17 @@
     <i class="bi bi-arrow-left"></i> Back to Topics
 </a>
 
-<div class="topic-title">{{ topic.name }}</div>
-<div class="topic-subtitle">{{ questions | list | length }} questions in this topic</div>
+<div class="topic-header">
+    <div class="topic-header-main">
+        <div class="topic-title">{{ topic.name }}</div>
+        <div class="topic-subtitle">{{ questions | list | length }} questions in this topic</div>
+    </div>
+    {% if current_user.is_authenticated %}
+    <a href="{{ url_for('export_topic_notes', topic_id=topic._id|string) }}" class="export-notes-btn">
+        <i class="bi bi-download"></i> Export Notes
+    </a>
+    {% endif %}
+</div>
 
 <div class="questions-table-wrap">
     <table class="q-table">

--- a/tests/test_notes_export.py
+++ b/tests/test_notes_export.py
@@ -1,0 +1,32 @@
+from notes_export import build_topic_notes_markdown, topic_notes_filename
+
+
+def test_topic_notes_markdown_includes_only_questions_with_notes():
+    questions = [
+        {'_id': 'q1', 'problem': 'Two Sum'},
+        {'_id': 'q2', 'problem': 'Missing Number'},
+        {'_id': 'q3', 'problem': 'Kadane Algorithm'},
+    ]
+    progress = {
+        'q1': {'notes': 'Use a hash map.'},
+        'q2': {'notes': '   '},
+        'q3': {'done': True},
+    }
+
+    markdown = build_topic_notes_markdown('Arrays', questions, progress)
+
+    assert markdown == '# Arrays Notes\n\n## Two Sum\n\nUse a hash map.\n'
+    assert 'Missing Number' not in markdown
+    assert 'Kadane Algorithm' not in markdown
+
+
+def test_topic_notes_markdown_falls_back_for_untitled_problem():
+    markdown = build_topic_notes_markdown('Graphs', [{'_id': 'q1'}], {'q1': {'notes': 'BFS first.'}})
+
+    assert '## Untitled Problem' in markdown
+    assert 'BFS first.' in markdown
+
+
+def test_topic_notes_filename_sanitizes_topic_name():
+    assert topic_notes_filename('Dynamic Programming & Greedy!') == 'dynamic_programming_greedy_notes.md'
+    assert topic_notes_filename('***') == 'topic_notes.md'


### PR DESCRIPTION
# Description

Adds a login-required topic notes export flow. Authenticated users now get an **Export Notes** button on each topic page, which downloads a Markdown file containing only questions where they have saved notes.

The export keeps the format simple for offline study:

```md
# Arrays Notes

## Two Sum

Use a hash map.
```

Fixes #93

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Tested in Local

Validation run:

```bash
/tmp/450-dsa-profile-tests/bin/python -m pytest tests/test_notes_export.py -q
python3 -m py_compile app.py notes_export.py tests/test_notes_export.py
git diff --check
```