### PR TITLE
refactor: share oauth account linking helpers

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -23,6 +23,38 @@ COMMON_WEAK_PASSWORDS = {
 }
 
 
+def resolve_oauth_user(provider_field, provider_id, name, email=None):
+    """Find, link, or create an OAuth-backed user record.
+
+    Returns a tuple of `(user_doc, action)` where action is one of
+    `existing`, `linked`, or `created`.
+    """
+    user_doc = db.user.find_one({provider_field: provider_id})
+    if user_doc:
+        return user_doc, "existing"
+
+    if email:
+        user_doc = db.user.find_one({"email": email})
+
+    if user_doc:
+        db.user.update_one({"_id": user_doc["_id"]}, {"$set": {provider_field: provider_id}})
+        user_doc[provider_field] = provider_id
+        return user_doc, "linked"
+
+    result = db.user.insert_one(
+        {
+            "name": name,
+            "email": email,
+            provider_field: provider_id,
+            "progress": {},
+            "is_admin": False,
+            "created_at": utc_now(),
+        }
+    )
+    user_doc = db.user.find_one({"_id": result.inserted_id})
+    return user_doc, "created"
+
+
 def validate_registration_password(password, confirm_password):
     """Return user-facing validation errors for local password registration."""
     password = password or ""
@@ -218,27 +250,16 @@ def authorize_github():
                 email = email_item["email"]
                 break
 
-    user_doc = db.user.find_one({"github_id": github_id})
-    if not user_doc:
-        if email:
-            user_doc = db.user.find_one({"email": email})
-        if user_doc:
-            db.user.update_one({"_id": user_doc["_id"]}, {"$set": {"github_id": github_id}})
-            user_doc["github_id"] = github_id
-            flash("Linked GitHub to your account! Welcome back!", "success")
-        else:
-            result = db.user.insert_one(
-                {
-                    "name": user_info.get("name", user_info.get("login", "GitHub User")),
-                    "email": email,
-                    "github_id": github_id,
-                    "progress": {},
-                    "is_admin": False,
-                    "created_at": utc_now(),
-                }
-            )
-            user_doc = db.user.find_one({"_id": result.inserted_id})
-            flash("Welcome! Your GitHub account has been connected. 🎉", "success")
+    user_doc, action = resolve_oauth_user(
+        "github_id",
+        github_id,
+        user_info.get("name", user_info.get("login", "GitHub User")),
+        email=email,
+    )
+    if action == "linked":
+        flash("Linked GitHub to your account! Welcome back!", "success")
+    elif action == "created":
+        flash("Welcome! Your GitHub account has been connected. 🎉", "success")
 
     login_user(UserWrapper(user_doc))
     return redirect(url_for("tracker.index"))
@@ -269,27 +290,16 @@ def authorize_google():
     google_id = user_info["sub"]
     email = user_info.get("email")
 
-    user_doc = db.user.find_one({"google_id": google_id})
-    if not user_doc:
-        if email:
-            user_doc = db.user.find_one({"email": email})
-        if user_doc:
-            db.user.update_one({"_id": user_doc["_id"]}, {"$set": {"google_id": google_id}})
-            user_doc["google_id"] = google_id
-            flash("Linked Google to your account! Welcome back!", "success")
-        else:
-            result = db.user.insert_one(
-                {
-                    "name": user_info.get("name", "Google User"),
-                    "email": email,
-                    "google_id": google_id,
-                    "progress": {},
-                    "is_admin": False,
-                    "created_at": utc_now(),
-                }
-            )
-            user_doc = db.user.find_one({"_id": result.inserted_id})
-            flash("Welcome! Your Google account has been connected. 🎉", "success")
+    user_doc, action = resolve_oauth_user(
+        "google_id",
+        google_id,
+        user_info.get("name", "Google User"),
+        email=email,
+    )
+    if action == "linked":
+        flash("Linked Google to your account! Welcome back!", "success")
+    elif action == "created":
+        flash("Welcome! Your Google account has been connected. 🎉", "success")
 
     login_user(UserWrapper(user_doc))
     return redirect(url_for("tracker.index"))

--- a/tests/test_oauth_linking.py
+++ b/tests/test_oauth_linking.py
@@ -237,3 +237,83 @@ def test_google_missing_userinfo_returns_400(monkeypatch):
         with patch("app.auth.routes.google", new=mock):
             resp = client.get("/login/google/authorize")
             assert resp.status_code == 400
+
+
+def test_resolve_oauth_user_returns_existing_provider_match(monkeypatch):
+    import app.auth.routes as auth_routes
+
+    existing = {
+        "_id": EXISTING_USER_ID,
+        "email": "test@example.com",
+        "github_id": str(GITHUB_USER_INFO["id"]),
+        "progress": {},
+    }
+    class FakeUserCollection:
+        @staticmethod
+        def find_one(q):
+            if q.get("github_id") == str(GITHUB_USER_INFO["id"]):
+                return existing
+            return None
+
+        @staticmethod
+        def update_one(*args, **kwargs):
+            raise AssertionError("provider-matched users should not be relinked")
+
+        @staticmethod
+        def insert_one(*args, **kwargs):
+            raise AssertionError("provider-matched users should not be recreated")
+
+    class FakeDB:
+        user = FakeUserCollection()
+
+    db = FakeDB()
+    monkeypatch.setattr(auth_routes, "db", db)
+
+    user_doc, action = auth_routes.resolve_oauth_user(
+        "github_id",
+        str(GITHUB_USER_INFO["id"]),
+        "Ignored Name",
+        email="other@example.com",
+    )
+
+    assert action == "existing"
+    assert user_doc["_id"] == EXISTING_USER_ID
+    assert user_doc["github_id"] == str(GITHUB_USER_INFO["id"])
+
+
+def test_resolve_oauth_user_links_existing_email_match(monkeypatch):
+    import app.auth.routes as auth_routes
+
+    existing = {"_id": EXISTING_USER_ID, "email": "test@example.com", "progress": {}}
+    db = make_fake_db(existing=existing)
+    monkeypatch.setattr(auth_routes, "db", db)
+
+    user_doc, action = auth_routes.resolve_oauth_user(
+        "google_id",
+        GOOGLE_USER_INFO["sub"],
+        GOOGLE_USER_INFO["name"],
+        email=GOOGLE_USER_INFO["email"],
+    )
+
+    assert action == "linked"
+    assert user_doc["_id"] == EXISTING_USER_ID
+    assert user_doc["google_id"] == GOOGLE_USER_INFO["sub"]
+
+
+def test_resolve_oauth_user_creates_new_user_without_email(monkeypatch):
+    import app.auth.routes as auth_routes
+
+    inserted = {}
+    db = make_fake_db(inserted=inserted)
+    monkeypatch.setattr(auth_routes, "db", db)
+
+    user_doc, action = auth_routes.resolve_oauth_user(
+        "github_id",
+        str(GITHUB_USER_INFO["id"]),
+        GITHUB_USER_INFO["login"],
+        email=None,
+    )
+
+    assert action == "created"
+    assert user_doc["github_id"] == str(GITHUB_USER_INFO["id"])
+    assert user_doc["email"] is None


### PR DESCRIPTION
## Summary
- Extract shared OAuth account resolution into a reusable helper for provider callbacks
- Preserve existing provider lookup, email-linking, and new-user creation behavior
- Add focused coverage for GitHub/Google account linking paths

## Tests
- `python3 -m pytest tests/test_oauth_linking.py tests/test_google_oauth_nonce.py -q`
- `python3 -m py_compile app/auth/routes.py tests/test_oauth_linking.py`
- `git diff --check`

Closes #411