### PR TITLE
Feat/account deletion 86

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,6 +1,6 @@
 from bson import ObjectId
 from flask import Blueprint, flash, redirect, render_template, request, session, url_for
-from flask_login import UserMixin, current_user, login_user, logout_user
+from flask_login import UserMixin, current_user, login_required, login_user, logout_user
 
 from app.extensions import bcrypt, db, github, google, login_manager
 
@@ -86,6 +86,21 @@ def register():
 @auth_bp.route("/logout")
 def logout():
     logout_user()
+    return redirect(url_for("auth.login"))
+
+
+@auth_bp.route("/delete_account", methods=["POST"])
+@login_required
+def delete_account():
+    password = request.form.get("password")
+    user_doc = db.user.find_one({"_id": current_user.id})
+    if user_doc.get("password") and not bcrypt.check_password_hash(user_doc["password"], password):
+        flash("Incorrect password. Account not deleted.", "danger")
+        return redirect(url_for("profile.profile"))
+    user_id = current_user.id
+    logout_user()
+    db.user.delete_one({"_id": user_id})
+    flash("Your account has been permanently deleted.", "info")
     return redirect(url_for("auth.login"))
 
 

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -94,9 +94,10 @@ def logout():
 @auth_bp.route("/delete_account", methods=["POST"])
 @login_required
 def delete_account():
-    # CSRF check
+    # CSRF check — consume token immediately (single-use)
     token = request.form.get("csrf_token", "")
-    if not token or token != session.get("delete_csrf_token"):
+    expected = session.pop("delete_csrf_token", None)
+    if not token or not expected or token != expected:
         abort(403)
 
     user_doc = db.user.find_one({"_id": current_user.id})
@@ -112,7 +113,6 @@ def delete_account():
             return redirect(url_for("profile.profile"))
 
     user_id = current_user.id
-    session.pop("delete_csrf_token", None)
     logout_user()
     db.user.delete_one({"_id": user_id})
     flash("Your account has been permanently deleted.", "info")
@@ -126,7 +126,8 @@ def delete_account_token():
     token = secrets.token_hex(32)
     session["delete_csrf_token"] = token
     from flask import jsonify
-    return jsonify({"csrf_token": token, "is_oauth": not bool(db.user.find_one({"_id": current_user.id}, {"password": 1}).get("password"))})
+    user_doc = db.user.find_one({"_id": current_user.id}, {"password": 1}) or {}
+    return jsonify({"csrf_token": token, "is_oauth": not bool(user_doc.get("password"))})
 
 
 @auth_bp.route("/login/github")

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,5 +1,7 @@
+import secrets
+
 from bson import ObjectId
-from flask import Blueprint, flash, redirect, render_template, request, session, url_for
+from flask import Blueprint, abort, flash, redirect, render_template, request, session, url_for
 from flask_login import UserMixin, current_user, login_required, login_user, logout_user
 
 from app.extensions import bcrypt, db, github, google, login_manager
@@ -92,16 +94,39 @@ def logout():
 @auth_bp.route("/delete_account", methods=["POST"])
 @login_required
 def delete_account():
-    password = request.form.get("password")
+    # CSRF check
+    token = request.form.get("csrf_token", "")
+    if not token or token != session.get("delete_csrf_token"):
+        abort(403)
+
     user_doc = db.user.find_one({"_id": current_user.id})
-    if user_doc.get("password") and not bcrypt.check_password_hash(user_doc["password"], password):
-        flash("Incorrect password. Account not deleted.", "danger")
-        return redirect(url_for("profile.profile"))
+    if not user_doc:
+        logout_user()
+        return redirect(url_for("auth.login"))
+
+    # Password accounts require password confirmation
+    if user_doc.get("password"):
+        password = request.form.get("password", "")
+        if not password or not bcrypt.check_password_hash(user_doc["password"], password):
+            flash("Incorrect password. Account not deleted.", "danger")
+            return redirect(url_for("profile.profile"))
+
     user_id = current_user.id
+    session.pop("delete_csrf_token", None)
     logout_user()
     db.user.delete_one({"_id": user_id})
     flash("Your account has been permanently deleted.", "info")
     return redirect(url_for("auth.login"))
