### PR TITLE
refactor: share auth form validation

### DIFF
--- a/static/js/auth_forms.js
+++ b/static/js/auth_forms.js
@@ -1,0 +1,47 @@
+(function (window) {
+    function validateEmail(value) {
+        return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+    }
+
+    function setFieldState(input, iconEl, errorEl, valid, empty) {
+        if (empty) {
+            input.classList.remove('is-valid', 'is-invalid');
+            if (iconEl) iconEl.innerHTML = '';
+            if (errorEl) errorEl.classList.remove('show');
+            return;
+        }
+
+        input.classList.toggle('is-valid', valid);
+        input.classList.toggle('is-invalid', !valid);
+
+        if (iconEl) {
+            iconEl.innerHTML = valid
+                ? '<i class="bi bi-check-circle-fill" style="color:#22c55e"></i>'
+                : '<i class="bi bi-x-circle-fill" style="color:#ef4444"></i>';
+        }
+
+        if (errorEl) {
+            errorEl.classList.toggle('show', !valid);
+        }
+    }
+
+    function setupPasswordToggle(toggleButton, passwordInput, toggleIcon) {
+        toggleButton.addEventListener('click', () => {
+            const show = passwordInput.type === 'password';
+            passwordInput.type = show ? 'text' : 'password';
+            toggleIcon.className = show ? 'bi bi-eye-slash' : 'bi bi-eye';
+        });
+    }
+
+    function setSubmitLoading(button, label) {
+        button.disabled = true;
+        button.innerHTML = '<i class="bi bi-arrow-repeat"></i> ' + label;
+    }
+
+    window.AuthForms = {
+        validateEmail,
+        setFieldState,
+        setupPasswordToggle,
+        setSubmitLoading,
+    };
+})(window);

--- a/templates/login.html
+++ b/templates/login.html
@@ -89,6 +89,7 @@
     </div>
 </div>
 
+<script src="{{ url_for('static', filename='js/auth_forms.js') }}"></script>
 <script>
 const emailInput = document.getElementById('email');
 const emailError = document.getElementById('emailError');
@@ -99,32 +100,14 @@ const togglePassword = document.getElementById('togglePassword');
 const toggleIcon = document.getElementById('toggleIcon');
 const submitBtn = document.getElementById('submitBtn');
 
-function validateEmail(value) {
-    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-}
-
 emailInput.addEventListener('input', () => {
     const val = emailInput.value.trim();
-    if (val === '') {
-        emailInput.classList.remove('is-valid', 'is-invalid');
-        emailIcon.innerHTML = '';
-        emailError.classList.remove('show');
-    } else if (validateEmail(val)) {
-        emailInput.classList.add('is-valid');
-        emailInput.classList.remove('is-invalid');
-        emailIcon.innerHTML = '<i class="bi bi-check-circle-fill valid"></i>';
-        emailError.classList.remove('show');
-    } else {
-        emailInput.classList.add('is-invalid');
-        emailInput.classList.remove('is-valid');
-        emailIcon.innerHTML = '<i class="bi bi-x-circle-fill invalid"></i>';
-        emailError.classList.add('show');
-    }
+    AuthForms.setFieldState(emailInput, emailIcon, emailError, AuthForms.validateEmail(val), val === '');
 });
 
 emailInput.addEventListener('blur', () => {
-    if (emailInput.value.trim() && !validateEmail(emailInput.value.trim())) {
-        emailError.classList.add('show');
+    if (emailInput.value.trim() && !AuthForms.validateEmail(emailInput.value.trim())) {
+        AuthForms.setFieldState(emailInput, emailIcon, emailError, false, false);
     }
 });
 
@@ -142,17 +125,12 @@ passwordInput.addEventListener('blur', () => {
     }
 });
 
