### PR TITLE
Added swagger api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Update `SECRET_KEY` and any OAuth or MongoDB credentials in `.env` before runnin
 
 3. **Run the Flask app**
 ```bash
-python app.py
+python run.py
 ```
 
 4. **Open in browser**
@@ -84,12 +84,24 @@ The project uses SQLAlchemy ORM with SQLite:
 
 ## API Endpoints
 
+Interactive Swagger/OpenAPI documentation is available after starting the app:
+
+```
+http://localhost:5000/apidocs
+```
+
 ### Frontend Routes
 - `GET /` - Dashboard with all topics
 - `GET /topic/<topic_id>` - View questions for a topic
 
-### AJAX API
+### REST API
+- `GET /api/search_questions` - Search DSA questions by query and optional limit.
+- `GET /api/leaderboard` - Fetch paginated leaderboard data by ranking mode.
 - `POST /update_question/<question_id>` - Update question (body: `{done, bookmark, notes}`)
+- `POST /sync_platforms` - Sync authenticated user's coding platform statistics.
+- `POST /edit_profile` - Update authenticated user's profile fields.
+- `POST /upload_photo` - Upload a profile image when photo storage is configured.
+- `GET /search_universities` - Search university names for profile autocomplete.
 
 ## Conversion from React
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ import os
 import secrets
 
 from dotenv import load_dotenv
+from flasgger import Swagger
 from flask import Flask, session
 
 from app.admin import admin_bp
@@ -25,8 +26,32 @@ def create_app():
     app.config["MONGO_URI"] = os.environ.get("MONGO_URI", "mongodb://localhost:27017/450_dsa")
     app.config["CACHE_TYPE"] = "SimpleCache"
     app.config["CACHE_DEFAULT_TIMEOUT"] = 300
+    app.config["SWAGGER"] = {
+        "title": "450 DSA Tracker API",
+        "uiversion": 3,
+    }
     
     cache.init_app(app)
+    Swagger(
+        app,
+        template={
+            "swagger": "2.0",
+            "info": {
+                "title": "450 DSA Tracker API",
+                "description": "API documentation for search, leaderboard, progress, and profile endpoints.",
+                "version": "1.0.0",
+            },
+            "basePath": "/",
+            "securityDefinitions": {
+                "SessionAuth": {
+                    "type": "apiKey",
+                    "name": "session",
+                    "in": "cookie",
+                    "description": "Flask-Login session cookie.",
+                },
+            },
+        },
+    )
 
     # Initialize extensions
     mongo.init_app(app)

--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -53,6 +53,84 @@ def leaderboard():
 @leaderboard_bp.route("/api/leaderboard")
 @cache.cached(timeout=300, query_string=True)
 def api_leaderboard():
+    """Get leaderboard rankings.
+    ---
+    tags:
+      - Leaderboard
+    parameters:
+      - name: mode
+        in: query
+        type: string
+        required: false
+        default: cscore
+        enum:
+          - cscore
+          - questions
+          - rating
+          - college
+        description: Ranking mode used to sort leaderboard entries.
+      - name: page
+        in: query
+        type: integer
+        required: false
+        default: 1
+        minimum: 1
+        description: Page number for paginated results.
+      - name: per_page
+        in: query
+        type: integer
+        required: false
+        default: 20
+        maximum: 100
+        description: Number of entries per page.
+      - name: current_user_id
+        in: query
+        type: string
+        required: false
+        description: Optional user id used to return that user's current rank.
+    responses:
+      200:
+        description: Paginated leaderboard response.
+        schema:
+          type: object
+          properties:
+            entries:
+              type: array
+              items:
+                type: object
+                properties:
+                  rank:
+                    type: integer
+                  user_id:
+                    type: string
+                  name:
+                    type: string
+                  profile_photo:
+                    type: string
+                  college:
+                    type: string
+                  c_score:
+                    type: integer
+                  total_solved:
+                    type: integer
+                  dsa_done:
+                    type: integer
+                  lc_total:
+                    type: integer
+                  lc_rating:
+                    type: integer
+            total:
+              type: integer
+            page:
+              type: integer
+            per_page:
+              type: integer
+            total_pages:
+              type: integer
+            current_user_rank:
+              type: integer
+              x-nullable: true
+    """
     mode = request.args.get("mode", "cscore")
     page = int(request.args.get("page", 1))
     per_page = min(int(request.args.get("per_page", 20)), 100)

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -52,6 +52,64 @@ def build_sync_platforms_response(platform_status: dict):
 @login_required
 @limiter.limit("5 per minute")
 def sync_platforms():
