### PR TITLE
fix: configure persistent rate-limit storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ SECRET_KEY=change-me-to-a-random-string
 # MongoDB (Future/Alternative Database)
 MONGO_URI=mongodb://localhost:27017/dsa_tracker
 
+# Rate limiting
+# Use memory:// for local development. Use a shared backend in production, for example:
+# RATELIMIT_STORAGE_URI=redis://localhost:6379/0
+RATELIMIT_STORAGE_URI=memory://
+
 # GitHub OAuth
 GITHUB_CLIENT_ID=your-github-client-id
 GITHUB_CLIENT_SECRET=your-github-client-secret

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,12 +18,24 @@ from app.tracker import tracker_bp
 from app.utils import platform_color_filter, platform_name_filter
 
 
+def _is_production_environment():
+    return os.environ.get("FLASK_ENV") == "production" or os.environ.get("APP_ENV") == "production"
+
+
+def _configure_rate_limit_storage(app):
+    storage_uri = os.environ.get("RATELIMIT_STORAGE_URI", "memory://")
+    if storage_uri == "memory://" and _is_production_environment():
+        raise RuntimeError("Set RATELIMIT_STORAGE_URI to a persistent backend before running in production.")
+    app.config["RATELIMIT_STORAGE_URI"] = storage_uri
+
+
 def create_app():
     load_dotenv()
 
     app = Flask(__name__, template_folder="../templates", static_folder="../static")
     app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "supersecretkey")
     app.config["MONGO_URI"] = os.environ.get("MONGO_URI", "mongodb://localhost:27017/450_dsa")
+    _configure_rate_limit_storage(app)
     app.config["CACHE_TYPE"] = "SimpleCache"
     app.config["CACHE_DEFAULT_TIMEOUT"] = 300
     app.config["SWAGGER"] = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ cloudinary==1.39.1
 Pillow==10.3.0
 mongomock==4.1.2
 Flask-Limiter==3.5.0
+redis==5.0.4
 # pyjson5==1.6.2
 Flask-Caching==2.0.2
 flasgger==0.9.7.1

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -50,6 +50,7 @@ def test_create_app_preserves_routes_and_blueprints(monkeypatch):
     flask_app = app_module.create_app()
 
     assert flask_app.config["MONGO_URI"] == "mongodb://localhost:27017/450_dsa"
+    assert flask_app.config["RATELIMIT_STORAGE_URI"] == "memory://"
     assert login_manager.login_view == "auth.login"
     assert registered_clients == ["github", "google"]
     assert {"auth", "tracker", "profile", "leaderboard", "search", "admin", "public"} <= set(flask_app.blueprints)
@@ -97,3 +98,31 @@ def test_create_app_preserves_routes_and_blueprints(monkeypatch):
     assert "/sync_platforms" in spec["paths"]
     assert "/edit_profile" in spec["paths"]
     assert "/upload_photo" in spec["paths"]
+
+
+def test_create_app_uses_configured_rate_limit_storage(monkeypatch):
+    monkeypatch.setenv("RATELIMIT_STORAGE_URI", "redis://localhost:6379/0")
+    monkeypatch.setattr(app_module, "db", FakeDB())
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.limiter, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
+
+    flask_app = app_module.create_app()
+
+    assert flask_app.config["RATELIMIT_STORAGE_URI"] == "redis://localhost:6379/0"
+
+
+def test_create_app_requires_persistent_rate_limit_storage_in_production(monkeypatch):
+    monkeypatch.delenv("RATELIMIT_STORAGE_URI", raising=False)
+    monkeypatch.setenv("FLASK_ENV", "production")
+    monkeypatch.setattr(app_module, "db", FakeDB())
+
+    try:
+        app_module.create_app()
+    except RuntimeError as exc:
+        assert "RATELIMIT_STORAGE_URI" in str(exc)
+    else:
+        raise AssertionError("production startup should require persistent rate-limit storage")


### PR DESCRIPTION
## Summary
- configure Flask-Limiter storage through `RATELIMIT_STORAGE_URI`, defaulting to `memory://` for local development
- fail fast in production when no persistent rate-limit backend is configured
- document the env var and Redis example in `.env.example`
- add the Redis client dependency so `redis://` storage works when configured
- cover default, configured, and production-misconfigured app startup paths

Closes #223

## Tests
- `/tmp/450-dsa-issue196/bin/python -m pytest tests/test_app_factory.py -q`
- `/tmp/450-dsa-issue196/bin/python -m ruff check app/__init__.py tests/test_app_factory.py`
- `/tmp/450-dsa-issue196/bin/python -m py_compile app/__init__.py tests/test_app_factory.py`
- `/tmp/450-dsa-issue196/bin/python -m pytest tests -q`
- `git diff --check`

Suggested labels from the linked issue: `gssoc`, `gssoc:approved`, `level:advanced`, `type:bug`.