### PR TITLE
Handle invalid JSON for sync platforms

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -37,7 +37,10 @@ profile_bp = Blueprint("profile", __name__)
 @login_required
 @limiter.limit("5 per minute")
 def sync_platforms():
-    data = request.json
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"success": False, "error": "Request body must be a JSON object."}), 400
+
     now = utc_now()
     user_id = current_user.id
 

--- a/tests/test_sync_platforms.py
+++ b/tests/test_sync_platforms.py
@@ -1,0 +1,50 @@
+from flask import Flask
+
+from app.profile.routes import profile_bp
+
+
+def create_profile_test_app():
+    app = Flask(__name__)
+    app.config.update(TESTING=True, LOGIN_DISABLED=True, SECRET_KEY="test-secret")
+    app.register_blueprint(profile_bp)
+    return app
+
+
+def test_sync_platforms_rejects_missing_json_body():
+    app = create_profile_test_app()
+
+    response = app.test_client().post("/sync_platforms")
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "success": False,
+        "error": "Request body must be a JSON object.",
+    }
+
+
+def test_sync_platforms_rejects_malformed_json_body():
+    app = create_profile_test_app()
+
+    response = app.test_client().post(
+        "/sync_platforms",
+        data="{bad json",
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "success": False,
+        "error": "Request body must be a JSON object.",
+    }
+
+
+def test_sync_platforms_rejects_non_object_json_body():
+    app = create_profile_test_app()
+
+    response = app.test_client().post("/sync_platforms", json=["leetcode"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "success": False,
+        "error": "Request body must be a JSON object.",
+    }


### PR DESCRIPTION
## Summary
- Handle empty, malformed, and non-object JSON payloads in `/sync_platforms` with a 400 JSON response.
- Add route coverage for the invalid payload cases described in #138.

## Context
`sync_platforms()` previously read `request.json` and then checked platform keys on the decoded value. Requests without a JSON body, with malformed JSON, or with a non-object payload could fail before returning a clean API response.

## Changes
- Use `request.get_json(silent=True)` so malformed JSON does not raise during parsing.
- Validate that the decoded payload is a JSON object before reading platform keys.
- Add tests for missing JSON, malformed JSON, and non-object JSON payloads.

## Verification
- `PYTHONPATH=. pytest tests/test_sync_platforms.py tests/test_app_factory.py -q`
- `git diff --check`

## Risk
- Low. The change is limited to request validation at the start of `/sync_platforms`.
- Valid JSON object payloads continue through the existing sync flow unchanged.

Fixes #138
