### PR TITLE
fix: return per-platform sync status

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -33,6 +33,20 @@ from progress_export import build_progress_csv
 profile_bp = Blueprint("profile", __name__)
 
 
+def build_sync_platforms_response(platform_status: dict):
+    attempted = sum(1 for value in platform_status.values() if value.get("status") != "skipped")
+    synced = sum(1 for value in platform_status.values() if value.get("status") == "synced")
+    failed = sum(1 for value in platform_status.values() if value.get("status") == "failed")
+    partial_success = bool(synced and failed)
+
+    if attempted == 0:
+        return {"success": False, "error": "No platforms provided to sync.", "platforms": platform_status}
+    if synced == 0 and failed > 0:
+        return {"success": False, "error": "Sync failed for all platforms.", "platforms": platform_status}
+
+    return {"success": True, "partial_success": partial_success, "platforms": platform_status}
+
+
 @profile_bp.route("/sync_platforms", methods=["POST"])
 @login_required
 @limiter.limit("5 per minute")
@@ -77,47 +91,97 @@ def sync_platforms():
 
     combined = {}
     totals = {}
+    platform_status = {}
+
+    def _mark(platform_key: str, status: str, error: str = None):
+        payload = {"status": status}
+        if error:
+            payload["error"] = error
+        platform_status[platform_key] = payload
+
     if lc_user:
-        lc = fetch_leetcode(lc_user)
-        for key, value in lc.get("calendar", {}).items():
-            combined[key] = combined.get(key, 0) + value
-        if lc.get("total"):
-            totals["LeetCode"] = lc.get("total")
-        if lc.get("difficulty"):
-            totals["LeetCode_Easy"] = lc["difficulty"].get("Easy", 0)
-            totals["LeetCode_Medium"] = lc["difficulty"].get("Medium", 0)
-            totals["LeetCode_Hard"] = lc["difficulty"].get("Hard", 0)
-        if lc.get("contest"):
-            totals["LeetCode_Contests"] = lc["contest"].get("attendedContestsCount", 0)
-            totals["LeetCode_Rating"] = int(lc["contest"].get("rating", 0))
-            totals["LeetCode_GlobalRank"] = lc["contest"].get("globalRanking", 0)
+        try:
+            lc = fetch_leetcode(lc_user)
+            if not lc:
+                _mark("leetcode", "failed", "No data returned (username may be invalid or rate-limited).")
+            else:
+                _mark("leetcode", "synced")
+                for key, value in lc.get("calendar", {}).items():
+                    combined[key] = combined.get(key, 0) + value
+                if lc.get("total") is not None:
+                    totals["LeetCode"] = lc.get("total")
+                if lc.get("difficulty"):
+                    totals["LeetCode_Easy"] = lc["difficulty"].get("Easy", 0)
+                    totals["LeetCode_Medium"] = lc["difficulty"].get("Medium", 0)
+                    totals["LeetCode_Hard"] = lc["difficulty"].get("Hard", 0)
+                if lc.get("contest"):
+                    totals["LeetCode_Contests"] = lc["contest"].get("attendedContestsCount", 0)
+                    totals["LeetCode_Rating"] = int(lc["contest"].get("rating", 0))
+                    totals["LeetCode_GlobalRank"] = lc["contest"].get("globalRanking", 0)
 
-        rating_history = fetch_leetcode_rating_history(lc_user)
-        if rating_history:
-            update_fields["rating_history"] = rating_history
+                try:
+                    rating_history = fetch_leetcode_rating_history(lc_user)
+                    if rating_history:
+                        update_fields["rating_history"] = rating_history
+                except Exception:
+                    pass
 
-        lc_badges = fetch_lc_badges(lc_user)
-        update_fields["lc_badges_json"] = json.dumps(lc_badges)
+                try:
+                    lc_badges = fetch_lc_badges(lc_user)
+                    update_fields["lc_badges_json"] = json.dumps(lc_badges)
+                except Exception:
+                    pass
+        except Exception:
+            _mark("leetcode", "failed", "Failed to fetch LeetCode stats.")
+    else:
+        _mark("leetcode", "skipped")
 
     if gh_user:
