### PR TITLE
refactor: extract public card service module

### DIFF
--- a/app/profile/card_service.py
+++ b/app/profile/card_service.py
@@ -1,0 +1,54 @@
+import time
+from io import BytesIO
+
+from bson.objectid import ObjectId
+
+import card_generator
+
+from app.extensions import db
+from app.utils import compute_c_score, compute_user_platforms
+from streaks import compute_streak
+
+
+card_cache = {}
+CACHE_TTL = 3600
+
+
+def get_public_card_image(user_id, object_id=None, db_handle=None):
+    current_time = time.time()
+    if user_id in card_cache:
+        cached_time, cached_image = card_cache[user_id]
+        if current_time - cached_time < CACHE_TTL:
+            cached_image.seek(0)
+            return cached_image
+
+    db_handle = db_handle or db
+    object_id = object_id or ObjectId(user_id)
+    user = db_handle.user.find_one({"_id": object_id})
+    if not user:
+        raise LookupError("User not found")
+
+    name = user.get("name", "Anonymous")
+
+    stats = compute_c_score(user)
+    c_score = stats["c_score"]
+    dsa_done = stats["dsa_done"]
+
+    total_questions = db_handle.question.count_documents({})
+    dsa_progress = round((dsa_done / total_questions * 100) if total_questions > 0 else 0, 1)
+
+    progress_data = user.get("progress", {})
+    current_streak, _ = compute_streak(progress_data)
+
+    all_questions = list(db_handle.question.find())
+    solved_items = {qid: progress for qid, progress in progress_data.items() if progress.get("done")}
+    platforms = compute_user_platforms(solved_items, user.get("external_totals", {}), all_questions)
+
+    img_io = card_generator.generate_progress_card(
+        name, c_score, dsa_progress, current_streak, platforms
+    )
+    if isinstance(img_io, BytesIO):
+        img_io.seek(0)
+
+    card_cache[user_id] = (current_time, img_io)
+    return img_io

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -1,10 +1,8 @@
 import json
-import os
 
 import requests
 from flask import Blueprint, current_app, jsonify, render_template, request, send_file
 from flask_login import current_user, login_required
-from card_generator import generate_progress_card
 
 from app.extensions import db
 from app.extensions import limiter, cache
@@ -19,11 +17,12 @@ from app.platforms.fetchers import (
     fetch_leetcode_rating_history,
 )
 from app.profile.card_service import CACHE_TTL, card_cache, get_public_card_image
-from app.utils import ensure_utc_datetime, json_error, json_success, normalize_coding_ninjas_profile_id, utc_now, compute_c_score, compute_user_platforms
-from streaks import compute_streak
+from app.utils import ensure_utc_datetime, json_error, json_success, normalize_coding_ninjas_profile_id, utc_now, compute_user_platforms
 from profile_validation import build_profile_updates
 
 profile_bp = Blueprint("profile", __name__)
+
+__all__ = ["CACHE_TTL", "card_cache", "get_public_card_image"]
 
 
 def build_sync_platforms_response(platform_status: dict):

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -1,6 +1,5 @@
 import json
 import os
-import time
 
 import requests
 from flask import Blueprint, current_app, jsonify, render_template, request, send_file
@@ -19,6 +18,7 @@ from app.platforms.fetchers import (
     fetch_leetcode,
     fetch_leetcode_rating_history,
 )
+from app.profile.card_service import CACHE_TTL, card_cache, get_public_card_image
 from app.utils import ensure_utc_datetime, json_error, json_success, normalize_coding_ninjas_profile_id, utc_now, compute_c_score, compute_user_platforms
 from streaks import compute_streak
 from profile_validation import build_profile_updates
@@ -353,48 +353,24 @@ def edit_profile():
     return json_success()
 
 
-card_cache = {}
-CACHE_TTL = 3600
-
 @profile_bp.route("/u/<user_id>/card.png")
 def public_card(user_id):
     from bson.objectid import ObjectId
     try:
-        user = db.user.find_one({"_id": ObjectId(user_id)})
+        object_id = ObjectId(user_id)
     except Exception:
         return "Invalid User ID", 400
-        
-    if not user:
-        return "User not found", 404
-        
-    current_time = time.time()
-    if user_id in card_cache:
-        cached_time, cached_image = card_cache[user_id]
-        if current_time - cached_time < CACHE_TTL:
-            cached_image.seek(0)
-            return send_file(cached_image, mimetype="image/png")
-            
-    try:
-        name = user.get("name", "Anonymous")
-        
-        stats = compute_c_score(user)
-        c_score = stats["c_score"]
-        dsa_done = stats["dsa_done"]
-        
-        total_questions = db.question.count_documents({})
-        dsa_progress = round((dsa_done / total_questions * 100) if total_questions > 0 else 0, 1)
-        
-        progress_data = user.get("progress", {})
-        current_streak, _ = compute_streak(progress_data)
-        
-        all_questions = list(db.question.find())
-        solved_items = {qid: p for qid, p in progress_data.items() if p.get("done")}
-        platforms = compute_user_platforms(solved_items, user.get("external_totals", {}), all_questions)
 
