### PR TITLE
perf: implement Flask-Caching for leaderboard to prevent full DB scans

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 from flask import Flask
 
 from app.auth import auth_bp
-from app.extensions import bcrypt, db, limiter, login_manager, mongo, oauth
+from app.extensions import bcrypt, db, limiter, login_manager, mongo, oauth, cache
 from app.leaderboard import leaderboard_bp
 from app.profile import profile_bp
 from app.search import search_bp
@@ -19,6 +19,10 @@ def create_app():
     app = Flask(__name__, template_folder="../templates")
     app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "supersecretkey")
     app.config["MONGO_URI"] = os.environ.get("MONGO_URI", "mongodb://localhost:27017/450_dsa")
+    app.config["CACHE_TYPE"] = "SimpleCache"
+    app.config["CACHE_DEFAULT_TIMEOUT"] = 300
+    
+    cache.init_app(app)
 
     mongo.init_app(app)
     bcrypt.init_app(app)

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -5,6 +5,7 @@ from flask_limiter.util import get_remote_address
 from flask_login import LoginManager
 from flask_pymongo import PyMongo
 from werkzeug.local import LocalProxy
+from flask_caching import Cache
 
 
 mongo = PyMongo()
@@ -15,3 +16,4 @@ oauth = OAuth()
 limiter = Limiter(key_func=get_remote_address, default_limits=[], headers_enabled=True)
 github = LocalProxy(lambda: oauth.create_client("github"))
 google = LocalProxy(lambda: oauth.create_client("google"))
+cache = Cache()

--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, jsonify, render_template, request
 from flask_login import current_user
 
-from app.extensions import limiter
+from app.extensions import limiter, cache
 from app.utils import build_college_leaderboard_data, build_leaderboard_data
 
 
@@ -10,6 +10,7 @@ leaderboard_bp = Blueprint("leaderboard", __name__)
 
 @leaderboard_bp.route("/leaderboard")
 @limiter.limit("20 per minute")
+@cache.cached(timeout=300)
 def leaderboard():
     entries = build_leaderboard_data()
 
@@ -40,6 +41,7 @@ def leaderboard():
 
 
 @leaderboard_bp.route("/api/leaderboard")
+@cache.cached(timeout=300, query_string=True)
 def api_leaderboard():
     mode = request.args.get("mode", "cscore")
     entries = build_leaderboard_data()

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -12,7 +12,7 @@ import time
 from card_generator import generate_progress_card
 
 from app.extensions import db
-from app.extensions import limiter
+from app.extensions import limiter, cache
 from app.platforms.fetchers import (
     fetch_coding_ninjas,
     fetch_gfg,
@@ -128,6 +128,9 @@ def sync_platforms():
     update_fields["external_totals"] = totals
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
+
+    cache.clear()
+    
     return jsonify({"success": True})
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ Pillow==10.3.0
 mongomock==4.1.2
 Flask-Limiter==3.5.0
 # pyjson5==1.6.2
+Flask-Caching

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ Pillow==10.3.0
 mongomock==4.1.2
 Flask-Limiter==3.5.0
 # pyjson5==1.6.2
-Flask-Caching
+Flask-Caching==2.0.2


### PR DESCRIPTION
# Description

This PR integrates `Flask-Caching` to optimize the `/leaderboard` and `/api/leaderboard` routes. Previously, these routes performed a full database scan and recomputed C-Scores for every user on each page load, which would cause timeouts as the user base grows. 

Changes made:
* Added `Flask-Caching` to `requirements.txt`.
* Initialized `SimpleCache` (with a 300-second timeout) in the app factory (`app/extensions.py` and `app/__init__.py`).
* Cached the leaderboard rendering and API routes to prevent redundant DB calls.
* Added `cache.clear()` in the `/sync_platforms` route (`app/profile/routes.py`) to ensure the cache is invalidated immediately when a user updates their scores.

Fixes #82 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which improves code structure)
- [ ] Documentation (non-breaking change which improves documentation)
- [x] Performance (non-breaking change which improves performance)
- [ ] Chore (non-breaking change which does not modify src or test files)
- [x] Build / CI (non-breaking change which does not modify src or test files)
- [ ] Security (non-breaking change which improves security)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] Tested in Local (Verified initialization of Flask-Caching, verified caching decorators on routes, and tested cache invalidation logic during platform syncs).