### PR TITLE
fix: parameterize LeetCode GraphQL query

### DIFF
--- a/app/platforms/fetchers.py
+++ b/app/platforms/fetchers.py
@@ -7,13 +7,41 @@ import requests
 from app.utils import normalize_coding_ninjas_profile_id
 
 
+LEETCODE_PROFILE_QUERY = """
+query userProfile($username: String!) {
+  matchedUser(username: $username) {
+    submitStatsGlobal {
+      acSubmissionNum {
+        difficulty
+        count
+      }
+    }
+    userCalendar {
+      submissionCalendar
+    }
+  }
+  userContestRanking(username: $username) {
+    attendedContestsCount
+    rating
+    globalRanking
+    topPercentage
+  }
+}
+"""
+
+
+def build_leetcode_profile_payload(username):
+    return {
+        "query": LEETCODE_PROFILE_QUERY,
+        "variables": {"username": username},
+    }
+
+
 def fetch_leetcode(username):
     try:
         response = requests.post(
             "https://leetcode.com/graphql",
-            json={
-                "query": f'{{ matchedUser(username: "{username}") {{ submitStatsGlobal {{ acSubmissionNum {{ difficulty count }} }} userCalendar {{ submissionCalendar }} }} userContestRanking(username: "{username}") {{ attendedContestsCount rating globalRanking topPercentage }} }}'
-            },
+            json=build_leetcode_profile_payload(username),
             timeout=8,
         )
         response_json = response.json().get("data", {})

--- a/tests/test_leetcode_payload.py
+++ b/tests/test_leetcode_payload.py
@@ -1,0 +1,20 @@
+from app.platforms.fetchers import build_leetcode_profile_payload
+
+
+def test_leetcode_profile_payload_uses_graphql_variables():
+    payload = build_leetcode_profile_payload("saurabhhhcodes")
+
+    assert payload["variables"] == {"username": "saurabhhhcodes"}
+    assert "matchedUser(username: $username)" in payload["query"]
+    assert "userContestRanking(username: $username)" in payload["query"]
+    assert "saurabhhhcodes" not in payload["query"]
+
+
+def test_leetcode_profile_payload_keeps_special_characters_out_of_query_text():
+    username = 'bad"user) { injected { id } } #'
+
+    payload = build_leetcode_profile_payload(username)
+
+    assert payload["variables"]["username"] == username
+    assert username not in payload["query"]
+    assert "injected" not in payload["query"]


### PR DESCRIPTION
# Description

This fixes the LeetCode profile sync query so the username is sent through GraphQL variables instead of being interpolated into the query text. The response parsing behavior stays unchanged, but quoted or GraphQL-like username input can no longer alter the query document.

Fixes #23

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Tested in Local

Commands run:
- `python3 -m pytest tests/test_leetcode_payload.py tests/test_platform_fetcher.py` -> 4 passed
- `python3 -m py_compile app/platforms/fetchers.py tests/test_leetcode_payload.py`
- `git diff --check`
- `python3 -m pytest` -> 70 passed, 23 existing Flask-Limiter in-memory storage warnings

## Checklist
- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs

```text
70 passed, 23 warnings in 0.79s
```