-        gh = fetch_github(gh_user)
-        for key, value in gh.get("calendar", {}).items():
-            combined[key] = combined.get(key, 0) + value
-        if gh.get("stats"):
-            totals["GitHub_Issues"] = gh["stats"]["issues"]
-            totals["GitHub_PRs"] = gh["stats"]["prs"]
-            totals["GitHub_Merged_PRs"] = gh["stats"]["merged_prs"]
-            totals["GitHub_Commits"] = gh["stats"]["commits"]
+        try:
+            gh = fetch_github(gh_user)
+            if not gh:
+                _mark("github", "failed", "No data returned (username may be invalid or rate-limited).")
+            else:
+                _mark("github", "synced")
+                for key, value in gh.get("calendar", {}).items():
+                    combined[key] = combined.get(key, 0) + value
+                if gh.get("stats"):
+                    totals["GitHub_Issues"] = gh["stats"]["issues"]
+                    totals["GitHub_PRs"] = gh["stats"]["prs"]
+                    totals["GitHub_Merged_PRs"] = gh["stats"]["merged_prs"]
+                    totals["GitHub_Commits"] = gh["stats"]["commits"]
+        except Exception:
+            _mark("github", "failed", "Failed to fetch GitHub stats.")
+    else:
+        _mark("github", "skipped")
 
     if gfg_user:
-        gfg = fetch_gfg(gfg_user)
-        if gfg.get("total"):
-            totals["GFG"] = int(gfg.get("total", 0))
+        try:
+            gfg = fetch_gfg(gfg_user)
+            if not gfg:
+                _mark("gfg", "failed", "No data returned (username may be invalid or rate-limited).")
+            else:
+                _mark("gfg", "synced")
+                if gfg.get("total") is not None:
+                    totals["GFG"] = int(gfg.get("total", 0))
+        except Exception:
+            _mark("gfg", "failed", "Failed to fetch GFG stats.")
+    else:
+        _mark("gfg", "skipped")
 
     if cn_user:
-        cn = fetch_coding_ninjas(cn_user)
-        if cn.get("total"):
-            totals["Coding Ninjas"] = int(cn.get("total", 0))
+        try:
+            cn = fetch_coding_ninjas(cn_user)
+            if not cn:
+                _mark("codingninjas", "failed", "No data returned (username may be invalid or rate-limited).")
+            else:
+                _mark("codingninjas", "synced")
+                if cn.get("total") is not None:
+                    totals["Coding Ninjas"] = int(cn.get("total", 0))
+        except Exception:
+            _mark("codingninjas", "failed", "Failed to fetch Coding Ninjas stats.")
+    else:
+        _mark("codingninjas", "skipped")
 
     if hr_user:
         try:
@@ -125,8 +189,11 @@ def sync_platforms():
             update_fields["hr_badges_json"] = json.dumps(hr_badges)
             if hr_solved > 0:
                 totals["HackerRank"] = hr_solved
+            _mark("hackerrank", "synced")
         except Exception:
-            print("Unable to fetch HackerRank badges")
+            _mark("hackerrank", "failed", "Failed to fetch HackerRank stats.")
+    else:
+        _mark("hackerrank", "skipped")
 
     update_fields["external_daily_counts"] = combined
     update_fields["external_totals"] = totals
@@ -134,8 +201,7 @@ def sync_platforms():
     current_user.reload()
 
     cache.clear()
