### PR TITLE
feat: add AtCoder platform integration

### DIFF
--- a/app/platforms/fetchers.py
+++ b/app/platforms/fetchers.py
@@ -249,6 +249,18 @@ def fetch_gfg(username):
         return {}
 
 
+def fetch_atcoder(handle):
+    try:
+        r = requests.get(
+            'https://kenkoooo.com/atcoder/atcoder-api/v3/user/acceptance_count',
+            params={'user': handle}, timeout=8)
+        if r.status_code == 200:
+            return {'total': r.json().get('count', 0)}
+    except Exception as e:
+        print(f'AtCoder Error: {e}')
+    return {}
+
+
 def fetch_coding_ninjas(username):
     """Fetch Coding Ninjas/Code360 solved count from public profile pages."""
     profile_id = normalize_coding_ninjas_profile_id(username)

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -17,6 +17,7 @@ from card_generator import generate_progress_card
 from app.extensions import db
 from app.extensions import limiter, cache
 from app.platforms.fetchers import (
+    fetch_atcoder,
     fetch_coding_ninjas,
     fetch_gfg,
     fetch_github,
@@ -73,6 +74,7 @@ def sync_platforms():
     gfg_user = current_user.gfg_username or ""
     hr_user = current_user.hackerrank_username or ""
     cn_user = current_user.codingninjas_username or ""
+    ac_user = current_user.atcoder_username or ""
 
     if "leetcode" in data:
         lc_user = data.get("leetcode", "").strip()
@@ -89,6 +91,9 @@ def sync_platforms():
     if "codingninjas" in data:
         cn_user = normalize_coding_ninjas_profile_id(data.get("codingninjas", ""))
         update_fields["codingninjas_username"] = cn_user
+    if "atcoder" in data:
+        ac_user = data.get("atcoder", "").strip()
+        update_fields["atcoder_username"] = ac_user
 
     combined = {}
     totals = {}
@@ -195,6 +200,20 @@ def sync_platforms():
             _mark("hackerrank", "failed", "Failed to fetch HackerRank stats.")
     else:
         _mark("hackerrank", "skipped")
+
+    if ac_user:
+        try:
+            ac = fetch_atcoder(ac_user)
+            if not ac:
+                _mark("atcoder", "failed", "No data returned (handle may be invalid or rate-limited).")
+            else:
+                _mark("atcoder", "synced")
+                if ac.get("total") is not None:
+                    totals["AtCoder"] = int(ac.get("total", 0))
+        except Exception:
+            _mark("atcoder", "failed", "Failed to fetch AtCoder stats.")
+    else:
+        _mark("atcoder", "skipped")
 
     update_fields["external_daily_counts"] = combined
     update_fields["external_totals"] = totals

--- a/app/utils.py
+++ b/app/utils.py
@@ -379,7 +379,7 @@ def build_college_leaderboard_data(entries=None):
 
 def compute_user_platforms(solved_items, external_totals, all_questions):
     """Compute platform counts combining solved DSA questions with external totals."""
-    platforms = {"LeetCode": 0, "GFG": 0, "Coding Ninjas": 0, "HackerRank": 0, "Other": 0}
+    platforms = {"LeetCode": 0, "GFG": 0, "Coding Ninjas": 0, "HackerRank": 0, "AtCoder": 0, "Other": 0}
     
     for question in all_questions:
         question_id = str(question.get("_id", ""))
@@ -401,5 +401,6 @@ def compute_user_platforms(solved_items, external_totals, all_questions):
     platforms["GFG"] = max(platforms["GFG"], ext_totals.get("GFG", 0))
     platforms["Coding Ninjas"] = max(platforms["Coding Ninjas"], ext_totals.get("Coding Ninjas", 0))
     platforms["HackerRank"] = max(platforms["HackerRank"], ext_totals.get("HackerRank", 0))
-    
+    platforms["AtCoder"] = ext_totals.get("AtCoder", 0)
+
     return platforms

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -176,6 +176,12 @@
         {% if user.hackerrank_username %}<i class="bi bi-check-circle-fill check-ok"></i><a href="https://www.hackerrank.com/{{ user.hackerrank_username }}" target="_blank" class="link-out"><i class="bi bi-box-arrow-up-right"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;"><i class="bi bi-box-arrow-up-right"></i></a>{% endif %}
       </span>
     </div>
+    <div class="platform-row">
+      <span><i class="bi bi-trophy" style="color:#f97316;margin-right:6px"></i>AtCoder</span>
+      <span style="display:flex;align-items:center;gap:6px">
+        {% if user.atcoder_username %}<i class="bi bi-check-circle-fill check-ok"></i><a href="https://atcoder.jp/users/{{ user.atcoder_username }}" target="_blank" class="link-out"><i class="bi bi-box-arrow-up-right"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;"><i class="bi bi-box-arrow-up-right"></i></a>{% endif %}
+      </span>
+    </div>
     <button class="add-btn" onclick="openSyncModal()"><i class="bi bi-plus"></i> Add Platform</button>
     <div class="sec-title" style="margin-top:14px">Development Stats</div>
     <div class="platform-row">
@@ -361,6 +367,10 @@
         <strong>{{ platforms['HackerRank'] }}</strong>
       </div>
       <div class="legend-item">
+        <span><span class="legend-dot" style="background:#f97316"></span><span style="color:#f97316;font-weight:700">AtCoder</span></span>
+        <strong>{{ platforms['AtCoder'] }}</strong>
+      </div>
+      <div class="legend-item">
         <span><span class="legend-dot" style="background:#6c757d"></span><span style="color:#6c757d;font-weight:700">Other</span></span>
         <strong>{{ platforms['Other'] }}</strong>
       </div>
@@ -424,6 +434,8 @@
     <input class="m-inp" id="cn_username" placeholder="e.g. Harshydv or full profile URL" value="{{ user.codingninjas_username or '' }}">
     <label class="m-lbl"><i class="bi bi-h-square" style="color:#00bd6c;margin-right:4px"></i>HackerRank Username</label>
     <input class="m-inp" id="hr_username" placeholder="e.g. hacker" value="{{ user.hackerrank_username or '' }}">
+    <label class="m-lbl"><i class="bi bi-trophy" style="color:#f97316;margin-right:4px"></i>AtCoder Handle</label>
+    <input class="m-inp" id="ac_username" placeholder="e.g. tourist" value="{{ user.atcoder_username or '' }}">
     <div class="m-note">GFG and Coding Ninjas sync are experimental and may take a few seconds.</div>
     <div class="m-actions">
       <button class="m-cancel" onclick="closeSyncModal()">Cancel</button>
@@ -593,8 +605,9 @@ window.handleQuickSync = function(btn) {
   const gfg = '{{ user.gfg_username or "" }}';
   const hr = '{{ user.hackerrank_username or "" }}';
   const cn = '{{ user.codingninjas_username or "" }}';
-  
-  if(!lc && !gh && !gfg && !hr && !cn){
+  const ac = '{{ user.atcoder_username or "" }}';
+
+  if(!lc && !gh && !gfg && !hr && !cn && !ac){
     showToast('⚠️ No platforms connected to sync!');
     return;
   }
@@ -603,11 +616,11 @@ window.handleQuickSync = function(btn) {
   icon.classList.add('btn-spinner');
   icon.className = 'bi bi-arrow-clockwise btn-spinner';
   showToast('⏳ Syncing profiles...');
-  
+
   fetch('/sync_platforms', {
     method:'POST',
     headers:{'Content-Type':'application/json'},
-    body:JSON.stringify({leetcode:lc,github:gh,gfg:gfg,hackerrank:hr,codingninjas:cn})
+    body:JSON.stringify({leetcode:lc,github:gh,gfg:gfg,hackerrank:hr,codingninjas:cn,atcoder:ac})
   })
   .then(r => r.json())
   .then(res => {
@@ -615,7 +628,7 @@ window.handleQuickSync = function(btn) {
     icon.className = 'bi bi-arrow-clockwise';
     if(res.success){
       const platforms = res.platforms || {};
-      const labels = {leetcode:'LeetCode',github:'GitHub',gfg:'GFG',hackerrank:'HackerRank',codingninjas:'Coding Ninjas'};
+      const labels = {leetcode:'LeetCode',github:'GitHub',gfg:'GFG',hackerrank:'HackerRank',codingninjas:'Coding Ninjas',atcoder:'AtCoder'};
       const synced = Object.keys(platforms).filter(k => platforms[k].status === 'synced').map(k => labels[k] || k);
       const failed = Object.keys(platforms).filter(k => platforms[k].status === 'failed').map(k => labels[k] || k);
       if(res.partial_success){
@@ -642,7 +655,8 @@ window.handleSyncProfile = function(btn){
   const gfg=document.getElementById('gfg_username').value.trim();
   const hr=document.getElementById('hr_username').value.trim();
   const cn=document.getElementById('cn_username').value.trim();
-  if(!lc && !gh && !gfg && !hr && !cn){showToast('\u26a0\ufe0f Enter at least one username');return;}
+  const ac=document.getElementById('ac_username').value.trim();
+  if(!lc && !gh && !gfg && !hr && !cn && !ac){showToast('\u26a0\ufe0f Enter at least one username');return;}
 
   // Disable button & show spinner
   btn.disabled=true;
@@ -673,7 +687,7 @@ window.handleSyncProfile = function(btn){
   fetch('/sync_platforms',{
     method:'POST',
     headers:{'Content-Type':'application/json'},
-    body:JSON.stringify({leetcode:lc,github:gh,gfg:gfg,hackerrank:hr,codingninjas:cn}),
+    body:JSON.stringify({leetcode:lc,github:gh,gfg:gfg,hackerrank:hr,codingninjas:cn,atcoder:ac}),
     signal:ctrl.signal
   })
   .then(r=>{clearTimeout(timer);return r.json();})
@@ -683,7 +697,7 @@ window.handleSyncProfile = function(btn){
     if(res.success){
       syncContent.innerHTML='<i class="bi bi-check-lg"></i> Synced!';
       const platforms = res.platforms || {};
-      const labels = {leetcode:'LeetCode',github:'GitHub',gfg:'GFG',hackerrank:'HackerRank',codingninjas:'Coding Ninjas'};
+      const labels = {leetcode:'LeetCode',github:'GitHub',gfg:'GFG',hackerrank:'HackerRank',codingninjas:'Coding Ninjas',atcoder:'AtCoder'};
       const synced = Object.keys(platforms).filter(k => platforms[k].status === 'synced').map(k => labels[k] || k);
       const failed = Object.keys(platforms).filter(k => platforms[k].status === 'failed').map(k => labels[k] || k);
       if(res.partial_success){

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from unittest.mock import MagicMock
+
+# Pillow (PIL) doesn't support Python 3.14 yet.
+# Mock it so tests that import from `app` can still collect and run.
+for _mod in ('PIL', 'PIL.Image', 'PIL.ImageDraw', 'PIL.ImageFont'):
+    sys.modules.setdefault(_mod, MagicMock())
+sys.modules.setdefault('card_generator', MagicMock())

--- a/tests/test_platform_fetcher.py
+++ b/tests/test_platform_fetcher.py
@@ -1,6 +1,36 @@
 import time
+from unittest.mock import MagicMock, patch
 
 from platform_fetcher import run_fetch_jobs
+from app.platforms.fetchers import fetch_atcoder
+
+
+def test_fetch_atcoder_returns_total_on_success():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'count': 42}
+
+    with patch('app.platforms.fetchers.requests.get', return_value=mock_response):
+        result = fetch_atcoder('tourist')
+
+    assert result == {'total': 42}
+
+
+def test_fetch_atcoder_returns_empty_on_non_200():
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+
+    with patch('app.platforms.fetchers.requests.get', return_value=mock_response):
+        result = fetch_atcoder('unknown_user')
+
+    assert result == {}
+
+
+def test_fetch_atcoder_returns_empty_on_exception():
+    with patch('app.platforms.fetchers.requests.get', side_effect=Exception('timeout')):
+        result = fetch_atcoder('tourist')
+
+    assert result == {}
 
 
 def test_run_fetch_jobs_executes_jobs_concurrently():


### PR DESCRIPTION
## Description

Adds AtCoder platform integration so users can sync their AtCoder accepted submission count to their profile.

Closes #77

### Changes made

* Added `fetch_atcoder(handle)` fetcher in `app/platforms/fetchers.py` using the kenkoooo AtCoder Problems API
* Wired AtCoder into `sync_platforms()`:

  * reads `atcoder_username` from request
  * saves username to DB
  * stores total in `external_totals["AtCoder"]`
* Added AtCoder support to `compute_user_platforms()` in `app/utils.py`
* Profile page now shows:

  * AtCoder platform row
  * profile link to `atcoder.jp/users/{handle}`
  * solved count in stats legend
* Sync modal now includes an AtCoder handle input field
* Added AtCoder support to both quick-sync and modal sync JS payloads
* Added `tests/conftest.py` to mock PIL modules for Python 3.14 test compatibility

---

## Type of change

* New feature (non-breaking change which adds functionality)

---

## How Has This Been Tested?

Tested locally.

### Added unit tests in `tests/test_platform_fetcher.py`

* `test_fetch_atcoder_returns_total_on_success`
* `test_fetch_atcoder_returns_empty_on_non_200`
* `test_fetch_atcoder_returns_empty_on_exception`

### Test Results

```bash
tests/test_platform_fetcher.py::test_fetch_atcoder_returns_total_on_success PASSED
tests/test_platform_fetcher.py::test_fetch_atcoder_returns_empty_on_non_200 PASSED
tests/test_platform_fetcher.py::test_fetch_atcoder_returns_empty_on_exception PASSED
tests/test_platform_fetcher.py::test_run_fetch_jobs_executes_jobs_concurrently PASSED
tests/test_platform_fetcher.py::test_run_fetch_jobs_keeps_other_results_when_one_job_fails PASSED

5 passed in 0.95s
```

---

## Checklist

* [x] I have starred this repository
* [x] My PR references the issue number
* [x] I placed files in the correct location
* [x] I added or updated tests where useful

---

## Additional Notes

`tests/conftest.py` mocks PIL imports because Pillow currently does not support Python 3.14. This prevents unrelated import failures during test collection for modules importing `card_generator`.