+    """Sync coding platform statistics for the authenticated user.
+    ---
+    tags:
+      - Profile
+    parameters:
+      - name: body
+        in: body
+        required: false
+        schema:
+          type: object
+          properties:
+            leetcode:
+              type: string
+              description: LeetCode username.
+            github:
+              type: string
+              description: GitHub username.
+            gfg:
+              type: string
+              description: GeeksforGeeks username.
+            hackerrank:
+              type: string
+              description: HackerRank username.
+            codingninjas:
+              type: string
+              description: Coding Ninjas profile id or URL.
+    security:
+      - SessionAuth: []
+    responses:
+      200:
+        description: Platform sync result.
+        schema:
+          type: object
+          properties:
+            success:
+              type: boolean
+            partial_success:
+              type: boolean
+            error:
+              type: string
+            platforms:
+              type: object
+              additionalProperties:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - synced
+                      - failed
+                      - skipped
+                  error:
+                    type: string
+      401:
+        description: Login required.
+      429:
+        description: Rate limit exceeded.
+    """
     data = request.json
     now = utc_now()
     user_id = current_user.id
@@ -208,6 +266,68 @@ def sync_platforms():
 @profile_bp.route("/edit_profile", methods=["POST"])
 @login_required
 def edit_profile():
+    """Update profile fields for the authenticated user.
+    ---
+    tags:
+      - Profile
+    parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+              maxLength: 100
+            bio:
+              type: string
+              maxLength: 500
+            location:
+              type: string
+              maxLength: 100
+            college:
+              type: string
+              maxLength: 200
+            headline:
+              type: string
+              maxLength: 150
+            linkedin_url:
+              type: string
+              maxLength: 300
+            twitter_url:
+              type: string
+              maxLength: 300
+            website_url:
+              type: string
+              maxLength: 300
+            resume_url:
+              type: string
+              maxLength: 300
+    security:
+      - SessionAuth: []
+    responses:
+      200:
+        description: Profile updated successfully.
+        schema:
+          type: object
+          properties:
+            success:
+              type: boolean
+              example: true
+      400:
+        description: Invalid profile payload.
+        schema:
+          type: object
+          properties:
+            success:
+              type: boolean
+              example: false
+            error:
+              type: string
+      401:
+        description: Login required.
+    """
     data = request.get_json()
     if not data:
         return jsonify({"success": False, "error": "No data"}), 400
@@ -270,6 +390,32 @@ def public_card(user_id):
 
 @profile_bp.route("/search_universities")
 def search_universities():
+    """Search universities by name.
+    ---
+    tags:
+      - Profile
+    parameters:
+      - name: q
+        in: query
+        type: string
+        required: true
+        minLength: 2
+        description: University name search text.
+    responses:
+      200:
+        description: Matching universities.
+        schema:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              country:
+                type: string
+              label:
+                type: string
+    """
     query = request.args.get("q", "").strip()
     if len(query) < 2:
         return jsonify([])
@@ -300,6 +446,46 @@ def search_universities():
 @login_required
 @limiter.limit("10 per minute")
 def upload_photo():
+    """Upload a profile photo.
+    ---
+    tags:
+      - Profile
+    consumes:
+      - multipart/form-data
+    parameters:
+      - name: photo
+        in: formData
+        type: file
+        required: true
+        description: Profile image file.
+    security:
+      - SessionAuth: []
+    responses:
+      200:
+        description: Photo uploaded successfully when an uploader is configured.
+        schema:
+          type: object
+          properties:
+            success:
+              type: boolean
+            photo_url:
+              type: string
+      401:
+        description: Login required.
+      429:
+        description: Rate limit exceeded.
+      500:
+        description: Photo upload is currently disabled or upload failed.
+        schema:
+          type: object
+          properties:
+            success:
+              type: boolean
+              example: false
+            error:
+              type: string
+              example: Photo upload disabled (Cloudinary not configured)
+    """
     return jsonify({"success": False, "error": "Photo upload disabled (Cloudinary not configured)"}), 500
 
 

--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -16,6 +16,73 @@ def search():
 @search_bp.route("/api/search_questions")
 @limiter.limit("30 per minute")
 def api_search_questions():
+    """Search DSA questions.
+    ---
+    tags:
+      - Search
+    parameters:
+      - name: q
+        in: query
+        type: string
+        required: false
+        description: Search text. Supports platform filters such as "leetcode arrays".
+      - name: limit
+        in: query
+        type: integer
+        required: false
+        default: 40
+        minimum: 1
+        maximum: 80
+        description: Maximum number of matching questions to return.
+    responses:
+      200:
+        description: Search results and external search suggestions.
+        schema:
+          type: object
+          properties:
+            query:
+              type: string
+            requested_platforms:
+              type: array
+              items:
+                type: string
+            results:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  problem:
+                    type: string
+                  topic:
+                    type: string
+                  topic_id:
+                    type: string
+                  links:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        platform:
+                          type: string
+                        url:
+                          type: string
+                        color:
+                          type: string
+                  external_searches:
+                    type: array
+                    items:
+                      type: object
+                  score:
+                    type: integer
+            external_searches:
+              type: array
+              items:
+                type: object
+      429:
+        description: Rate limit exceeded.
+    """
     raw_query = request.args.get("q", "")
     try:
         limit = min(max(int(request.args.get("limit", 40)), 1), 80)

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -106,6 +106,56 @@ def export_topic_notes(topic_id):
 @tracker_bp.route("/update_question/<question_id>", methods=["POST"])
 @login_required
 def update_question(question_id):
