### PR TITLE
Validate DSA seed data duplicates

### DIFF
--- a/data.json
+++ b/data.json
@@ -127,16 +127,6 @@
       },
       {
         "Topic": "Array",
-        "Problem": "Kadane's Algo [V.V.V.V.V IMP]",
-        "Done": false,
-        "Bookmark": false,
-        "Notes": "",
-        "URL": "https://practice.geeksforgeeks.org/problems/kadanes-algorithm/0",
-        "URL2": "",
-        "difficulty": "Medium"
-      },
-      {
-        "Topic": "Array",
         "Problem": "Merge Intervals",
         "Done": false,
         "Bookmark": false,

--- a/data_quality.py
+++ b/data_quality.py
@@ -1,0 +1,139 @@
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+
+DATA_PATH = Path(__file__).resolve().with_name("data.json")
+
+# These are intentional cross-topic references in the Love Babbar sheet.
+ALLOWED_DUPLICATE_PROBLEMS = {
+    "chocolate distribution problem",
+    "word wrap problem",
+    "edit distance",
+    "word break problem",
+    "count all palindromic subsequence in a given string",
+    "rearrange characters in a string such that no two adjacent are same",
+    "given a sequence of words print all anagrams together",
+    "subset sum problem",
+}
+
+ALLOWED_DUPLICATE_URLS = {
+    "https://practice.geeksforgeeks.org/problems/kadanes-algorithm/0",
+    "https://practice.geeksforgeeks.org/problems/minimum-number-of-jumps/0",
+    "https://practice.geeksforgeeks.org/problems/inversion-of-array/0",
+    "https://practice.geeksforgeeks.org/problems/chocolate-distribution-problem/0",
+    "https://practice.geeksforgeeks.org/problems/longest-repeating-subsequence/0",
+    "https://practice.geeksforgeeks.org/problems/permutations-of-a-given-string/0",
+    "https://practice.geeksforgeeks.org/problems/word-wrap/0",
+    "https://practice.geeksforgeeks.org/problems/edit-distance3702/1",
+    "https://practice.geeksforgeeks.org/problems/parenthesis-checker/0",
+    "https://practice.geeksforgeeks.org/problems/word-break/0",
+    "https://practice.geeksforgeeks.org/problems/count-palindromic-subsequences/1",
+    "https://practice.geeksforgeeks.org/problems/longest-common-subsequence/0",
+    "https://practice.geeksforgeeks.org/problems/rearrange-characters4649/1",
+    "https://practice.geeksforgeeks.org/problems/k-anagrams-1/0",
+    "https://practice.geeksforgeeks.org/problems/allocate-minimum-number-of-pages/0",
+    "https://practice.geeksforgeeks.org/problems/merge-k-sorted-linked-lists/1",
+    "https://practice.geeksforgeeks.org/problems/first-non-repeating-character-in-a-stream/0",
+    "https://www.geeksforgeeks.org/minimize-cash-flow-among-given-set-friends-borrowed-money",
+    "https://practice.geeksforgeeks.org/problems/minimum-cost-of-ropes/0",
+    "https://practice.geeksforgeeks.org/problems/rat-in-a-maze-problem/1",
+    "https://practice.geeksforgeeks.org/problems/m-coloring-problem/0",
+    "https://practice.geeksforgeeks.org/problems/subset-sum-problem2014/1",
+    "https://www.geeksforgeeks.org/find-if-there-is-a-path-of-more-than-k-length-from-a-source",
+}
+
+ALLOWED_DUPLICATE_URL2S = {
+    "https://www.codingninjas.com/codestudio/problems/create-a-graph-and-print-it_1214551",
+}
+
+
+def load_data(path=DATA_PATH):
+    with open(path) as data_file:
+        return json.load(data_file)
+
+
+def normalize_problem(value):
+    value = (value or "").strip().lower()
+    value = re.sub(r"\[[^\]]*\]", "", value)
+    value = re.sub(r"[^a-z0-9]+", " ", value)
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def normalize_url(value):
+    value = (value or "").strip()
+    if not value:
+        return ""
+
+    parts = urlsplit(value)
+    path = re.sub(r"/+$", "", parts.path)
+    return urlunsplit((parts.scheme.lower(), parts.netloc.lower(), path, "", ""))
+
+
+def iter_questions(data):
+    for topic in data:
+        topic_name = topic.get("topicName", "")
+        for index, question in enumerate(topic.get("questions", [])):
+            yield {
+                "topic": topic_name,
+                "index": index,
+                "problem": question.get("Problem", ""),
+                "url": question.get("URL", ""),
+                "url2": question.get("URL2", ""),
+            }
+
+
+def duplicate_groups(data, field, normalizer):
+    groups = defaultdict(list)
+    for question in iter_questions(data):
+        key = normalizer(question[field])
+        if key:
+            groups[key].append(question)
+
+    return {key: values for key, values in groups.items() if len(values) > 1}
+
+
+def unexpected_duplicate_groups(data):
+    problem_duplicates = duplicate_groups(data, "problem", normalize_problem)
+    url_duplicates = duplicate_groups(data, "url", normalize_url)
+    url2_duplicates = duplicate_groups(data, "url2", normalize_url)
+
+    return {
+        "problems": {
+            key: values
+            for key, values in problem_duplicates.items()
+            if key not in ALLOWED_DUPLICATE_PROBLEMS
+        },
+        "urls": {
+            key: values
+            for key, values in url_duplicates.items()
+            if key not in ALLOWED_DUPLICATE_URLS
+        },
+        "url2s": {
+            key: values
+            for key, values in url2_duplicates.items()
+            if key not in ALLOWED_DUPLICATE_URL2S
+        },
+    }
+
+
+def main():
+    unexpected = unexpected_duplicate_groups(load_data())
+    unexpected = {name: groups for name, groups in unexpected.items() if groups}
+
+    if not unexpected:
+        print("No unexpected duplicate problems or URLs found.")
+        return 0
+
+    for group_name, groups in unexpected.items():
+        print(f"{group_name}:")
+        for key, questions in groups.items():
+            locations = ", ".join(f"{item['topic']}[{item['index']}]" for item in questions)
+            print(f"  {key}: {locations}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -1,0 +1,37 @@
+from data_quality import (
+    ALLOWED_DUPLICATE_PROBLEMS,
+    ALLOWED_DUPLICATE_URLS,
+    duplicate_groups,
+    load_data,
+    normalize_problem,
+    normalize_url,
+    unexpected_duplicate_groups,
+)
+
+
+def test_seed_data_has_no_unexpected_duplicate_problems_or_urls():
+    unexpected = unexpected_duplicate_groups(load_data())
+
+    assert unexpected == {"problems": {}, "urls": {}, "url2s": {}}
+
+
+def test_known_cross_topic_duplicates_are_documented():
+    data = load_data()
+    problem_duplicates = duplicate_groups(data, "problem", normalize_problem)
+    url_duplicates = duplicate_groups(data, "url", normalize_url)
+
+    assert "subset sum problem" in problem_duplicates
+    assert "subset sum problem" in ALLOWED_DUPLICATE_PROBLEMS
+    assert "https://practice.geeksforgeeks.org/problems/kadanes-algorithm/0" in url_duplicates
+    assert "https://practice.geeksforgeeks.org/problems/kadanes-algorithm/0" in ALLOWED_DUPLICATE_URLS
+
+
+def test_url_normalization_ignores_query_strings_and_trailing_slashes():
+    assert (
+        normalize_url("https://www.codingninjas.com/codestudio/problems/create-a-graph-and-print-it_1214551?topList=love-babbar-dsa-sheet-problems")
+        == "https://www.codingninjas.com/codestudio/problems/create-a-graph-and-print-it_1214551"
+    )
+    assert (
+        normalize_url("https://www.geeksforgeeks.org/minimize-cash-flow-among-given-set-friends-borrowed-money/")
+        == "https://www.geeksforgeeks.org/minimize-cash-flow-among-given-set-friends-borrowed-money"
+    )


### PR DESCRIPTION
## Summary
- Remove the duplicate Kadane entry from the Array seed data
- Add a data-quality audit for duplicate problem names and duplicate primary/secondary URLs
- Document intentional cross-topic references with an allowlist and regression tests

## Tests
- python3 data_quality.py
- python3 -m pytest tests/test_data_quality.py

Closes #244