-togglePassword.addEventListener('click', () => {
-    const isPassword = passwordInput.type === 'password';
-    passwordInput.type = isPassword ? 'text' : 'password';
-    toggleIcon.className = isPassword ? 'bi bi-eye-slash' : 'bi bi-eye';
-});
+AuthForms.setupPasswordToggle(togglePassword, passwordInput, toggleIcon);
 
 document.getElementById('loginForm').addEventListener('submit', (e) => {
     let valid = true;
-    if (!validateEmail(emailInput.value.trim())) {
-        emailInput.classList.add('is-invalid');
-        emailError.classList.add('show');
+    if (!AuthForms.validateEmail(emailInput.value.trim())) {
+        AuthForms.setFieldState(emailInput, emailIcon, emailError, false, false);
         valid = false;
     }
     if (passwordInput.value.length === 0) {
@@ -164,8 +142,7 @@ document.getElementById('loginForm').addEventListener('submit', (e) => {
         e.preventDefault();
         return;
     }
-    submitBtn.disabled = true;
-    submitBtn.innerHTML = '<i class="bi bi-arrow-repeat"></i> Signing in...';
+    AuthForms.setSubmitLoading(submitBtn, 'Signing in...');
 });
 </script>
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -115,34 +115,17 @@
     </div>
 </div>
 
+<script src="{{ url_for('static', filename='js/auth_forms.js') }}"></script>
 <script>
-function validateEmail(v) { return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v); }
-
-function setFieldState(input, iconEl, errorEl, valid, empty) {
-    if (empty) {
-        input.classList.remove('is-valid', 'is-invalid');
-        iconEl.innerHTML = '';
-        errorEl.classList.remove('show');
-    } else if (valid) {
-        input.classList.add('is-valid'); input.classList.remove('is-invalid');
-        iconEl.innerHTML = '<i class="bi bi-check-circle-fill" style="color:#22c55e"></i>';
-        errorEl.classList.remove('show');
-    } else {
-        input.classList.add('is-invalid'); input.classList.remove('is-valid');
-        iconEl.innerHTML = '<i class="bi bi-x-circle-fill" style="color:#ef4444"></i>';
-        errorEl.classList.add('show');
-    }
-}
-
 const nameInput = document.getElementById('name');
 const nameIcon = document.getElementById('nameIcon');
 const nameError = document.getElementById('nameError');
 nameInput.addEventListener('input', () => {
     const v = nameInput.value.trim();
-    setFieldState(nameInput, nameIcon, nameError, v.length >= 2, v === '');
+    AuthForms.setFieldState(nameInput, nameIcon, nameError, v.length >= 2, v === '');
 });
 nameInput.addEventListener('blur', () => {
-    if (nameInput.value.trim().length === 0) setFieldState(nameInput, nameIcon, nameError, false, false);
+    if (nameInput.value.trim().length === 0) AuthForms.setFieldState(nameInput, nameIcon, nameError, false, false);
 });
 
 const emailInput = document.getElementById('email');
@@ -150,11 +133,11 @@ const emailIcon = document.getElementById('emailIcon');
 const emailError = document.getElementById('emailError');
 emailInput.addEventListener('input', () => {
     const v = emailInput.value.trim();
-    setFieldState(emailInput, emailIcon, emailError, validateEmail(v), v === '');
+    AuthForms.setFieldState(emailInput, emailIcon, emailError, AuthForms.validateEmail(v), v === '');
 });
 emailInput.addEventListener('blur', () => {
-    if (emailInput.value.trim() && !validateEmail(emailInput.value.trim()))
-        setFieldState(emailInput, emailIcon, emailError, false, false);
+    if (emailInput.value.trim() && !AuthForms.validateEmail(emailInput.value.trim()))
+        AuthForms.setFieldState(emailInput, emailIcon, emailError, false, false);
 });
 
 const passwordInput = document.getElementById('password');
@@ -213,20 +196,16 @@ passwordInput.addEventListener('input', () => {
     }
 });
 
-togglePassword.addEventListener('click', () => {
-    const show = passwordInput.type === 'password';
-    passwordInput.type = show ? 'text' : 'password';
-    toggleIcon.className = show ? 'bi bi-eye-slash' : 'bi bi-eye';
-});
+AuthForms.setupPasswordToggle(togglePassword, passwordInput, toggleIcon);
 
 document.getElementById('registerForm').addEventListener('submit', (e) => {
     let valid = true;
     if (nameInput.value.trim().length < 2) {
-        setFieldState(nameInput, nameIcon, nameError, false, false);
+        AuthForms.setFieldState(nameInput, nameIcon, nameError, false, false);
         valid = false;
     }
-    if (!validateEmail(emailInput.value.trim())) {
-        setFieldState(emailInput, emailIcon, emailError, false, false);
+    if (!AuthForms.validateEmail(emailInput.value.trim())) {
+        AuthForms.setFieldState(emailInput, emailIcon, emailError, false, false);
         valid = false;
     }
     const v = passwordInput.value;
@@ -238,8 +217,7 @@ document.getElementById('registerForm').addEventListener('submit', (e) => {
     }
     if (!valid) { e.preventDefault(); return; }
     const btn = document.getElementById('submitBtn');
-    btn.disabled = true;
-    btn.innerHTML = '<i class="bi bi-arrow-repeat"></i> Creating account...';
+    AuthForms.setSubmitLoading(btn, 'Creating account...');
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a shared auth_forms.js helper for email checks, field state, password toggles, and submit loading states
- update login and register templates to use the shared helper
- preserve page-specific validation rules for login and registration

Fixes #420

## Tests
- git diff --check
- python -m pytest tests/test_app_factory.py tests/test_security_headers.py