+    """Update the authenticated user's progress for a question.
+    ---
+    tags:
+      - Tracker
+    parameters:
+      - name: question_id
+        in: path
+        type: string
+        required: true
+        description: MongoDB ObjectId of the question to update.
+      - name: body
+        in: body
+        required: true
+        schema:
+          type: object
+          properties:
+            done:
+              type: boolean
+              description: Whether the question is completed.
+            bookmark:
+              type: boolean
+              description: Whether the question is bookmarked.
+            notes:
+              type: string
+              description: User notes for the question.
+    security:
+      - SessionAuth: []
+    responses:
+      200:
+        description: Question progress updated successfully.
+        schema:
+          type: object
+          properties:
+            success:
+              type: boolean
+              example: true
+      401:
+        description: Login required.
+      404:
+        description: Question not found.
+        schema:
+          type: object
+          properties:
+            success:
+              type: boolean
+              example: false
+            error:
+              type: string
+              example: Question not found
+    """
     try:
         question = db.question.find_one({"_id": ObjectId(question_id)})
     except Exception:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ mongomock==4.1.2
 Flask-Limiter==3.5.0
 # pyjson5==1.6.2
 Flask-Caching==2.0.2
+flasgger==0.9.7.1

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -77,8 +77,23 @@ def test_create_app_preserves_routes_and_blueprints(monkeypatch):
     assert "/u/<user_id>" in routes
     assert "/search" in routes
     assert "/api/search_questions" in routes
+    assert "/apidocs/" in routes
+    assert "/apispec_1.json" in routes
 
     question_indexes = app_module.db.question.indexes
     assert (([("problem", "text")],), {"name": "problem_text"}) in question_indexes
     assert "/admin" in routes
     assert "/admin/users/<user_id>/delete" in routes
+
+    docs_response = flask_app.test_client().get("/apidocs/")
+    assert docs_response.status_code == 200
+
+    response = flask_app.test_client().get("/apispec_1.json")
+    assert response.status_code == 200
+    spec = response.get_json()
+    assert "/api/search_questions" in spec["paths"]
+    assert "/api/leaderboard" in spec["paths"]
+    assert "/update_question/{question_id}" in spec["paths"]
+    assert "/sync_platforms" in spec["paths"]
+    assert "/edit_profile" in spec["paths"]
+    assert "/upload_photo" in spec["paths"]


### PR DESCRIPTION

  # Description

  Added Swagger/OpenAPI documentation for the Flask API endpoints using Flasgger.

  Fixes #88

  ## Summary
  - Added Flasgger dependency and initialized Swagger UI at `/apidocs/`
  - Added YAML docstring specs for REST API endpoints:
    - `GET /api/search_questions`
    - `GET /api/leaderboard`
    - `POST /update_question/<question_id>`
    - `POST /sync_platforms`
    - `POST /edit_profile`
    - `POST /upload_photo`
    - `GET /search_universities`
  - Updated README with the API docs link and correct local run command
  - Added app factory test coverage for Swagger routes and generated spec paths

  ## Type of change

  - [x] Enhancement (non-breaking change which adds functionality)
  - [x] Documentation (non-breaking change which improves documentation)

  # How Has This Been Tested?

  - [x] Tested in Local

  ```bash
  pytest -q
```

  Result:

  73 passed, 27 warnings

  Also manually verified:

  - /apidocs/ loads Swagger UI
  - /apispec_1.json returns the OpenAPI JSON
  - Documented endpoints appear in Swagger UI

  ## Checklist

  - [x] I have starred this repository.
  - [x] My PR references the issue number.
  - [x] I placed files in the correct location.
  - [x] I added or updated tests where useful.

  ## Screenshots Or Logs

  Swagger UI and OpenAPI JSON were verified locally at:

  http://127.0.0.1:5000/apidocs/
<img width="1826" height="1080" alt="image" src="https://github.com/user-attachments/assets/ed19b47a-821d-4c48-ba4e-e5b7a24086dd" />

  http://127.0.0.1:5000/apispec_1.json
<img width="1799" height="1085" alt="image" src="https://github.com/user-attachments/assets/60e29767-9b46-4e89-a578-db84f2bd8bc4" />
