### PR TITLE
feat: show empty state when difficulty filter has no matches

### DIFF
--- a/templates/topic.html
+++ b/templates/topic.html
@@ -165,7 +165,17 @@
                 </td>
             </tr>
             {% endfor %}
-        </tbody>
+            <tr id="empty-state-row" style="display:none;">
+                <td colspan="6" class="text-center" style="padding: 2rem;">
+                <p style="margin-bottom: 0.75rem; color: var(--text-muted, #888);">
+                    No questions match the selected difficulty.
+                </p>
+                <button class="filter-btn" data-difficulty="all" onclick="document.querySelector('[data-difficulty=all]').click()">
+                    Clear filter &amp; show all
+                </button>
+            </td>
+        </tr>
+    </tbody>
     </table>
 </div>
 
@@ -235,6 +245,13 @@ document.querySelectorAll('.filter-btn').forEach(btn => {
         window.location.href = currentUrl.toString();
     });
 });
+(function() {
+    const rows = document.querySelectorAll('#questions-table tbody tr:not(#empty-state-row)');
+    const emptyRow = document.getElementById('empty-state-row');
+    if (rows.length === 0) {
+        emptyRow.style.display = '';
+    }
+})();
 
 // Notes Modal
 const modal = document.getElementById('notesModal');


### PR DESCRIPTION
# Description

When a user selects a difficulty filter (Easy / Medium / Hard) and no questions match, the table body was rendering empty with no explanation or way to reset. This change adds a friendly empty state row that appears automatically when the filtered result set is empty.

Fixes #151 

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Tested in Local

Manually tested by selecting a difficulty filter that yields zero results — the empty state row appears with a "Clear filter & show all" link. Verified that selecting a difficulty with results continues to render the table normally.