### PR TITLE
fix: sanitize university autocomplete suggestions

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -849,13 +849,20 @@ function handlePhotoUpload(e){
   let timer = null, activeIdx = -1;
 
   function renderItems(items){
-    dd.innerHTML = '';
+    dd.textContent = '';
     activeIdx = -1;
     if(!items.length){ dd.style.display='none'; return; }
     items.forEach((item, i) => {
       const div = document.createElement('div');
       div.style.cssText = 'padding:9px 14px;cursor:pointer;font-size:.83rem;border-bottom:1px solid var(--border-subtle);display:flex;justify-content:space-between;align-items:center;transition:background .15s';
-      div.innerHTML = '<span style="font-weight:600;color:var(--text-primary)">' + item.name + '</span><span style="font-size:.72rem;color:var(--text-muted)">' + item.country + '</span>';
+      const name = document.createElement('span');
+      name.style.cssText = 'font-weight:600;color:var(--text-primary)';
+      name.textContent = item.name;
+      const country = document.createElement('span');
+      country.style.cssText = 'font-size:.72rem;color:var(--text-muted)';
+      country.textContent = item.country;
+      div.appendChild(name);
+      div.appendChild(country);
       div.dataset.label = item.label;
       div.addEventListener('mouseenter', () => { setActive(i); });
       div.addEventListener('click', () => { inp.value = item.label; dd.style.display='none'; });

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 # Pillow (PIL) doesn't support Python 3.14 yet.
 # Mock it so tests that import from `app` can still collect and run.
-for _mod in ('PIL', 'PIL.Image', 'PIL.ImageDraw', 'PIL.ImageFont'):
-    sys.modules.setdefault(_mod, MagicMock())
-sys.modules.setdefault('card_generator', MagicMock())
+if sys.version_info >= (3, 14):
+    for _mod in ('PIL', 'PIL.Image', 'PIL.ImageDraw', 'PIL.ImageFont'):
+        sys.modules.setdefault(_mod, MagicMock())
+    sys.modules.setdefault('card_generator', MagicMock())


### PR DESCRIPTION
# Description

This PR fixes a security issue in the university autocomplete dropdown rendering inside the profile edit modal.

Previously, third-party university API data was rendered using `innerHTML`, which could allow unsafe HTML injection. This update replaces the unsafe rendering logic with secure DOM manipulation APIs using `createElement()` and `textContent`.

The existing dropdown appearance, keyboard navigation, and click selection behavior remain unchanged.

Fixes #147

---

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (non-breaking change which adds functionality)
* [ ] Refactor (non-breaking change which improves code structure)
* [ ] Documentation (non-breaking change which improves documentation)
* [ ] Performance (non-breaking change which improves performance)
* [ ] Chore (non-breaking change which does not modify src or test files)
* [ ] Build / CI (non-breaking change which does not modify src or test files)
* [x] Security (non-breaking change which improves security)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

* Verified autocomplete suggestions render correctly.

* Tested keyboard navigation and click selection behavior.

* Confirmed HTML-like university names render safely as plain text.

* Checked dropdown styling remains unchanged.

* [x] Tested in Local

## Checklist

* [x] I have starred this repository.
* [x] My PR references the issue number.
* [x] I placed files in the correct location.
* [ ] I added or updated tests where useful.

## Screenshots Or Logs

N/A — no visual UI changes were introduced beyond secure rendering behavior.
