### PR TITLE
fix: pin dependency versions and add dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest==8.2.2
+pytest-cov==5.0.0
+ruff==0.4.8
+black==24.4.2
+pre-commit==3.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,11 @@
 Flask==2.3.2
-Flask-PyMongo
-pymongo
-Flask-Login
-Authlib
-requests
-python-dotenv
-email-validator
-Flask-Bcrypt
-flask-bcrypt
+Flask-PyMongo==2.3.0
+pymongo==4.7.2
+Flask-Login==0.6.3
+Authlib==1.3.0
+requests==2.31.0
+python-dotenv==1.0.1
+email-validator==2.1.1
+Flask-Bcrypt==1.0.1
+mongomock==4.1.2
 # pyjson5==1.6.2
-mongomock

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,7 @@ requests==2.31.0
 python-dotenv==1.0.1
 email-validator==2.1.1
 Flask-Bcrypt==1.0.1
+cloudinary==1.39.1
+Pillow==10.3.0
 mongomock==4.1.2
 # pyjson5==1.6.2


### PR DESCRIPTION
# Description

This PR fixes Issue #105 by pinning all dependency versions in `requirements.txt` to prevent unexpected build breakage caused by future package updates.

Additionally, a separate `requirements-dev.txt` file has been added for development dependencies.

Fixes #105

## Changes Made

* Added pinned versions for all previously unpinned packages
* Removed duplicate `flask-bcrypt` entry
* Added pinned versions for:

  * Flask-PyMongo
  * pymongo
  * Flask-Login
  * Authlib
  * requests
  * python-dotenv
  * email-validator
  * Flask-Bcrypt
  * mongomock
* Created `requirements-dev.txt`
* Added development tools:

  * pytest
  * pytest-cov
  * ruff
  * black
  * pre-commit

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Chore (non-breaking change which does not modify src or test files)
* [x] Build / CI (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

* [x] Tested in Local

## Verification

* Successfully installed all dependencies using:

  * `pip install -r requirements.txt`
  * `pip install -r requirements-dev.txt`
* Verified no duplicate dependency conflicts
* Confirmed application dependencies resolve correctly
