### PR TITLE
Set secure session cookie defaults

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,6 +19,18 @@ from app.tracker import tracker_bp
 from app.utils import platform_color_filter, platform_name_filter
 
 
+def _env_flag(name, default=False):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_local_environment():
+    app_env = os.environ.get("FLASK_ENV") or os.environ.get("APP_ENV") or os.environ.get("ENV") or ""
+    return app_env.strip().lower() in {"development", "dev", "local", "test", "testing"} or _env_flag("FLASK_DEBUG")
+
+
 def _is_production_environment():
     return os.environ.get("FLASK_ENV") == "production" or os.environ.get("APP_ENV") == "production"
 
@@ -37,6 +49,9 @@ def create_app():
     app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "supersecretkey")
     app.config["MONGO_URI"] = os.environ.get("MONGO_URI", "mongodb://localhost:27017/450_dsa")
     _configure_rate_limit_storage(app)
+    app.config["SESSION_COOKIE_HTTPONLY"] = True
+    app.config["SESSION_COOKIE_SAMESITE"] = os.environ.get("SESSION_COOKIE_SAMESITE", "Lax")
+    app.config["SESSION_COOKIE_SECURE"] = _env_flag("SESSION_COOKIE_SECURE", default=not _is_local_environment())
     app.config["CACHE_TYPE"] = "SimpleCache"
     app.config["CACHE_DEFAULT_TIMEOUT"] = 300
     app.config["SWAGGER"] = {

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -99,6 +99,44 @@ def test_create_app_preserves_routes_and_blueprints(monkeypatch):
     assert "/edit_profile" in spec["paths"]
     assert "/upload_photo" in spec["paths"]
 
+def test_create_app_sets_secure_session_cookie_defaults(monkeypatch):
+    monkeypatch.delenv("FLASK_ENV", raising=False)
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.delenv("ENV", raising=False)
+    monkeypatch.delenv("FLASK_DEBUG", raising=False)
+    monkeypatch.delenv("SESSION_COOKIE_SECURE", raising=False)
+    monkeypatch.setattr(app_module, "db", FakeDB())
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.limiter, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
+
+    flask_app = app_module.create_app()
+
+    assert flask_app.config["SESSION_COOKIE_HTTPONLY"] is True
+    assert flask_app.config["SESSION_COOKIE_SAMESITE"] == "Lax"
+    assert flask_app.config["SESSION_COOKIE_SECURE"] is True
+
+
+def test_create_app_allows_insecure_session_cookie_in_development(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "development")
+    monkeypatch.delenv("SESSION_COOKIE_SECURE", raising=False)
+    monkeypatch.setattr(app_module, "db", FakeDB())
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.limiter, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
+
+    flask_app = app_module.create_app()
+
+    assert flask_app.config["SESSION_COOKIE_HTTPONLY"] is True
+    assert flask_app.config["SESSION_COOKIE_SAMESITE"] == "Lax"
+    assert flask_app.config["SESSION_COOKIE_SECURE"] is False
+
 
 def test_create_app_uses_configured_rate_limit_storage(monkeypatch):
     monkeypatch.setenv("RATELIMIT_STORAGE_URI", "redis://localhost:6379/0")


### PR DESCRIPTION
## Summary
- Configure Flask session cookies with `HttpOnly` and `SameSite=Lax` defaults
- Enable `SESSION_COOKIE_SECURE` outside local development by default
- Allow environment overrides for local/dev deployments and add app factory coverage

## Tests
- python3 -m pytest tests/test_app_factory.py

Closes #247