### PR TITLE
Improve empty platform search state

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -178,6 +178,12 @@ const chips = document.querySelectorAll('.platform-chip');
 let activeToken = '';
 let debounceTimer = null;
 let controller = null;
+const platformLabels = {
+  leetcode: 'LeetCode',
+  gfg: 'GFG',
+  cn: 'Coding Ninjas',
+  hackerrank: 'HackerRank'
+};
 
 function escapeHtml(value) {
   return String(value || '').replace(/[&<>"']/g, ch => ({
@@ -207,12 +213,23 @@ function renderEmpty(icon, text) {
   results.innerHTML = `<div class="empty-search"><i class="bi ${icon}"></i><p>${escapeHtml(text)}</p></div>`;
 }
 
+function renderPlatformPrompt() {
+  const platform = platformLabels[activeToken] || 'selected platform';
+  meta.textContent = `${platform} filter selected`;
+  renderEmpty('bi-search-heart', `Type a search term to find ${platform} practice links.`);
+}
+
 function renderResults(payload) {
   const count = payload.results.length;
   const platforms = payload.requested_platforms || [];
   meta.textContent = count ? `${count} result${count === 1 ? '' : 's'}${platforms.length ? ' with ' + platforms.join(', ') : ''}` : '';
 
   if (!input.value.trim()) {
+    if (activeToken) {
+      renderPlatformPrompt();
+      return;
+    }
+
     meta.textContent = '';
     renderEmpty('bi-search', 'Start typing to search the DSA sheet.');
     return;
@@ -259,7 +276,12 @@ async function runSearch() {
   const query = currentQuery();
   if (controller) controller.abort();
 
-  if (!input.value.trim() && !activeToken) {
+  if (!input.value.trim()) {
+    if (activeToken) {
+      renderPlatformPrompt();
+      return;
+    }
+
     meta.textContent = '';
     renderEmpty('bi-search', 'Start typing to search the DSA sheet.');
     return;

--- a/tests/test_search_template.py
+++ b/tests/test_search_template.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+SEARCH_TEMPLATE = Path(__file__).resolve().parents[1] / "templates" / "search.html"
+
+
+def test_search_platform_prompt_includes_each_chip_label():
+    template = SEARCH_TEMPLATE.read_text()
+
+    assert "leetcode: 'LeetCode'" in template
+    assert "gfg: 'GFG'" in template
+    assert "cn: 'Coding Ninjas'" in template
+    assert "hackerrank: 'HackerRank'" in template
+
+
+def test_search_empty_input_uses_active_platform_prompt():
+    template = SEARCH_TEMPLATE.read_text()
+
+    assert "function renderPlatformPrompt()" in template
+    assert "if (activeToken) {\n      renderPlatformPrompt();" in template
+    assert "Type a search term to find ${platform} practice links." in template


### PR DESCRIPTION
## Summary
- Show a platform-specific prompt when a search chip is selected with an empty input
- Avoid falling back to the generic start-search state while a platform filter is active
- Add template coverage for each platform chip label and the empty active-filter prompt

## Tests
- python3 -m pytest tests/test_search_template.py tests/test_search_utils.py

Closes #242