### PR TITLE
Fix GitHub OAuth authorization flow

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -97,7 +97,14 @@ def login_github():
 
 @auth_bp.route("/login/github/authorize")
 def authorize_github():
+    token = github.authorize_access_token()
+    if not token:
+        return "GitHub authorization failed", 400
+
     response = github.get("user")
+    if not response.ok:
+        return "Failed to fetch GitHub user", 400
+
     user_info = response.json()
     github_id = str(user_info["id"])
 


### PR DESCRIPTION
** Fixes #78**

**Changes Made**

* Restored `github.authorize_access_token()` before GitHub API requests
* Added error handling for failed token exchange
* Prevented unauthenticated `github.get('user')` calls
* Preserved existing session/login flow
 
 **This Fix Works**

GitHub OAuth requires exchanging the callback authorization code for an access token before accessing authenticated GitHub endpoints.

Previously, `github.get('user')` could execute without a valid token because `authorize_access_token()` was commented out.

This fix ensures proper OAuth authentication flow and improves login reliability and security.