+
+
+@auth_bp.route("/delete_account/token", methods=["GET"])
+@login_required
+def delete_account_token():
+    """Generate and return a CSRF token for the delete account form."""
+    token = secrets.token_hex(32)
+    session["delete_csrf_token"] = token
+    from flask import jsonify
+    return jsonify({"csrf_token": token, "is_oauth": not bool(db.user.find_one({"_id": current_user.id}, {"password": 1}).get("password"))})
 
 
 @auth_bp.route("/login/github")

--- a/card_generator.py
+++ b/card_generator.py
@@ -1,6 +1,7 @@
 import io
 from PIL import Image, ImageDraw, ImageFont
 
+
 def generate_progress_card(name, c_score, dsa_progress, current_streak, platforms):
     width, height = 800, 400
     bg_color = (24, 24, 27) # zinc-900

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -141,6 +141,7 @@
     <div class="meta-row"><i class="bi bi-mortarboard" style="color:var(--info)"></i> Computer Science</div>
     {% endif %}
     <button onclick="openEditProfile()" style="width:100%;margin-top:12px;padding:8px;border:1px solid var(--border-color);border-radius:9px;background:none;color:var(--text-secondary);font-size:.8rem;font-family:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:6px;transition:all .2s" onmouseover="this.style.borderColor='var(--accent)';this.style.color='var(--accent)'" onmouseout="this.style.borderColor='var(--border-color)';this.style.color='var(--text-secondary)'"><i class="bi bi-pencil-square"></i> Edit Profile</button>
+    <button onclick="openDeleteModal()" style="width:100%;margin-top:8px;padding:8px;border:1px solid #ef4444;border-radius:9px;background:none;color:#ef4444;font-size:.8rem;font-family:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:6px;transition:all .2s" onmouseover="this.style.background='rgba(239,68,68,.1)'" onmouseout="this.style.background='none'"><i class="bi bi-trash3"></i> Delete Account</button>
   </div>
 
   <div class="card">
@@ -503,6 +504,25 @@
 <!-- Toast notification -->
 <div class="toast" id="toast" style=""></div>
 
+<!-- Delete Account Modal -->
+<div class="modal-ov" id="deleteAccountModal" role="dialog" aria-modal="true" aria-labelledby="deleteModalTitle">
+  <div class="modal-bx" style="max-width:420px;border-color:#ef4444">
+    <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px">
+      <h3 id="deleteModalTitle" style="color:#ef4444;margin:0"><i class="bi bi-exclamation-triangle-fill"></i> Delete Account</h3>
+      <button onclick="closeDeleteModal()" style="background:none;border:none;color:var(--text-muted);font-size:1.2rem;cursor:pointer" aria-label="Close">✕</button>
+    </div>
+    <p style="font-size:.83rem;color:var(--text-secondary);margin-bottom:16px">This action is <strong style="color:#ef4444">permanent and irreversible</strong>. All your progress, bookmarks, notes, and profile data will be deleted.</p>
+    <form method="POST" action="/delete_account" id="deleteAccountForm">
+      <label class="m-lbl" for="delete_password">Confirm your password to continue</label>
+      <input class="m-inp" type="password" id="delete_password" name="password" placeholder="Enter your password" required autocomplete="current-password">
+      <div class="m-actions">
+        <button type="button" class="m-cancel" onclick="closeDeleteModal()">Cancel</button>
+        <button type="submit" style="padding:8px 16px;background:#ef4444;border:none;border-radius:8px;color:#fff;font-size:.83rem;font-weight:700;cursor:pointer;font-family:inherit">Delete My Account</button>
+      </div>
+    </form>
+  </div>
+</div>
+
 <!-- Sync Loading Overlay -->
 <div id="syncOverlay" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.75);z-index:10000;flex-direction:column;align-items:center;justify-content:center;gap:20px">
   <div style="width:60px;height:60px;border:4px solid rgba(255,107,0,.3);border-top-color:var(--accent);border-radius:50%;animation:spin .9s linear infinite"></div>
@@ -732,8 +752,10 @@ function showToast(msg){
 }
 function openEditProfile(){document.getElementById('editProfileModal').classList.add('open')}
 function closeEditProfile(){document.getElementById('editProfileModal').classList.remove('open')}
+function openDeleteModal(){document.getElementById('deleteAccountModal').classList.add('open');setTimeout(()=>document.getElementById('delete_password').focus(),100);}
+function closeDeleteModal(){document.getElementById('deleteAccountModal').classList.remove('open');document.getElementById('delete_password').value='';}
 