-        from card_generator import generate_progress_card
-        img_io = generate_progress_card(name, c_score, dsa_progress, current_streak, platforms)
-        
-        card_cache[user_id] = (current_time, img_io)
+    try:
+        img_io = get_public_card_image(user_id, object_id, db_handle=db)
+    except LookupError:
+        return "User not found", 404
+    except Exception:
+        current_app.logger.exception("Failed to generate public progress card")
+        return "Unable to generate progress card", 500
+
+    try:
+        img_io.seek(0)
         return send_file(img_io, mimetype="image/png")
     except Exception:
         current_app.logger.exception("Failed to generate public progress card")

--- a/tests/test_public_card_service.py
+++ b/tests/test_public_card_service.py
@@ -1,0 +1,86 @@
+from io import BytesIO
+
+from bson.objectid import ObjectId
+
+from app.profile.card_service import card_cache, get_public_card_image
+
+
+class FakeUserCollection:
+    def __init__(self, user):
+        self.user = user
+
+    def find_one(self, query):
+        if self.user and query.get("_id") == self.user["_id"]:
+            return self.user
+        return None
+
+
+class FakeQuestionCollection:
+    def __init__(self, questions):
+        self.questions = list(questions)
+
+    def count_documents(self, query):
+        return len(self.questions)
+
+    def find(self, *args, **kwargs):
+        return list(self.questions)
+
+
+class FakeDB:
+    def __init__(self, user, questions):
+        self.user = FakeUserCollection(user)
+        self.question = FakeQuestionCollection(questions)
+
+
+def test_get_public_card_image_builds_and_caches(monkeypatch):
+    user_id = ObjectId()
+    user = {
+        "_id": user_id,
+        "name": "Card User",
+        "progress": {"q1": {"done": True}},
+        "external_totals": {"LeetCode": 12},
+    }
+    fake_db = FakeDB(user, [{"_id": "q1", "url": "https://leetcode.com/problems/two-sum"}])
+    generated = []
+
+    def fake_generate(name, c_score, dsa_progress, current_streak, platforms):
+        generated.append((name, c_score, dsa_progress, current_streak, platforms))
+        return BytesIO(b"fake-png")
+
+    monkeypatch.setattr("app.profile.card_service.db", fake_db)
+    monkeypatch.setattr(
+        "app.profile.card_service.compute_c_score",
+        lambda user_doc: {"c_score": 144, "dsa_done": 1},
+    )
+    monkeypatch.setattr("app.profile.card_service.compute_streak", lambda progress: (4, 8))
+    monkeypatch.setattr(
+        "app.profile.card_service.compute_user_platforms",
+        lambda solved, totals, all_questions: {"LeetCode": 12},
+    )
+    monkeypatch.setattr("app.profile.card_service.card_generator.generate_progress_card", fake_generate)
+
+    card_cache.clear()
+
+    first = get_public_card_image(str(user_id), user_id)
+    second = get_public_card_image(str(user_id), user_id)
+
+    assert first.read() == b"fake-png"
+    second.seek(0)
+    assert second.read() == b"fake-png"
+    assert len(generated) == 1
+    assert generated[0] == ("Card User", 144, 100.0, 4, {"LeetCode": 12})
+
+
+def test_get_public_card_image_raises_for_missing_user(monkeypatch):
+    fake_db = FakeDB(None, [])
+    user_id = ObjectId()
+
+    monkeypatch.setattr("app.profile.card_service.db", fake_db)
+    card_cache.clear()
+
+    try:
+        get_public_card_image(str(user_id), user_id)
+    except LookupError as exc:
+        assert "User not found" in str(exc)
+    else:
+        raise AssertionError("Expected LookupError for missing user")


### PR DESCRIPTION
## Summary
- extract public progress card cache/DB/stat assembly into `app/profile/card_service.py`
- keep `/u/<user_id>/card.png` focused on request validation and response creation
- add focused service tests while preserving the existing route coverage

## Testing
- `python3 -m pytest tests/test_public_card_service.py tests/test_progress_card.py -q`
- `python3 -m py_compile app/profile/card_service.py app/profile/routes.py tests/test_public_card_service.py`
- `git diff --check`

Closes #410