### PR TITLE
fix: handle progress card copy failures

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -111,13 +111,39 @@
     <button class="card-btn" onclick="copyProgressCardUrl()" style="background:#10b981;">
       <i class="bi bi-share-fill" style="margin-right:6px"></i> Share Progress (Image)
     </button>
+    <div id="progress-card-copy-fallback" style="display:none;margin-top:8px">
+      <input id="progress-card-copy-url" type="text" readonly aria-label="Progress image URL"
+             style="width:100%;padding:8px;border:1px solid var(--border-color);border-radius:8px;background:var(--bg-secondary);color:var(--text-secondary);font-size:.75rem">
+    </div>
     <script>
+      function showProgressCardUrlFallback(url) {
+        const fallback = document.getElementById('progress-card-copy-fallback');
+        const input = document.getElementById('progress-card-copy-url');
+        if (!fallback || !input) return;
+
+        input.value = url;
+        fallback.style.display = 'block';
+        input.focus();
+        input.select();
+
+        if (typeof showToast === 'function') {
+          showToast('Could not copy automatically. The URL is selected below.', 'warning');
+        }
+      }
+
       function copyProgressCardUrl() {
         const url = window.location.origin + '/u/{{ user.id }}/card.png';
+        if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+          showProgressCardUrlFallback(url);
+          return;
+        }
+
         navigator.clipboard.writeText(url).then(() => {
           if (typeof showToast === 'function') {
             showToast('Progress Image URL copied!', 'success');
           }
+        }).catch(() => {
+          showProgressCardUrlFallback(url);
         });
       }
     </script>

--- a/tests/test_progress_card_copy.py
+++ b/tests/test_progress_card_copy.py
@@ -5,7 +5,7 @@ PROFILE_TEMPLATE = Path(__file__).resolve().parents[1] / "templates" / "profile.
 
 
 def test_progress_card_copy_handles_clipboard_rejection():
-    template = PROFILE_TEMPLATE.read_text()
+    template = PROFILE_TEMPLATE.read_text(encoding="utf-8")
 
     assert "navigator.clipboard.writeText(url).then" in template
     assert ".catch(() =>" in template
@@ -13,7 +13,7 @@ def test_progress_card_copy_handles_clipboard_rejection():
 
 
 def test_progress_card_copy_fallback_exposes_readonly_url_field():
-    template = PROFILE_TEMPLATE.read_text()
+    template = PROFILE_TEMPLATE.read_text(encoding="utf-8")
 
     assert 'id="progress-card-copy-fallback"' in template
     assert 'id="progress-card-copy-url"' in template

--- a/tests/test_progress_card_copy.py
+++ b/tests/test_progress_card_copy.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+PROFILE_TEMPLATE = Path(__file__).resolve().parents[1] / "templates" / "profile.html"
+
+
+def test_progress_card_copy_handles_clipboard_rejection():
+    template = PROFILE_TEMPLATE.read_text()
+
+    assert "navigator.clipboard.writeText(url).then" in template
+    assert ".catch(() =>" in template
+    assert "showProgressCardUrlFallback(url)" in template
+
+
+def test_progress_card_copy_fallback_exposes_readonly_url_field():
+    template = PROFILE_TEMPLATE.read_text()
+
+    assert 'id="progress-card-copy-fallback"' in template
+    assert 'id="progress-card-copy-url"' in template
+    assert 'aria-label="Progress image URL"' in template
+    assert "input.select()" in template


### PR DESCRIPTION
## Summary
- handle Clipboard API rejection and unsupported-browser paths in `copyProgressCardUrl()`
- reveal a readonly selected URL field when automatic copying is unavailable
- add regression coverage for the rejection handler and visible fallback field

Closes #246

## Tests
- `/tmp/450-dsa-issue196/bin/python -m pytest tests/test_progress_card_copy.py -q`
- `/tmp/450-dsa-issue196/bin/python -m ruff check tests/test_progress_card_copy.py`
- `/tmp/450-dsa-issue196/bin/python -m py_compile tests/test_progress_card_copy.py`
- `/tmp/450-dsa-issue196/bin/python -m pytest tests -q`
- `git diff --check`

Suggested labels from the linked issue: `gssoc`, `gssoc:approved`, `level:beginner`, `type:bug`.