### PR TITLE
perf: parallelize external platform sync fetches

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from authlib.integrations.flask_client import OAuth
 from dotenv import load_dotenv
 from profile_validation import build_profile_updates
 from notes_export import build_topic_notes_markdown, topic_notes_filename
+from platform_fetcher import run_fetch_jobs
 
 load_dotenv()
 
@@ -822,10 +823,26 @@ def sync_platforms():
         cn_user = normalize_coding_ninjas_profile_id(data.get('codingninjas', ''))
         update_fields['codingninjas_username'] = cn_user
 
+    fetch_jobs = {}
+    if lc_user:
+        fetch_jobs['leetcode'] = lambda username=lc_user: fetch_leetcode(username)
+        fetch_jobs['leetcode_rating_history'] = lambda username=lc_user: fetch_leetcode_rating_history(username)
+        fetch_jobs['leetcode_badges'] = lambda username=lc_user: fetch_lc_badges(username)
+    if gh_user:
+        fetch_jobs['github'] = lambda username=gh_user: fetch_github(username)
+    if gfg_user:
+        fetch_jobs['gfg'] = lambda username=gfg_user: fetch_gfg(username)
+    if cn_user:
+        fetch_jobs['coding_ninjas'] = lambda username=cn_user: fetch_coding_ninjas(username)
+    if hr_user:
+        fetch_jobs['hackerrank'] = lambda username=hr_user: fetch_hr_badges(username)
+
+    fetch_results, fetch_errors = run_fetch_jobs(fetch_jobs)
+
     combined = {}
     totals = {}
-    if lc_user:
-        lc = fetch_leetcode(lc_user)
+    lc = fetch_results.get('leetcode') or {}
+    if lc:
         for k, v in lc.get('calendar', {}).items():
             combined[k] = combined.get(k, 0) + v
         if lc.get('total'): 
@@ -838,15 +855,16 @@ def sync_platforms():
             totals['LeetCode_Contests'] = lc['contest'].get('attendedContestsCount', 0)
             totals['LeetCode_Rating'] = int(lc['contest'].get('rating', 0))
             totals['LeetCode_GlobalRank'] = lc['contest'].get('globalRanking', 0)
-        # Fetch rating history for graph
-        rh = fetch_leetcode_rating_history(lc_user)
-        if rh:
-            update_fields['rating_history'] = rh
-        # Fetch LC badges and store in dedicated field
-        lc_badges = fetch_lc_badges(lc_user)
-        update_fields['lc_badges_json'] = json.dumps(lc_badges)
-    if gh_user:
-        gh = fetch_github(gh_user)
+
+    rh = fetch_results.get('leetcode_rating_history')
+    if rh:
+        update_fields['rating_history'] = rh
+
+    if 'leetcode_badges' in fetch_results:
+        update_fields['lc_badges_json'] = json.dumps(fetch_results.get('leetcode_badges') or [])
+
+    gh = fetch_results.get('github') or {}
+    if gh:
         for k, v in gh.get('calendar', {}).items():
             combined[k] = combined.get(k, 0) + v
         if gh.get('stats'):
@@ -854,28 +872,32 @@ def sync_platforms():
             totals['GitHub_PRs'] = gh['stats']['prs']
             totals['GitHub_Merged_PRs'] = gh['stats']['merged_prs']
             totals['GitHub_Commits'] = gh['stats']['commits']
