### PR TITLE
feat: add daily streak tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from authlib.integrations.flask_client import OAuth
 from dotenv import load_dotenv
 from profile_validation import build_profile_updates
 from notes_export import build_topic_notes_markdown, topic_notes_filename
+from streaks import compute_streak
 
 load_dotenv()
 
@@ -102,6 +103,15 @@ def ensure_utc_datetime(value):
     if value and value.tzinfo is None:
         return value.replace(tzinfo=timezone.utc)
     return value
+
+
+@app.context_processor
+def inject_streak_summary():
+    if current_user.is_authenticated:
+        current_streak, _ = compute_streak(current_user.progress)
+        return {'current_streak': current_streak}
+    return {'current_streak': 0}
+
 
 def fetch_leetcode(username):
     try:
@@ -1010,6 +1020,7 @@ def profile():
             daily_counts[d_str] = daily_counts.get(d_str, 0) + count
 
     total_active_days = len(daily_counts)
+    current_streak, longest_streak = compute_streak(user.progress)
     sorted_dates = sorted(daily_counts.keys())
     cumulative_data = []
     cum_sum = 0
@@ -1095,6 +1106,8 @@ def profile():
                            daily_counts=daily_counts,
                            cumulative_data=cumulative_data,
                            total_active_days=total_active_days,
+                           current_streak=current_streak,
+                           longest_streak=longest_streak,
                            rating_history=rating_history,
                            lc_badges=lc_badges,
                            hr_badges=hr_badges)

--- a/streaks.py
+++ b/streaks.py
@@ -1,0 +1,46 @@
+from datetime import date, datetime, timedelta, timezone
+
+
+def _to_utc_date(value):
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).date()
+    if isinstance(value, date):
+        return value
+    return None
+
+
+def compute_streak(progress, today=None):
+    today = today or datetime.now(timezone.utc).date()
+    solved_dates = {
+        solved_date
+        for item in progress.values()
+        if item.get('done')
+        for solved_date in (_to_utc_date(item.get('timestamp')),)
+        if solved_date
+    }
+
+    if not solved_dates:
+        return 0, 0
+
+    longest_streak = 0
+    run_length = 0
+    previous_date = None
+
+    for solved_date in sorted(solved_dates):
+        if previous_date and solved_date == previous_date + timedelta(days=1):
+            run_length += 1
+        else:
+            run_length = 1
+
+        longest_streak = max(longest_streak, run_length)
+        previous_date = solved_date
+
+    anchor_date = today if today in solved_dates else today - timedelta(days=1)
+    current_streak = 0
+    while anchor_date in solved_dates:
+        current_streak += 1
+        anchor_date -= timedelta(days=1)
+
+    return current_streak, longest_streak

--- a/templates/base.html
+++ b/templates/base.html
@@ -232,6 +232,11 @@
             color: white;
         }
 
+        .streak-pill {
+            border-color: rgba(245, 158, 11, 0.45);
+            color: var(--warning);
+        }
+
         .icon-btn {
             width: 36px;
             height: 36px;
@@ -585,6 +590,12 @@
                 <i class="bi bi-briefcase-fill"></i>
                 <span>Company Wise Kit</span>
             </a>
+            {% if current_user.is_authenticated and current_streak >= 3 %}
+            <a href="{{ url_for('profile') }}" class="pill-btn streak-pill" title="{{ current_streak }} day streak">
+                <i class="bi bi-fire"></i>
+                <span>{{ current_streak }}d</span>
+            </a>
+            {% endif %}
             <button class="icon-btn" id="theme-toggle" aria-label="Toggle theme">
                 <i class="bi bi-moon-fill" id="theme-icon"></i>
             </button>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -33,7 +33,7 @@
 .meta-footer{font-size:0.72rem;color:var(--text-muted);display:flex;flex-direction:column;gap:4px;margin-top:8px}
 .meta-footer span{display:flex;justify-content:space-between}
 /* stat cards */
-.stat-row{display:grid;grid-template-columns:1fr 1fr 2fr;gap:12px}
+.stat-row{display:grid;grid-template-columns:1fr 1fr 1fr 2fr;gap:12px}
 .stat-card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:16px}
 .stat-num{font-size:2.4rem;font-weight:900;line-height:1;margin-top:4px}
 .stat-lbl{font-size:0.75rem;color:var(--text-secondary);font-weight:600}
@@ -196,6 +196,11 @@
     <div class="stat-card">
       <div class="stat-lbl">Total Active Days</div>
       <div class="stat-num">{{ total_active_days }}</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-lbl">Current Streak</div>
+      <div class="stat-num">{{ current_streak }}d</div>
+      <div style="font-size:.72rem;color:var(--text-secondary);margin-top:6px">Best: {{ longest_streak }}d</div>
     </div>
     <div class="stat-card">
       <div class="hm-meta">

--- a/tests/test_streaks.py
+++ b/tests/test_streaks.py
@@ -1,0 +1,51 @@
+from datetime import date, datetime, timezone
+
+from streaks import compute_streak
+
+
+def solved_on(timestamp):
+    return {'done': True, 'timestamp': timestamp}
+
+
+def test_compute_streak_counts_current_run_through_today():
+    progress = {
+        'a': solved_on(datetime(2026, 5, 18, tzinfo=timezone.utc)),
+        'b': solved_on(datetime(2026, 5, 19, tzinfo=timezone.utc)),
+        'c': solved_on(datetime(2026, 5, 20, tzinfo=timezone.utc)),
+    }
+
+    assert compute_streak(progress, today=date(2026, 5, 20)) == (3, 3)
+
+
+def test_compute_streak_allows_yesterday_as_active_streak():
+    progress = {
+        'a': solved_on(datetime(2026, 5, 18, tzinfo=timezone.utc)),
+        'b': solved_on(datetime(2026, 5, 19, tzinfo=timezone.utc)),
+    }
+
+    assert compute_streak(progress, today=date(2026, 5, 20)) == (2, 2)
+
+
+def test_compute_streak_resets_current_when_gap_exceeds_yesterday():
+    progress = {
+        'a': solved_on(datetime(2026, 5, 15, tzinfo=timezone.utc)),
+        'b': solved_on(datetime(2026, 5, 16, tzinfo=timezone.utc)),
+        'c': solved_on(datetime(2026, 5, 18, tzinfo=timezone.utc)),
+    }
+
+    assert compute_streak(progress, today=date(2026, 5, 20)) == (0, 2)
+
+
+def test_compute_streak_ignores_unsolved_or_missing_timestamps():
+    progress = {
+        'a': {'done': False, 'timestamp': datetime(2026, 5, 20, tzinfo=timezone.utc)},
+        'b': {'done': True},
+    }
+
+    assert compute_streak(progress, today=date(2026, 5, 20)) == (0, 0)
+
+
+def test_compute_streak_treats_naive_datetimes_as_utc():
+    progress = {'a': solved_on(datetime(2026, 5, 20))}
+
+    assert compute_streak(progress, today=date(2026, 5, 20)) == (1, 1)


### PR DESCRIPTION
## Summary
- add reusable daily streak computation for solved-question progress
- show current and longest streak on the profile page
- surface a compact topbar streak badge once the user reaches 3+ days

Fixes #85

## Validation
- `/tmp/450-dsa-profile-tests/bin/python -m pytest tests/test_streaks.py -q` -> 5 passed
- `python3 -m py_compile app.py streaks.py tests/test_streaks.py` -> passed
- `git diff --check` -> passed