### PR TITLE
chore: remove stale comments

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -53,7 +53,6 @@ def create_app():
         },
     )
 
-    # Initialize extensions
     mongo.init_app(app)
     bcrypt.init_app(app)
     login_manager.init_app(app)
@@ -82,7 +81,6 @@ def create_app():
         client_kwargs={"scope": "openid email profile"},
     )
 
-    # Create indexes (skip if using mock)
     try:
         db.user.create_index("email", unique=True, sparse=True)
         db.user.create_index("github_id", unique=True, sparse=True)
@@ -91,7 +89,7 @@ def create_app():
         db.topic.create_index("name", unique=True)
         db.question.create_index([("problem", "text")], name="problem_text")
     except Exception:
-        pass  # Skip indexes if using mock DB
+        pass
 
     # Lightweight schema backfill for legacy user documents.
     db.user.update_many({"is_admin": {"$exists": False}}, {"$set": {"is_admin": False}})
@@ -108,7 +106,6 @@ def create_app():
                 topic_id = result.inserted_id
                 questions = []
                 for question in topic["questions"]:
-                    # ADDED: difficulty field
                     difficulty = question.get("difficulty", "Medium")
                     questions.append(
                         {
@@ -116,7 +113,7 @@ def create_app():
                             "problem": question["Problem"],
                             "url": question["URL"],
                             "url2": question.get("URL2", ""),
-                            "difficulty": difficulty,  # <-- NEW FIELD
+                            "difficulty": difficulty,
                         }
                     )
                 if questions:

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -1,16 +1,10 @@
-import base64
 import json
 import os
 import time
 
-# Comment out cloudinary for now if not installed
-# import cloudinary
-# import cloudinary.uploader
-# import cloudinary.api
 import requests
 from flask import Blueprint, current_app, jsonify, render_template, request, send_file
 from flask_login import current_user, login_required
-import time
 from card_generator import generate_progress_card
 
 from app.extensions import db
@@ -29,7 +23,6 @@ from app.utils import ensure_utc_datetime, normalize_coding_ninjas_profile_id, u
 from streaks import compute_streak
 from profile_validation import build_profile_updates
 
-# THIS LINE IS IMPORTANT - defines the blueprint
 profile_bp = Blueprint("profile", __name__)
 
 
@@ -384,7 +377,6 @@ def public_card(user_id):
     try:
         name = user.get("name", "Anonymous")
         
-        # Calculate real stats
         stats = compute_c_score(user)
         c_score = stats["c_score"]
         dsa_done = stats["dsa_done"]
@@ -519,7 +511,6 @@ def profile():
     all_questions = list(db.question.find())
     solved_items = {question_id: progress for question_id, progress in user.progress.items() if progress.get("done")}
 
-    # ===== Count difficulties from DSA questions =====
     difficulty_map = {str(q["_id"]): q.get("difficulty", "Medium") for q in all_questions}
     
     dsa_easy = 0
@@ -534,8 +525,6 @@ def profile():
             dsa_medium += 1
         elif diff == "Hard":
             dsa_hard += 1
-    # ================================================
-
     platforms = {"LeetCode": 0, "GFG": 0, "Coding Ninjas": 0, "HackerRank": 0, "Other": 0}
     daily_counts = {}
 
@@ -569,7 +558,6 @@ def profile():
     ext_totals = user.external_totals or {}
     platforms = compute_user_platforms(solved_items, ext_totals, all_questions)
 
-    # Use DSA difficulties for the chart
     lc_easy = dsa_easy
     lc_medium = dsa_medium
     lc_hard = dsa_hard

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -249,7 +249,6 @@ function updateQuestion(id, data, callback) {
     });
 }
 
-// Update the checkbox event listener in topic.html
 document.querySelectorAll('.status-checkbox').forEach(cb => {
     cb.addEventListener('change', function() {
         if (!isAuthenticated) { 
@@ -274,7 +273,6 @@ document.querySelectorAll('.status-checkbox').forEach(cb => {
     });
 });
 
-// Update bookmark button event listener
 document.querySelectorAll('.bookmark-btn').forEach(btn => {
     btn.addEventListener('click', function() {
         if (!isAuthenticated) { 


### PR DESCRIPTION
## Summary
- remove stale commented-out imports and redundant explanatory comments
- clean outdated inline JavaScript listener comments
- drop leftover difficulty-field marker comments from app setup

Fixes #427

## Tests
- git diff --check
- python -m pytest tests/test_app_factory.py tests/test_public_profile.py tests/test_tracker_routes.py