-['syncModal','cardModal','editProfileModal'].forEach(id=>{
+['syncModal','cardModal','editProfileModal','deleteAccountModal'].forEach(id=>{
   const el=document.getElementById(id);
   if(el) el.addEventListener('click',e=>{if(e.target.id===id)el.classList.remove('open');});
 });

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -513,11 +513,14 @@
     </div>
     <p style="font-size:.83rem;color:var(--text-secondary);margin-bottom:16px">This action is <strong style="color:#ef4444">permanent and irreversible</strong>. All your progress, bookmarks, notes, and profile data will be deleted.</p>
     <form method="POST" action="/delete_account" id="deleteAccountForm">
-      <label class="m-lbl" for="delete_password">Confirm your password to continue</label>
-      <input class="m-inp" type="password" id="delete_password" name="password" placeholder="Enter your password" required autocomplete="current-password">
+      <input type="hidden" name="csrf_token" id="deleteCsrfToken">
+      <div id="deletePasswordWrap">
+        <label class="m-lbl" for="delete_password">Confirm your password to continue</label>
+        <input class="m-inp" type="password" id="delete_password" name="password" placeholder="Enter your password" autocomplete="current-password">
+      </div>
       <div class="m-actions">
         <button type="button" class="m-cancel" onclick="closeDeleteModal()">Cancel</button>
-        <button type="submit" style="padding:8px 16px;background:#ef4444;border:none;border-radius:8px;color:#fff;font-size:.83rem;font-weight:700;cursor:pointer;font-family:inherit">Delete My Account</button>
+        <button type="submit" id="deleteSubmitBtn" style="padding:8px 16px;background:#ef4444;border:none;border-radius:8px;color:#fff;font-size:.83rem;font-weight:700;cursor:pointer;font-family:inherit">Delete My Account</button>
       </div>
     </form>
   </div>
@@ -752,7 +755,25 @@ function showToast(msg){
 }
 function openEditProfile(){document.getElementById('editProfileModal').classList.add('open')}
 function closeEditProfile(){document.getElementById('editProfileModal').classList.remove('open')}
-function openDeleteModal(){document.getElementById('deleteAccountModal').classList.add('open');setTimeout(()=>document.getElementById('delete_password').focus(),100);}
+function openDeleteModal(){
+  fetch('/delete_account/token')
+    .then(r => r.json())
+    .then(data => {
+      document.getElementById('deleteCsrfToken').value = data.csrf_token;
+      const pwWrap = document.getElementById('deletePasswordWrap');
+      const pwInput = document.getElementById('delete_password');
+      if(data.is_oauth){
+        pwWrap.style.display = 'none';
+        pwInput.removeAttribute('required');
+      } else {
+        pwWrap.style.display = 'block';
+        pwInput.setAttribute('required', '');
+      }
+      document.getElementById('deleteAccountModal').classList.add('open');
+      setTimeout(() => (data.is_oauth ? document.getElementById('deleteSubmitBtn') : pwInput).focus(), 100);
+    })
+    .catch(() => showToast('❌ Failed to open delete dialog. Try again.'));
+}
 function closeDeleteModal(){document.getElementById('deleteAccountModal').classList.remove('open');document.getElementById('delete_password').value='';}
 
 ['syncModal','cardModal','editProfileModal','deleteAccountModal'].forEach(id=>{


### PR DESCRIPTION
Fixes #86

## Changes Made
* Added `POST /delete_account` route in `app/auth/routes.py` with `@login_required`
* Verifies password before deletion — OAuth users (no password set) can delete directly
* Calls `logout_user()` before `db.user.delete_one()` to permanently remove all user data from MongoDB
* Redirects users to the login page with a flash message after successful deletion
* Added a red **Delete Account** button in the profile sidebar below **Edit Profile**
* Added a confirmation modal with password input, `role="dialog"`, `aria-modal="true"`, and automatic focus on modal open
* Backdrop click and Cancel action both close the modal and clear the password field

## Files Changed
* `app/auth/routes.py`
* `templates/profile.html`

## Checklist
* ✅ Delete Account button added in profile settings (Danger Zone)
* ✅ Confirmation modal requiring password entry
* ✅ All user data permanently removed from MongoDB
* ✅ User logged out and redirected after account deletion

Hi @mohitkumhar! All acceptance criteria from #86 are covered. Feel free to assign me to other open issues as well — happy to keep contributing 
