### PR TITLE
fix: remove blocked jquery include

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -732,7 +732,6 @@
     </footer>
 
     <!-- Scripts -->
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
         

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,4 +1,4 @@
-from tests.test_tracker_routes import create_test_app
+from test_tracker_routes import create_test_app
 
 
 def test_base_template_does_not_load_blocked_jquery(monkeypatch):

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,25 @@
+from tests.test_tracker_routes import create_test_app
+
+
+def test_base_template_does_not_load_blocked_jquery(monkeypatch):
+    flask_app, _ = create_test_app(monkeypatch)
+
+    with flask_app.test_client() as client:
+        response = client.get("/")
+
+    html = response.data.decode("utf-8")
+    assert response.status_code == 200
+    assert "https://code.jquery.com" not in html
+
+
+def test_content_security_policy_matches_base_script_origins(monkeypatch):
+    flask_app, _ = create_test_app(monkeypatch)
+
+    with flask_app.test_client() as client:
+        response = client.get("/")
+
+    csp = response.headers["Content-Security-Policy"]
+    assert "script-src" in csp
+    assert "https://cdn.jsdelivr.net" in csp
+    assert "https://unpkg.com" in csp
+    assert "https://code.jquery.com" not in csp


### PR DESCRIPTION
## Summary
- remove the unused jQuery CDN include from `templates/base.html`
- keep CSP unchanged so all remaining scripts are already allowed by `script-src`
- add regression tests that the rendered base page no longer loads `https://code.jquery.com` and that the CSP script origins match the base template

Closes #217

## Tests
- `/tmp/450-dsa-issue196/bin/python -m pytest tests/test_security_headers.py -q`
- `/tmp/450-dsa-issue196/bin/python -m ruff check tests/test_security_headers.py`
- `/tmp/450-dsa-issue196/bin/python -m py_compile tests/test_security_headers.py`
- `/tmp/450-dsa-issue196/bin/python -m pytest tests -q`
- `git diff --check`

Suggested labels from the linked issue: `gssoc`, `gssoc:approved`, `level:beginner`, `type:bug`.