### PR TITLE
feat: export progress as CSV

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from authlib.integrations.flask_client import OAuth
 from dotenv import load_dotenv
 from profile_validation import build_profile_updates
 from notes_export import build_topic_notes_markdown, topic_notes_filename
+from progress_export import build_progress_csv
 
 load_dotenv()
 
@@ -964,6 +965,20 @@ def bookmarks():
     progress_dict = progress
     
     return render_template('bookmarks.html', questions=questions, progress_dict=progress_dict)
+
+@app.route('/export/csv')
+@login_required
+def export_csv():
+    questions = list(db.question.find())
+    topic_ids = list({q.get('topic') for q in questions if q.get('topic')})
+    topic_lookup = {
+        topic['_id']: topic.get('name', 'Unknown')
+        for topic in db.topic.find({'_id': {'$in': topic_ids}}, {'name': 1})
+    }
+    csv_data = build_progress_csv(questions, topic_lookup, current_user.progress)
+    response = Response(csv_data, mimetype='text/csv')
+    response.headers['Content-Disposition'] = 'attachment; filename=my_dsa_progress.csv'
+    return response
 
 @app.route('/profile')
 @login_required

--- a/progress_export.py
+++ b/progress_export.py
@@ -1,0 +1,26 @@
+import csv
+from io import StringIO
+
+
+CSV_HEADERS = ['Topic', 'Problem', 'Done', 'Bookmarked', 'Notes', 'URL']
+
+
+def build_progress_csv(questions, topic_lookup, progress):
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow(CSV_HEADERS)
+
+    for question in questions:
+        question_id = str(question.get('_id'))
+        item_progress = progress.get(question_id, {}) or {}
+        topic_name = topic_lookup.get(question.get('topic'), 'Unknown')
+        writer.writerow([
+            topic_name,
+            question.get('problem', ''),
+            bool(item_progress.get('done', False)),
+            bool(item_progress.get('bookmark', False)),
+            item_progress.get('notes', ''),
+            question.get('url', ''),
+        ])
+
+    return output.getvalue()

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -110,6 +110,9 @@
       <i class="bi bi-patch-check-fill" style="color:var(--success);font-size:.85rem"></i>
     </div>
     <button class="card-btn" onclick="showCodelioCard()">Get your Codolio Card</button>
+    <a class="card-btn" href="{{ url_for('export_csv') }}" style="background:var(--bg-secondary);border:1px solid var(--border-color);color:var(--text-secondary)">
+      <i class="bi bi-download" style="margin-right:6px"></i> Export Progress CSV
+    </a>
     <div class="prof-bio">{{ user.bio or 'Software Engineer | Problem Solver | DSA Enthusiast' }}</div>
     <div class="social-row">
       {% if user.email %}<a href="mailto:{{ user.email }}" class="social-icon" title="Email"><i class="bi bi-envelope"></i></a>{% endif %}

--- a/tests/test_progress_export.py
+++ b/tests/test_progress_export.py
@@ -1,0 +1,41 @@
+import csv
+from io import StringIO
+
+from progress_export import CSV_HEADERS, build_progress_csv
+
+
+def parse_csv(value):
+    return list(csv.reader(StringIO(value)))
+
+
+def test_progress_csv_includes_all_questions_with_statuses():
+    questions = [
+        {'_id': 'q1', 'topic': 't1', 'problem': 'Two Sum', 'url': 'https://example.com/two-sum'},
+        {'_id': 'q2', 'topic': 't2', 'problem': 'Binary Search'},
+    ]
+    progress = {
+        'q1': {'done': True, 'bookmark': True, 'notes': 'Use a hash map.'},
+    }
+
+    rows = parse_csv(build_progress_csv(questions, {'t1': 'Arrays', 't2': 'Search'}, progress))
+
+    assert rows[0] == CSV_HEADERS
+    assert rows[1] == ['Arrays', 'Two Sum', 'True', 'True', 'Use a hash map.', 'https://example.com/two-sum']
+    assert rows[2] == ['Search', 'Binary Search', 'False', 'False', '', '']
+
+
+def test_progress_csv_escapes_commas_and_newlines_in_notes():
+    questions = [{'_id': 'q1', 'topic': 't1', 'problem': 'Intervals'}]
+    progress = {'q1': {'notes': 'sort by start,\nthen merge'}}
+
+    rows = parse_csv(build_progress_csv(questions, {'t1': 'Arrays'}, progress))
+
+    assert rows[1][4] == 'sort by start,\nthen merge'
+
+
+def test_progress_csv_uses_unknown_topic_fallback():
+    questions = [{'_id': 'q1', 'topic': 'missing', 'problem': 'Mystery'}]
+
+    rows = parse_csv(build_progress_csv(questions, {}, {}))
+
+    assert rows[1][0] == 'Unknown'


### PR DESCRIPTION
# Description

Adds a login-required CSV export for full DSA progress. Users can download `my_dsa_progress.csv` from the profile page, with every question included and unsolved/unbookmarked items marked as `False`.

CSV columns:

- Topic
- Problem
- Done
- Bookmarked
- Notes
- URL

Fixes #84

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Tested in Local

Validation run:

```bash
/tmp/450-dsa-profile-tests/bin/python -m pytest tests/test_progress_export.py -q
python3 -m py_compile app.py progress_export.py tests/test_progress_export.py
git diff --check
```