### PR TITLE
fix: use params for university autocomplete

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -195,7 +195,11 @@ def search_universities():
     if len(query) < 2:
         return jsonify([])
     try:
-        response = requests.get(f"http://universities.hipolabs.com/search?name={query}", timeout=5)
+        response = requests.get(
+            "https://universities.hipolabs.com/search",
+            params={"name": query},
+            timeout=5,
+        )
         if response.status_code == 200:
             data = response.json()
             seen = set()

--- a/tests/test_university_search.py
+++ b/tests/test_university_search.py
@@ -1,0 +1,42 @@
+from flask import Flask
+
+import app.profile.routes as profile_routes
+from app.profile import profile_bp
+
+
+class FakeUniversityResponse:
+    status_code = 200
+
+    def json(self):
+        return [
+            {"name": "A&B University", "country": "India"},
+            {"name": "A&B University", "country": "India"},
+            {"name": "A and B College", "country": "India"},
+        ]
+
+
+def test_university_search_uses_https_and_params(monkeypatch):
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeUniversityResponse()
+
+    monkeypatch.setattr(profile_routes.requests, "get", fake_get)
+
+    app = Flask(__name__)
+    app.register_blueprint(profile_bp)
+
+    response = app.test_client().get("/search_universities?q=A%26B University")
+
+    assert response.status_code == 200
+    assert calls == [
+        (
+            "https://universities.hipolabs.com/search",
+            {"params": {"name": "A&B University"}, "timeout": 5},
+        )
+    ]
+    assert response.get_json() == [
+        {"name": "A&B University", "country": "India", "label": "A&B University, India"},
+        {"name": "A and B College", "country": "India", "label": "A and B College, India"},
+    ]


### PR DESCRIPTION
## Summary
- switch university autocomplete requests to HTTPS
- pass the user query via requests params instead of interpolating raw text into the URL
- add coverage for a query with spaces and symbols plus duplicate result filtering

## Verification
- python -m pytest tests/test_university_search.py
- python -m compileall app tests
- git diff --check

Closes #146