### PR TITLE
Handle leaderboard API errors

### DIFF
--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -322,6 +322,15 @@ function avatarHTML(entry, size = 36) {
   return escapeHTML((entry.name || '?')[0].toUpperCase());
 }
 
+function renderLeaderboardError(error) {
+  const message = error && error.message ? error.message : 'Error loading leaderboard data.';
+  currentPage = 1;
+  totalPages = 1;
+  currentUserRank = null;
+  document.getElementById('lbBody').innerHTML = `<tr><td colspan="5" class="loading">${escapeHTML(message)}</td></tr>`;
+  renderPagination();
+}
+
 async function loadLeaderboard(page = 1) {
   if (isLoading) return;
   isLoading = true;
@@ -332,16 +341,24 @@ async function loadLeaderboard(page = 1) {
     const url = `/api/leaderboard?mode=${activeMode}&page=${page}&per_page=20&current_user_id=${CURRENT_USER_ID || ''}`;
     const response = await fetch(url);
     const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data.error || data.message || `Leaderboard request failed (${response.status})`);
+    }
+
+    if (!Array.isArray(data.entries)) {
+      throw new Error('Leaderboard response was missing entries.');
+    }
     
-    totalPages = data.total_pages;
-    currentPage = data.page;
-    currentUserRank = data.current_user_rank;
+    totalPages = Number(data.total_pages) || 1;
+    currentPage = Number(data.page) || page;
+    currentUserRank = data.current_user_rank || null;
     
     renderTable(data.entries, activeMode);
     renderPagination();
   } catch (error) {
     console.error('Error loading leaderboard:', error);
-    document.getElementById('lbBody').innerHTML = '<tr><td colspan="5" class="loading" aria-label="Error loading data">Error loading data</td></tr>';
+    renderLeaderboardError(error);
   }
   
   isLoading = false;

--- a/tests/test_leaderboard_template.py
+++ b/tests/test_leaderboard_template.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+LEADERBOARD_TEMPLATE = Path(__file__).resolve().parents[1] / "templates" / "leaderboard.html"
+
+
+def test_leaderboard_fetch_checks_api_status_and_entries():
+    template = LEADERBOARD_TEMPLATE.read_text()
+
+    assert "if (!response.ok)" in template
+    assert "data.error || data.message || `Leaderboard request failed (${response.status})`" in template
+    assert "if (!Array.isArray(data.entries))" in template
+    assert "Leaderboard response was missing entries." in template
+
+
+def test_leaderboard_error_state_resets_pagination():
+    template = LEADERBOARD_TEMPLATE.read_text()
+
+    assert "function renderLeaderboardError(error)" in template
+    assert "currentPage = 1;" in template
+    assert "totalPages = 1;" in template
+    assert "currentUserRank = null;" in template
+    assert "renderPagination();" in template

--- a/tests/test_leaderboard_template.py
+++ b/tests/test_leaderboard_template.py
@@ -5,7 +5,7 @@ LEADERBOARD_TEMPLATE = Path(__file__).resolve().parents[1] / "templates" / "lead
 
 
 def test_leaderboard_fetch_checks_api_status_and_entries():
-    template = LEADERBOARD_TEMPLATE.read_text()
+    template = LEADERBOARD_TEMPLATE.read_text(encoding="utf-8")
 
     assert "if (!response.ok)" in template
     assert "data.error || data.message || `Leaderboard request failed (${response.status})`" in template
@@ -14,7 +14,7 @@ def test_leaderboard_fetch_checks_api_status_and_entries():
 
 
 def test_leaderboard_error_state_resets_pagination():
-    template = LEADERBOARD_TEMPLATE.read_text()
+    template = LEADERBOARD_TEMPLATE.read_text(encoding="utf-8")
 
     assert "function renderLeaderboardError(error)" in template
     assert "currentPage = 1;" in template


### PR DESCRIPTION
## Summary
- Validate non-OK leaderboard API responses before rendering rows
- Guard against malformed payloads where `entries` is missing or not an array
- Render a readable error row while resetting pagination to a stable state

## Tests
- python3 -m pytest tests/test_leaderboard_template.py tests/test_app_factory.py

Closes #241