### PR TITLE
Fix Google OAuth nonce handling

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -9,6 +9,7 @@ from app.utils import utc_now
 
 
 auth_bp = Blueprint("auth", __name__)
+GOOGLE_OAUTH_NONCE_SESSION_KEY = "google_oauth_nonce"
 
 
 class UserWrapper(UserMixin):
@@ -198,13 +199,19 @@ def authorize_github():
 @auth_bp.route("/login/google")
 def login_google():
     redirect_uri = url_for("auth.authorize_google", _external=True)
-    return google.authorize_redirect(redirect_uri)
+    nonce = secrets.token_urlsafe(16)
+    session[GOOGLE_OAUTH_NONCE_SESSION_KEY] = nonce
+    return google.authorize_redirect(redirect_uri, nonce=nonce)
 
 
 @auth_bp.route("/login/google/authorize")
 def authorize_google():
+    nonce = session.pop(GOOGLE_OAUTH_NONCE_SESSION_KEY, None)
+    if not nonce:
+        return "Google OAuth nonce missing", 400
+
     token = google.authorize_access_token()
-    user_info = google.parse_id_token(token, nonce=session.get("nonce"))
+    user_info = google.parse_id_token(token, nonce=nonce)
     if not user_info:
         user_info = google.userinfo()
 

--- a/tests/test_google_oauth_nonce.py
+++ b/tests/test_google_oauth_nonce.py
@@ -1,0 +1,101 @@
+import mongomock
+
+import app as app_module
+import app.auth.routes as auth_routes
+
+
+class FakeGoogleClient:
+    def __init__(self, parsed_user=None):
+        self.authorize_redirect_calls = []
+        self.authorize_access_token_called = False
+        self.parse_id_token_calls = []
+        self.userinfo_called = False
+        self.parsed_user = parsed_user or {
+            "sub": "google-user-1",
+            "email": "google@example.com",
+            "name": "Google User",
+        }
+
+    def authorize_redirect(self, redirect_uri, **kwargs):
+        self.authorize_redirect_calls.append((redirect_uri, kwargs))
+        return "redirected"
+
+    def authorize_access_token(self):
+        self.authorize_access_token_called = True
+        return {"id_token": "token"}
+
+    def parse_id_token(self, token, nonce=None):
+        self.parse_id_token_calls.append((token, nonce))
+        return self.parsed_user
+
+    def userinfo(self):
+        self.userinfo_called = True
+        return self.parsed_user
+
+
+def create_test_app(monkeypatch, google_client):
+    test_db = mongomock.MongoClient().db
+
+    monkeypatch.setattr(app_module, "db", test_db)
+    monkeypatch.setattr(auth_routes, "db", test_db)
+    monkeypatch.setattr(auth_routes, "google", google_client)
+
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
+
+    flask_app = app_module.create_app()
+    flask_app.config.update(TESTING=True)
+    flask_app._db_initialized = True
+
+    return flask_app, test_db
+
+
+def test_google_login_generates_and_sends_nonce(monkeypatch):
+    google_client = FakeGoogleClient()
+    flask_app, _ = create_test_app(monkeypatch, google_client)
+
+    with flask_app.test_client() as client:
+        response = client.get("/login/google")
+
+        with client.session_transaction() as session:
+            stored_nonce = session[auth_routes.GOOGLE_OAUTH_NONCE_SESSION_KEY]
+
+    assert response.status_code == 200
+    assert google_client.authorize_redirect_calls
+    redirect_uri, kwargs = google_client.authorize_redirect_calls[0]
+    assert redirect_uri == "http://localhost/login/google/authorize"
+    assert kwargs["nonce"] == stored_nonce
+
+
+def test_google_authorize_uses_and_consumes_nonce(monkeypatch):
+    google_client = FakeGoogleClient()
+    flask_app, test_db = create_test_app(monkeypatch, google_client)
+
+    with flask_app.test_client() as client:
+        with client.session_transaction() as session:
+            session[auth_routes.GOOGLE_OAUTH_NONCE_SESSION_KEY] = "expected-nonce"
+
+        response = client.get("/login/google/authorize")
+
+        with client.session_transaction() as session:
+            assert auth_routes.GOOGLE_OAUTH_NONCE_SESSION_KEY not in session
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/"
+    assert google_client.authorize_access_token_called is True
+    assert google_client.parse_id_token_calls == [({"id_token": "token"}, "expected-nonce")]
+    assert google_client.userinfo_called is False
+    assert test_db.user.find_one({"google_id": "google-user-1"}) is not None
+
+
+def test_google_authorize_rejects_missing_nonce(monkeypatch):
+    google_client = FakeGoogleClient()
+    flask_app, _ = create_test_app(monkeypatch, google_client)
+
+    with flask_app.test_client() as client:
+        response = client.get("/login/google/authorize")
+
+    assert response.status_code == 400
+    assert response.data == b"Google OAuth nonce missing"
+    assert google_client.authorize_access_token_called is False
+    assert google_client.parse_id_token_calls == []


### PR DESCRIPTION
# Description

  Fixes Google OAuth nonce handling for the login callback flow.

  Previously, `/login/google/authorize` passed `session.get("nonce")` into `google.parse_id_token()`, but `/
  login/google` never generated or stored a nonce before redirecting to Google. This meant nonce
  verification could receive `None`.

  This PR:
  - Generates a secure Google OAuth nonce before redirecting to Google.
  - Stores the nonce in the session under a Google-specific key.
  - Sends the nonce through `authorize_redirect`.
  - Consumes the nonce with `session.pop(...)` in the callback.
  - Rejects callback requests with a `400` response when the nonce is missing.
  - Adds focused tests for nonce generation, nonce usage, nonce cleanup, and missing nonce rejection.

  Fixes #79

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] Security (non-breaking change which improves security)

  # How Has This Been Tested?

  - [x] Tested in Local

  ```bash
  .venv/bin/pytest tests/test_google_oauth_nonce.py -q
```

  3 passed

  .venv/bin/pytest -q

  76 passed

  .venv/bin/ruff check app/auth/routes.py tests/test_google_oauth_nonce.py

  All checks passed!

  ## Checklist

  - [x] I have starred this repository.
  - [x] My PR references the issue number.
  - [x] I placed files in the correct location.
  - [x] I added or updated tests where useful.

  ## Logs and SS

  .venv/bin/pytest tests/test_google_oauth_nonce.py -q
  3 passed

  .venv/bin/pytest -q
  76 passed

  .venv/bin/ruff check app/auth/routes.py tests/test_google_oauth_nonce.py
  All checks passed!

<img width="945" height="808" alt="image" src="https://github.com/user-attachments/assets/37e4c8a2-dae4-4eef-a9af-2e2f0154f375" />
<img width="1218" height="294" alt="image" src="https://github.com/user-attachments/assets/8b6f229a-edbf-4908-acc0-566c2ff86bbf" />
