### PR TITLE
Fix profile metric contrast

### DIFF
--- a/static/js/css/main.css
+++ b/static/js/css/main.css
@@ -40,6 +40,28 @@ body {
     overflow-x: hidden;
 }
 
+.card,
+.card-dark,
+.stat-card {
+    color: var(--text-primary);
+}
+
+.stat-num,
+.big-num,
+.metric-value,
+.rating-num,
+.rank-num,
+.donut-inner {
+    color: var(--text-primary);
+}
+
+.stat-lbl,
+.metric-label,
+.sub-label,
+.rating-sub {
+    color: var(--text-secondary);
+}
+
 /* ─── Left Sidebar ─── */
 .sidebar {
     position: fixed;

--- a/templates/base.html
+++ b/templates/base.html
@@ -354,11 +354,33 @@
             border: 1px solid var(--border-color);
             border-radius: var(--radius-lg);
             padding: 18px;
+            color: var(--text-primary);
             transition: var(--transition);
         }
 
         .card-dark:hover {
             border-color: #333;
+        }
+
+        .card,
+        .stat-card {
+            color: var(--text-primary);
+        }
+
+        .stat-num,
+        .big-num,
+        .metric-value,
+        .rating-num,
+        .rank-num,
+        .donut-inner {
+            color: var(--text-primary);
+        }
+
+        .stat-lbl,
+        .metric-label,
+        .sub-label,
+        .rating-sub {
+            color: var(--text-secondary);
         }
 
         /* ─── Toast Notifications - TOP RIGHT ─── */

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -6,7 +6,7 @@
 <style>
 .prof-layout{display:grid;grid-template-columns:240px 1fr 260px;gap:16px;align-items:start}
 .prof-sidebar,.prof-main,.prof-right{display:flex;flex-direction:column;gap:14px}
-.card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:18px}
+.card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:18px;color:var(--text-primary)}
 .avatar-ring{width:90px;height:90px;border-radius:50%;background:linear-gradient(135deg,var(--accent),#ff375f);display:flex;align-items:center;justify-content:center;font-size:2rem;font-weight:800;color:#fff;margin:0 auto 12px;border:3px solid var(--border-color)}
 .prof-name{font-size:1.1rem;font-weight:800;text-align:center;margin-bottom:2px}
 .prof-handle{text-align:center;font-size:0.8rem;color:var(--accent);margin-bottom:12px;display:flex;align-items:center;justify-content:center;gap:4px}
@@ -34,8 +34,8 @@
 .meta-footer span{display:flex;justify-content:space-between}
 /* stat cards */
 .stat-row{display:grid;grid-template-columns:1fr 1fr 1fr 2fr;gap:12px}
-.stat-card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:16px}
-.stat-num{font-size:2.4rem;font-weight:900;line-height:1;margin-top:4px}
+.stat-card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:16px;color:var(--text-primary)}
+.stat-num{font-size:2.4rem;font-weight:900;line-height:1;margin-top:4px;color:var(--text-primary)}
 .stat-lbl{font-size:0.75rem;color:var(--text-secondary);font-weight:600}
 /* heatmap */
 .heatmap-grid{display:grid;grid-template-rows:repeat(7,10px);grid-auto-flow:column;gap:2px;overflow-x:auto;padding-bottom:4px}
@@ -51,7 +51,9 @@
 .award-badge .a-lbl{font-size:.58rem;color:var(--text-muted);margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:58px;text-align:center}
 .hr-stars{display:flex;gap:1px;align-items:center;justify-content:center;flex-wrap:nowrap;line-height:1}
 .hr-stars .s-on{color:#fbbf24;font-size:.65rem}
-.big-num{font-size:2.8rem;font-weight:900;line-height:1}
+.big-num{font-size:2.8rem;font-weight:900;line-height:1;color:var(--text-primary)}
+.metric-value{font-weight:900;line-height:1;color:var(--text-primary)}
+.metric-label{font-size:0.75rem;color:var(--text-secondary);font-weight:600}
 .sub-label{font-size:0.75rem;color:var(--text-secondary);font-weight:600}
 /* topic bars */
 .t-bar-row{display:flex;align-items:center;gap:8px;margin-bottom:6px;font-size:0.78rem}
@@ -280,7 +282,7 @@ body.modal-open {
       <div style="display:flex;justify-content:space-between;align-items:start;margin-bottom:8px">
         <div>
           <div class="stat-lbl">Rating</div>
-          <div style="font-size:1.6rem;font-weight:900">{{ lc_rating }}</div>
+          <div class="metric-value" style="font-size:1.6rem">{{ lc_rating }}</div>
         </div>
         <div style="text-align:right;font-size:.75rem;color:var(--text-secondary)">
           <div>Rank: {{ lc_rank }}</div>

--- a/templates/public_profile.html
+++ b/templates/public_profile.html
@@ -14,16 +14,16 @@
 <style>
 .prof-layout{display:grid;grid-template-columns:minmax(0,1fr);gap:16px;align-items:start;max-width:1100px;margin:0 auto}
 .prof-main{display:flex;flex-direction:column;gap:16px}
-.card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:18px}
+.card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:18px;color:var(--text-primary)}
 .avatar-ring{width:90px;height:90px;border-radius:50%;background:linear-gradient(135deg,var(--accent),#ff375f);display:flex;align-items:center;justify-content:center;font-size:2rem;font-weight:800;color:#fff;margin:0 auto 12px;border:3px solid var(--border-color);overflow:hidden}
 .prof-name{font-size:1.5rem;font-weight:800;text-align:center;margin-bottom:4px}
 .prof-handle{text-align:center;font-size:0.85rem;color:var(--accent);margin-bottom:12px}
 .sec-title{font-size:0.75rem;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:10px}
-.big-num{font-size:2.8rem;font-weight:900;line-height:1}
+.big-num{font-size:2.8rem;font-weight:900;line-height:1;color:var(--text-primary)}
 .sub-label{font-size:0.75rem;color:var(--text-secondary);font-weight:600}
 .stat-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px}
-.stat-card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:16px}
-.stat-num{font-size:2.4rem;font-weight:900;line-height:1;margin-top:4px}
+.stat-card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:16px;color:var(--text-primary)}
+.stat-num{font-size:2.4rem;font-weight:900;line-height:1;margin-top:4px;color:var(--text-primary)}
 .stat-lbl{font-size:0.75rem;color:var(--text-secondary);font-weight:600}
 @media(max-width:520px){.stat-row{grid-template-columns:1fr}}
 </style>


### PR DESCRIPTION
Fixes #442

## Summary
- Set readable foreground colors on shared card/stat metric classes.
- Apply the same color treatment to profile and public profile metric cards.
- Move the inline rating number onto the shared metric class.

## Tests
- `python -m pytest tests/test_public_profile.py tests/test_app_factory.py`
- `python -m pytest`