### PR TITLE
refactor: add JSON response helpers

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -25,7 +25,7 @@ from app.platforms.fetchers import (
     fetch_leetcode,
     fetch_leetcode_rating_history,
 )
-from app.utils import ensure_utc_datetime, normalize_coding_ninjas_profile_id, utc_now, compute_c_score, compute_user_platforms
+from app.utils import ensure_utc_datetime, json_error, json_success, normalize_coding_ninjas_profile_id, utc_now, compute_c_score, compute_user_platforms
 from streaks import compute_streak
 from profile_validation import build_profile_updates
 
@@ -111,7 +111,7 @@ def sync_platforms():
     """
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
-        return jsonify({"success": False, "error": "Request body must be a JSON object."}), 400
+        return json_error("Request body must be a JSON object.", status_code=400)
 
     now = utc_now()
     user_id = current_user.id
@@ -124,7 +124,7 @@ def sync_platforms():
             remaining = int(600 - diff)
             mins = remaining // 60
             secs = remaining % 60
-            return jsonify({"success": False, "error": f"Please wait {mins}m {secs}s before syncing again."})
+            return json_error(f"Please wait {mins}m {secs}s before syncing again.", status_code=200)
 
     update_fields = {"last_sync": now}
 
@@ -350,14 +350,14 @@ def edit_profile():
     """
     data = request.get_json()
     if not data:
-        return jsonify({"success": False, "error": "No data"}), 400
+        return json_error("No data", status_code=400)
     update_fields, error = build_profile_updates(data)
     if error:
-        return jsonify({"success": False, "error": error}), 400
+        return json_error(error, status_code=400)
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
-    return jsonify({"success": True})
+    return json_success()
 
 
 card_cache = {}
@@ -507,7 +507,7 @@ def upload_photo():
               type: string
               example: Photo upload disabled (Cloudinary not configured)
     """
-    return jsonify({"success": False, "error": "Photo upload disabled (Cloudinary not configured)"}), 500
+    return json_error("Photo upload disabled (Cloudinary not configured)", status_code=500)
 
 
 @profile_bp.route("/profile")

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -3,7 +3,7 @@ from flask import Blueprint, Response, jsonify, render_template, request
 from flask_login import current_user, login_required
 
 from app.extensions import db
-from app.utils import utc_now
+from app.utils import json_error, json_success, utc_now
 from notes_export import build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
 
@@ -159,9 +159,9 @@ def update_question(question_id):
     try:
         question = db.question.find_one({"_id": ObjectId(question_id)})
     except Exception:
-        return jsonify({"success": False, "error": "Question not found"}), 404
+        return json_error("Question not found", status_code=404)
     if not question:
-        return jsonify({"success": False, "error": "Question not found"}), 404
+        return json_error("Question not found", status_code=404)
 
     data = request.json
     user_id = current_user.id
@@ -192,9 +192,9 @@ def update_question(question_id):
     if update_fields:
         db.user.update_one({"_id": user_id}, {"$set": update_fields})
         current_user.reload()
-        return jsonify({"success": True, "message": message})
+        return json_success(message=message)
 
-    return jsonify({"success": True, "message": "No changes made"})
+    return json_success(message="No changes made")
 
 
 @tracker_bp.route("/bookmarks")

--- a/app/utils.py
+++ b/app/utils.py
@@ -2,6 +2,8 @@ import re
 from datetime import datetime, timezone
 from urllib.parse import quote_plus
 
+from flask import jsonify
+
 from app.extensions import db
 
 
@@ -31,6 +33,21 @@ PLATFORM_SEARCHES = {
 
 def utc_now():
     return datetime.now(timezone.utc)
+
+
+def json_response(payload=None, status_code=200, **fields):
+    body = dict(payload or {})
+    body.update(fields)
+    response = jsonify(body)
+    return response if status_code == 200 else (response, status_code)
+
+
+def json_success(status_code=200, **fields):
+    return json_response({"success": True}, status_code=status_code, **fields)
+
+
+def json_error(error, status_code=400, **fields):
+    return json_response({"success": False, "error": error}, status_code=status_code, **fields)
 
 
 def ensure_utc_datetime(value):


### PR DESCRIPTION
## Summary
- add shared json_response, json_success, and json_error helpers
- migrate profile and tracker API-style responses without changing their response bodies
- keep non-API JSON responses untouched for gradual adoption

Fixes #412

## Tests
- git diff --check
- python -m pytest tests/test_sync_platforms.py tests/test_profile_validation.py tests/test_tracker_routes.py