### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to making 450 DSA Cracker a welcoming, respectful, and inclusive project for everyone. Contributors, maintainers, and users are expected to help create a harassment-free environment in all project spaces.
+
+## Expected Behavior
+
+Examples of behavior that contributes to a positive environment include:
+
+* Being respectful of differing experiences, skill levels, and viewpoints.
+* Offering constructive feedback and accepting feedback gracefully.
+* Keeping discussions focused on the project and its community goals.
+* Showing empathy toward other contributors and users.
+
+## Unacceptable Behavior
+
+Examples of unacceptable behavior include:
+
+* Harassment, intimidation, threats, or personal attacks.
+* Discriminatory language or conduct related to identity, background, or personal characteristics.
+* Deliberate disruption of project discussions, issues, pull requests, or other collaboration spaces.
+* Publishing private information without explicit permission.
+* Any other behavior that project maintainers reasonably determine to be inappropriate.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, report it to the project maintainers. For general conduct concerns, open a GitHub issue with only the details that are safe to share publicly. For sensitive matters, contact a maintainer through an available private channel before posting identifying information.
+
+Reports will be reviewed as promptly and fairly as possible. Maintainers will respect the privacy and safety of everyone involved.
+
+## Enforcement
+
+Maintainers may take any action they judge appropriate to protect the project community, including:
+
+* Clarifying expectations with the people involved.
+* Removing or editing comments, commits, issues, pull requests, or other contributions.
+* Temporarily or permanently limiting participation in the project.
+
+Enforcement decisions should be based on the impact of the behavior, the safety of the community, and the need to maintain a constructive collaboration space.
+
+## Scope
+
+This Code of Conduct applies in all official project spaces, including GitHub issues, pull requests, discussions, documentation, and community conversations related to the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ This document provides guidelines and instructions for contributing to this proj
 
 ## Code of Conduct
 
-By participating in this project, you are expected to uphold a welcoming, inclusive, and harassment-free environment for everyone. Please be respectful and constructive in your communication.
+By participating in this project, you are expected to uphold a welcoming, inclusive, and harassment-free environment for everyone. Please read and follow the full [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- add a standalone Code of Conduct for contributors
- link the contributing guide to the full policy

Closes #186