### PR TITLE
fix: pin dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 Flask==2.3.2
-pymongo
-Flask-Login
-Authlib
-requests
-python-dotenv
-email-validator
-Flask-Bcrypt
+pymongo==4.17.0
+Flask-Login==0.6.3
+Authlib==1.6.12
+requests==2.32.5
+python-dotenv==1.2.1
+email-validator==2.3.0
+Flask-Bcrypt==1.0.1
 # pyjson5==1.6.2


### PR DESCRIPTION
## Summary
- closes #105
- pins all floating direct dependencies in `requirements.txt`
- keeps the existing Flask and commented pyjson5 pins unchanged
- reduces CI/build drift from unbounded package upgrades

## Validation
- `/tmp/450-dsa-pin-reqs/bin/python -m pip install -r requirements.txt`
- `/tmp/450-dsa-pin-reqs/bin/python -m pytest tests -q`
- `/tmp/450-dsa-pin-reqs/bin/python -m py_compile app.py profile_validation.py notes_export.py tests/test_profile_validation.py tests/test_notes_export.py`
- `git diff --check`

Suggested labels: `GSSoC26`, `gssoc-level1`, `devops`, `bug`, `gssoc`.