### PR TITLE
fix: reject blank display names

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -73,9 +73,13 @@ def register():
     if current_user.is_authenticated:
         return redirect(url_for("tracker.index"))
     if request.method == "POST":
-        name = request.form.get("name")
+        name = (request.form.get("name") or "").strip()
         email = request.form.get("email")
         password = request.form.get("password")
+
+        if not name:
+            flash("Name is required", "danger")
+            return redirect(url_for("auth.register"))
 
         existing_user = db.user.find_one({"email": email})
         if existing_user:
@@ -180,7 +184,7 @@ def authorize_github():
         if user_doc:
             db.user.update_one({"_id": user_doc["_id"]}, {"$set": {"github_id": github_id}})
             user_doc["github_id"] = github_id
-            flash(f"Linked GitHub to your account! Welcome back!", "success")
+            flash("Linked GitHub to your account! Welcome back!", "success")
         else:
             result = db.user.insert_one(
                 {
@@ -193,7 +197,7 @@ def authorize_github():
                 }
             )
             user_doc = db.user.find_one({"_id": result.inserted_id})
-            flash(f"Welcome! Your GitHub account has been connected. 🎉", "success")
+            flash("Welcome! Your GitHub account has been connected. 🎉", "success")
 
     login_user(UserWrapper(user_doc))
     return redirect(url_for("tracker.index"))
@@ -231,7 +235,7 @@ def authorize_google():
         if user_doc:
             db.user.update_one({"_id": user_doc["_id"]}, {"$set": {"google_id": google_id}})
             user_doc["google_id"] = google_id
-            flash(f"Linked Google to your account! Welcome back!", "success")
+            flash("Linked Google to your account! Welcome back!", "success")
         else:
             result = db.user.insert_one(
                 {
@@ -244,7 +248,7 @@ def authorize_google():
                 }
             )
             user_doc = db.user.find_one({"_id": result.inserted_id})
-            flash(f"Welcome! Your Google account has been connected. 🎉", "success")
+            flash("Welcome! Your Google account has been connected. 🎉", "success")
 
     login_user(UserWrapper(user_doc))
     return redirect(url_for("tracker.index"))

--- a/profile_validation.py
+++ b/profile_validation.py
@@ -29,6 +29,8 @@ def build_profile_updates(data):
             return None, f'{field} must be text'
 
         value = value.strip()
+        if field == 'name' and not value:
+            return None, 'name is required'
         if len(value) > max_length:
             return None, f'{field} must be at most {max_length} characters'
 

--- a/tests/test_oauth_linking.py
+++ b/tests/test_oauth_linking.py
@@ -1,7 +1,6 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from bson import ObjectId
-import pytest
 
 
 EXISTING_USER_ID = ObjectId()

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -16,6 +16,13 @@ def test_profile_updates_trim_text_and_accept_https_urls():
     }
 
 
+def test_profile_updates_reject_blank_name():
+    updates, error = build_profile_updates({'name': '   '})
+
+    assert updates is None
+    assert error == 'name is required'
+
+
 def test_profile_updates_reject_overlong_text():
     updates, error = build_profile_updates({'bio': 'x' * 501})
 

--- a/tests/test_registration_validation.py
+++ b/tests/test_registration_validation.py
@@ -1,5 +1,5 @@
 import app.auth.routes as auth_routes
-from tests.test_tracker_routes import create_test_app
+from test_tracker_routes import create_test_app
 
 
 def test_register_rejects_blank_display_name(monkeypatch):
@@ -12,7 +12,8 @@ def test_register_rejects_blank_display_name(monkeypatch):
             data={
                 "name": "   ",
                 "email": "blank-name@example.com",
-                "password": "strong-password",
+                "password": "StrongPass1!",
+                "confirm_password": "StrongPass1!",
             },
         )
 

--- a/tests/test_registration_validation.py
+++ b/tests/test_registration_validation.py
@@ -1,0 +1,20 @@
+import app.auth.routes as auth_routes
+from tests.test_tracker_routes import create_test_app
+
+
+def test_register_rejects_blank_display_name(monkeypatch):
+    flask_app, test_db = create_test_app(monkeypatch)
+    monkeypatch.setattr(auth_routes, "db", test_db)
+
+    with flask_app.test_client() as client:
+        response = client.post(
+            "/register",
+            data={
+                "name": "   ",
+                "email": "blank-name@example.com",
+                "password": "strong-password",
+            },
+        )
+
+    assert response.status_code == 302
+    assert test_db.user.count_documents({"email": "blank-name@example.com"}) == 0


### PR DESCRIPTION
## Summary
- reject blank or whitespace-only names in profile updates
- reject blank names during registration before hashing/inserting a user
- keep saved names trimmed so leaderboard and avatar rendering always have a stable non-empty display name
- add focused profile and registration regression tests

Closes #219

## Tests
- `/tmp/450-dsa-issue196/bin/python -m pytest tests/test_profile_validation.py tests/test_registration_validation.py tests/test_oauth_linking.py -q`
- `/tmp/450-dsa-issue196/bin/python -m ruff check profile_validation.py app/auth/routes.py tests/test_profile_validation.py tests/test_registration_validation.py tests/test_oauth_linking.py`
- `/tmp/450-dsa-issue196/bin/python -m py_compile profile_validation.py app/auth/routes.py tests/test_profile_validation.py tests/test_registration_validation.py tests/test_oauth_linking.py`
- `/tmp/450-dsa-issue196/bin/python -m pytest tests -q`
- `git diff --check`

Suggested labels from the linked issue: `gssoc`, `gssoc:approved`, `level:beginner`, `type:bug`.