-    if gfg_user:
-        gfg = fetch_gfg(gfg_user)
-        if gfg.get('total'):
-            totals['GFG'] = int(gfg.get('total', 0))
-    if cn_user:
-        cn = fetch_coding_ninjas(cn_user)
-        if cn.get('total'):
-            totals['Coding Ninjas'] = int(cn.get('total', 0))
-    # HackerRank: fetch badges + solved count from same endpoint
-    if hr_user:
-        try:
-            hr_badges, hr_solved = fetch_hr_badges(hr_user)
-            update_fields['hr_badges_json'] = json.dumps(hr_badges)
-            if hr_solved > 0:
-                totals['HackerRank'] = hr_solved
-        except Exception:
-            print("Unable to fetch HackerRank badges")
+
+    gfg = fetch_results.get('gfg') or {}
+    if gfg.get('total'):
+        totals['GFG'] = int(gfg.get('total', 0))
+
+    cn = fetch_results.get('coding_ninjas') or {}
+    if cn.get('total'):
+        totals['Coding Ninjas'] = int(cn.get('total', 0))
+
+    if 'hackerrank' in fetch_results:
+        hr_badges, hr_solved = fetch_results.get('hackerrank') or ([], 0)
+        update_fields['hr_badges_json'] = json.dumps(hr_badges)
+        if hr_solved > 0:
+            totals['HackerRank'] = hr_solved
+
     update_fields['external_daily_counts'] = combined
     update_fields['external_totals'] = totals
     db.user.update_one({'_id': user_id}, {'$set': update_fields})
     current_user.reload()
-    return jsonify({"success": True})
+    response = {"success": True}
+    if fetch_errors:
+        response["warnings"] = {
+            platform: "Unable to sync this platform right now."
+            for platform in fetch_errors
+        }
+    return jsonify(response)
 
 @app.route('/edit_profile', methods=['POST'])
 @login_required

--- a/platform_fetcher.py
+++ b/platform_fetcher.py
@@ -1,0 +1,26 @@
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+def run_fetch_jobs(fetch_jobs, max_workers=5):
+    if not fetch_jobs:
+        return {}, {}
+
+    worker_count = min(max_workers, len(fetch_jobs))
+    results = {}
+    errors = {}
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        future_names = {
+            executor.submit(fetch_job): name
+            for name, fetch_job in fetch_jobs.items()
+        }
+
+        for future in as_completed(future_names):
+            name = future_names[future]
+            try:
+                results[name] = future.result()
+            except Exception as exc:
+                results[name] = None
+                errors[name] = str(exc)
+
+    return results, errors

--- a/tests/test_platform_fetcher.py
+++ b/tests/test_platform_fetcher.py
@@ -1,0 +1,41 @@
+import time
+
+from platform_fetcher import run_fetch_jobs
+
+
+def test_run_fetch_jobs_executes_jobs_concurrently():
+    def slow_result(value):
+        time.sleep(0.2)
+        return value
+
+    started = time.perf_counter()
+    results, errors = run_fetch_jobs({
+        'leetcode': lambda: slow_result({'total': 10}),
+        'github': lambda: slow_result({'stats': {'prs': 4}}),
+        'gfg': lambda: slow_result({'total': 7}),
+    })
+    elapsed = time.perf_counter() - started
+
+    assert results == {
+        'leetcode': {'total': 10},
+        'github': {'stats': {'prs': 4}},
+        'gfg': {'total': 7},
+    }
+    assert errors == {}
+    assert elapsed < 0.45
+
+
+def test_run_fetch_jobs_keeps_other_results_when_one_job_fails():
+    def failing_job():
+        raise RuntimeError('platform unavailable')
+
+    results, errors = run_fetch_jobs({
+        'leetcode': lambda: {'total': 10},
+        'github': failing_job,
+        'gfg': lambda: {'total': 7},
+    })
+
+    assert results['leetcode'] == {'total': 10}
+    assert results['gfg'] == {'total': 7}
+    assert results['github'] is None
+    assert errors == {'github': 'platform unavailable'}


### PR DESCRIPTION
## Summary
- run LeetCode, GitHub, GFG, HackerRank, and Coding Ninjas sync fetches concurrently instead of sequentially
- keep successful platform results even if one fetch job raises unexpectedly
- return non-blocking warning messages for failed platform jobs
- add focused tests for concurrency and failure isolation

Fixes #81

## Validation
- `/tmp/450-dsa-profile-tests/bin/python -m pytest tests/test_platform_fetcher.py -q` -> 2 passed
- `python3 -m py_compile app.py platform_fetcher.py tests/test_platform_fetcher.py` -> passed
- `git diff --check` -> passed