### PR TITLE
fix: hide public card exception details

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -8,7 +8,7 @@ import time
 # import cloudinary.uploader
 # import cloudinary.api
 import requests
-from flask import Blueprint, jsonify, render_template, request, send_file
+from flask import Blueprint, current_app, jsonify, render_template, request, send_file
 from flask_login import current_user, login_required
 from flask import Response
 import time
@@ -406,8 +406,9 @@ def public_card(user_id):
         
         card_cache[user_id] = (current_time, img_io)
         return send_file(img_io, mimetype="image/png")
-    except Exception as e:
-        return str(e), 500
+    except Exception:
+        current_app.logger.exception("Failed to generate public progress card")
+        return "Unable to generate progress card", 500
 
 
 @profile_bp.route("/search_universities")

--- a/tests/test_progress_card.py
+++ b/tests/test_progress_card.py
@@ -240,7 +240,7 @@ def test_public_card_caching(client, app):
 
 
 def test_public_card_exception_handling(client, app):
-    """Test that exceptions during card generation are handled."""
+    """Test that card generation errors do not expose raw exception text."""
     user_id = ObjectId()
     user_data = {
         "_id": user_id,
@@ -254,11 +254,12 @@ def test_public_card_exception_handling(client, app):
     app.mock_db.user.data[str(user_id)] = user_data
     
     with patch('app.profile.routes.db', app.mock_db), \
-         patch('card_generator.generate_progress_card', side_effect=Exception("Test error")):
+         patch('card_generator.generate_progress_card', side_effect=Exception("Secret path leak")):
         response = client.get(f"/u/{user_id}/card.png")
         
         assert response.status_code == 500
-        assert b"Test error" in response.data
+        assert b"Unable to generate progress card" in response.data
+        assert b"Secret path leak" not in response.data
 
 
 def test_card_generator_with_long_name(client, app):


### PR DESCRIPTION
## Summary
- stop returning raw exception text from the public progress card route
- log card generation failures server-side with `current_app.logger.exception`
- update the progress-card regression test to assert internal exception text is not exposed

Closes #199

## Tests
- `/tmp/450-dsa-issue196/bin/python -m pytest tests/test_progress_card.py -q`
- `/tmp/450-dsa-issue196/bin/python -m pytest tests -q`
- `/tmp/450-dsa-issue196/bin/python -m py_compile app/profile/routes.py tests/test_progress_card.py`
- `git diff --check`