-    
-    return jsonify({"success": True})
+    return jsonify(build_sync_platforms_response(platform_status))
 
 
 @profile_bp.route("/edit_profile", methods=["POST"])

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -591,7 +591,15 @@ window.handleQuickSync = function(btn) {
     btn.disabled = false;
     icon.className = 'bi bi-arrow-clockwise';
     if(res.success){
-      showToast('✅ Synced successfully! Reloading...');
+      const platforms = res.platforms || {};
+      const labels = {leetcode:'LeetCode',github:'GitHub',gfg:'GFG',hackerrank:'HackerRank',codingninjas:'Coding Ninjas'};
+      const synced = Object.keys(platforms).filter(k => platforms[k].status === 'synced').map(k => labels[k] || k);
+      const failed = Object.keys(platforms).filter(k => platforms[k].status === 'failed').map(k => labels[k] || k);
+      if(res.partial_success){
+        showToast('⚠️ Partial sync. Synced: ' + synced.join(', ') + '. Failed: ' + failed.join(', ') + '. Reloading...');
+      } else {
+        showToast('✅ Synced successfully! Reloading...');
+      }
       setTimeout(()=>window.location.reload(), 1200);
     } else {
       showToast('❌ Sync failed: ' + (res.error || 'unknown'));
@@ -651,12 +659,25 @@ window.handleSyncProfile = function(btn){
     overlay.style.display='none';
     if(res.success){
       syncContent.innerHTML='<i class="bi bi-check-lg"></i> Synced!';
-      showToast('\u2705 Synced successfully! Reloading...');
+      const platforms = res.platforms || {};
+      const labels = {leetcode:'LeetCode',github:'GitHub',gfg:'GFG',hackerrank:'HackerRank',codingninjas:'Coding Ninjas'};
+      const synced = Object.keys(platforms).filter(k => platforms[k].status === 'synced').map(k => labels[k] || k);
+      const failed = Object.keys(platforms).filter(k => platforms[k].status === 'failed').map(k => labels[k] || k);
+      if(res.partial_success){
+        showToast('⚠️ Partial sync. Synced: ' + synced.join(', ') + '. Failed: ' + failed.join(', ') + '. Reloading...');
+      } else {
+        showToast('\u2705 Synced successfully! Reloading...');
+      }
       setTimeout(()=>window.location.reload(),1200);
     }else{
       btn.disabled=false;
       syncContent.innerHTML='<i class="bi bi-arrow-repeat"></i> Sync Activity';
-      showToast('\u274c Sync failed: '+(res.error||'unknown'));
+      if(res.platforms){
+        showToast('\u274c Sync failed: '+(res.error||'unknown')+'. Check platform statuses in console.');
+        console.warn('Sync platform statuses:', res.platforms);
+      } else {
+        showToast('\u274c Sync failed: '+(res.error||'unknown'));
+      }
     }
   })
   .catch(err=>{

--- a/tests/test_sync_platforms_response.py
+++ b/tests/test_sync_platforms_response.py
@@ -1,0 +1,36 @@
+from app.profile.routes import build_sync_platforms_response
+
+
+def test_sync_platforms_response_partial_success():
+    platform_status = {
+        "leetcode": {"status": "failed", "error": "timeout"},
+        "github": {"status": "synced"},
+        "gfg": {"status": "skipped"},
+        "codingninjas": {"status": "skipped"},
+        "hackerrank": {"status": "skipped"},
+    }
+    result = build_sync_platforms_response(platform_status)
+    assert result["success"] is True
+    assert result["partial_success"] is True
+    assert result["platforms"]["leetcode"]["status"] == "failed"
+
+
+def test_sync_platforms_response_all_failed():
+    platform_status = {
+        "leetcode": {"status": "failed", "error": "timeout"},
+        "github": {"status": "failed", "error": "not found"},
+    }
+    result = build_sync_platforms_response(platform_status)
+    assert result["success"] is False
+    assert "all platforms" in result["error"].lower()
+
+
+def test_sync_platforms_response_none_attempted():
+    platform_status = {
+        "leetcode": {"status": "skipped"},
+        "github": {"status": "skipped"},
+    }
+    result = build_sync_platforms_response(platform_status)
+    assert result["success"] is False
+    assert "no platforms" in result["error"].lower()
+


### PR DESCRIPTION
# Description

Improve the profile “Sync Platforms” endpoint response so users can see which platform syncs succeeded vs failed (instead of a blanket success), and surface partial-sync details in the UI toast.

Fixes #139

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Tested in Local

Notes:
- Ran a quick manual check by triggering sync with a mix of valid/invalid usernames and confirmed the API returns per-platform statuses and the UI shows “partial sync” messaging.