### PR TITLE
feat: add rate limiting to API endpoints using Flask-Limiter (#80)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 from flask import Flask
 
 from app.auth import auth_bp
-from app.extensions import bcrypt, db, login_manager, mongo, oauth
+from app.extensions import bcrypt, db, limiter, login_manager, mongo, oauth
 from app.leaderboard import leaderboard_bp
 from app.profile import profile_bp
 from app.search import search_bp
@@ -24,6 +24,7 @@ def create_app():
     bcrypt.init_app(app)
     login_manager.init_app(app)
     oauth.init_app(app)
+    limiter.init_app(app)
 
     login_manager.login_view = "auth.login"
 
@@ -89,5 +90,18 @@ def create_app():
     app.register_blueprint(profile_bp)
     app.register_blueprint(leaderboard_bp)
     app.register_blueprint(search_bp)
+
+    @app.errorhandler(429)
+    def ratelimit_handler(e):
+        retry_after = getattr(e, 'retry_after', 60)
+        from flask import jsonify
+        response = jsonify({
+            'error': 'Too many requests',
+            'message': str(e.description),
+            'retry_after': retry_after
+        })
+        response.status_code = 429
+        response.headers['Retry-After'] = str(retry_after)
+        return response
 
     return app

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -1,5 +1,7 @@
 from authlib.integrations.flask_client import OAuth
 from flask_bcrypt import Bcrypt
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from flask_login import LoginManager
 from flask_pymongo import PyMongo
 from werkzeug.local import LocalProxy
@@ -10,5 +12,6 @@ db = LocalProxy(lambda: mongo.db)
 bcrypt = Bcrypt()
 login_manager = LoginManager()
 oauth = OAuth()
+limiter = Limiter(key_func=get_remote_address, default_limits=[], headers_enabled=True)
 github = LocalProxy(lambda: oauth.create_client("github"))
 google = LocalProxy(lambda: oauth.create_client("google"))

--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, jsonify, render_template, request
 from flask_login import current_user
 
+from app.extensions import limiter
 from app.utils import build_college_leaderboard_data, build_leaderboard_data
 
 
@@ -8,6 +9,7 @@ leaderboard_bp = Blueprint("leaderboard", __name__)
 
 
 @leaderboard_bp.route("/leaderboard")
+@limiter.limit("20 per minute")
 def leaderboard():
     entries = build_leaderboard_data()
 

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -12,6 +12,7 @@ import time
 from card_generator import generate_progress_card
 
 from app.extensions import db
+from app.extensions import limiter
 from app.platforms.fetchers import (
     fetch_coding_ninjas,
     fetch_gfg,
@@ -30,6 +31,7 @@ profile_bp = Blueprint("profile", __name__)
 
 @profile_bp.route("/sync_platforms", methods=["POST"])
 @login_required
+@limiter.limit("5 per minute")
 def sync_platforms():
     data = request.json
     now = utc_now()
@@ -209,6 +211,7 @@ def search_universities():
 
 @profile_bp.route("/upload_photo", methods=["POST"])
 @login_required
+@limiter.limit("10 per minute")
 def upload_photo():
     if "photo" not in request.files:
         return jsonify({"success": False, "error": "No file"}), 400

--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, jsonify, render_template, request
 
+from app.extensions import limiter
 from app.utils import search_dsa_questions
 
 
@@ -13,6 +14,7 @@ def search():
 
 
 @search_bp.route("/api/search_questions")
+@limiter.limit("30 per minute")
 def api_search_questions():
     raw_query = request.args.get("q", "")
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ python-dotenv
 email-validator
 Flask-Bcrypt
 flask-bcrypt
+Flask-Limiter==3.5.0
 # pyjson5==1.6.2
 mongomock
 cloudinary


### PR DESCRIPTION
Fixes #80 
## Changes Made
* ✅ Added `Flask-Limiter==3.5.0` to `requirements.txt`
* ✅ Added `limiter` instance in `app/extensions.py` using `get_remote_address` with `headers_enabled=True`
* ✅ Initialized `limiter.init_app(app)` in `app/__init__.py`

### Applied Rate Limits
* ✅ `GET /api/search_questions` → `30/minute`
* ✅ `POST /sync_platforms` → `5/minute`
* ✅ `POST /upload_photo` → `10/minute`
* ✅ `GET /leaderboard` → `20/minute`

### Error Handling
* ✅ Added custom `@app.errorhandler(429)` response
* ✅ Returns JSON response with `retry_after` field
* ✅ Includes `Retry-After` response header

## Files Changed
* `requirements.txt`
* `app/extensions.py`
* `app/__init__.py`
* `app/search/routes.py`
* `app/profile/routes.py`
* `app/leaderboard/routes.py`

## Checklist
* [x] Flask-Limiter added to `requirements.txt`
* [x] Rate limits applied to all 4 heavy endpoints
* [x] Custom `429` response implemented
* [x] `Retry-After` header included

Hi @mohitkumhar! All acceptance criteria from #80 are covered. 