### PR TITLE
refactor: extract sync platforms service module

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -6,37 +6,14 @@ from flask_login import current_user, login_required
 
 from app.extensions import db
 from app.extensions import limiter, cache
-from app.platforms.fetchers import (
-    fetch_atcoder,
-    fetch_coding_ninjas,
-    fetch_gfg,
-    fetch_github,
-    fetch_hr_badges,
-    fetch_lc_badges,
-    fetch_leetcode,
-    fetch_leetcode_rating_history,
-)
 from app.profile.card_service import CACHE_TTL, card_cache, get_public_card_image
-from app.utils import ensure_utc_datetime, json_error, json_success, normalize_coding_ninjas_profile_id, utc_now, compute_user_platforms
+from app.profile.sync_service import build_sync_platforms_response, sync_user_platforms
+from app.utils import json_error, json_success, utc_now, compute_user_platforms
 from profile_validation import build_profile_updates
 
 profile_bp = Blueprint("profile", __name__)
 
 __all__ = ["CACHE_TTL", "card_cache", "get_public_card_image"]
-
-
-def build_sync_platforms_response(platform_status: dict):
-    attempted = sum(1 for value in platform_status.values() if value.get("status") != "skipped")
-    synced = sum(1 for value in platform_status.values() if value.get("status") == "synced")
-    failed = sum(1 for value in platform_status.values() if value.get("status") == "failed")
-    partial_success = bool(synced and failed)
-
-    if attempted == 0:
-        return {"success": False, "error": "No platforms provided to sync.", "platforms": platform_status}
-    if synced == 0 and failed > 0:
-        return {"success": False, "error": "Sync failed for all platforms.", "platforms": platform_status}
-
-    return {"success": True, "partial_success": partial_success, "platforms": platform_status}
 
 
 @profile_bp.route("/sync_platforms", methods=["POST"])
@@ -106,175 +83,8 @@ def sync_platforms():
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
         return json_error("Request body must be a JSON object.", status_code=400)
-
-    now = utc_now()
-    user_id = current_user.id
-
-    last_sync = current_user.last_sync
-    if last_sync:
-        last_sync = ensure_utc_datetime(last_sync)
-        diff = (now - last_sync).total_seconds()
-        if diff < 600:
-            remaining = int(600 - diff)
-            mins = remaining // 60
-            secs = remaining % 60
-            return json_error(f"Please wait {mins}m {secs}s before syncing again.", status_code=200)
-
-    update_fields = {"last_sync": now}
-
-    leetcode_username = current_user.leetcode_username or ""
-    github_username = current_user.github_username or ""
-    gfg_username = current_user.gfg_username or ""
-    hackerrank_username = current_user.hackerrank_username or ""
-    codingninjas_username = current_user.codingninjas_username or ""
-    atcoder_username = current_user.atcoder_username or ""
-
-    if "leetcode" in data:
-        leetcode_username = data.get("leetcode", "").strip()
-        update_fields["leetcode_username"] = leetcode_username
-    if "github" in data:
-        github_username = data.get("github", "").strip()
-        update_fields["github_username"] = github_username
-    if "gfg" in data:
-        gfg_username = data.get("gfg", "").strip()
-        update_fields["gfg_username"] = gfg_username
-    if "hackerrank" in data:
-        hackerrank_username = data.get("hackerrank", "").strip()
-        update_fields["hackerrank_username"] = hackerrank_username
-    if "codingninjas" in data:
-        codingninjas_username = normalize_coding_ninjas_profile_id(data.get("codingninjas", ""))
-        update_fields["codingninjas_username"] = codingninjas_username
-    if "atcoder" in data:
-        atcoder_username = data.get("atcoder", "").strip()
-        update_fields["atcoder_username"] = atcoder_username
-
-    combined_daily_counts = {}
-    platform_totals = {}
-    platform_status = {}
-
-    def _mark(platform_key: str, status: str, error: str = None):
-        payload = {"status": status}
-        if error:
-            payload["error"] = error
-        platform_status[platform_key] = payload
-
-    if leetcode_username:
-        try:
-            leetcode_data = fetch_leetcode(leetcode_username)
-            if not leetcode_data:
-                _mark("leetcode", "failed", "No data returned (username may be invalid or rate-limited).")
-            else:
-                _mark("leetcode", "synced")
-                for key, value in leetcode_data.get("calendar", {}).items():
-                    combined_daily_counts[key] = combined_daily_counts.get(key, 0) + value
-                if leetcode_data.get("total") is not None:
-                    platform_totals["LeetCode"] = leetcode_data.get("total")
-                if leetcode_data.get("difficulty"):
-                    platform_totals["LeetCode_Easy"] = leetcode_data["difficulty"].get("Easy", 0)
-                    platform_totals["LeetCode_Medium"] = leetcode_data["difficulty"].get("Medium", 0)
-                    platform_totals["LeetCode_Hard"] = leetcode_data["difficulty"].get("Hard", 0)
-                if leetcode_data.get("contest"):
-                    platform_totals["LeetCode_Contests"] = leetcode_data["contest"].get("attendedContestsCount", 0)
-                    platform_totals["LeetCode_Rating"] = int(leetcode_data["contest"].get("rating", 0))
-                    platform_totals["LeetCode_GlobalRank"] = leetcode_data["contest"].get("globalRanking", 0)
-
-                try:
-                    rating_history = fetch_leetcode_rating_history(leetcode_username)
-                    if rating_history:
-                        update_fields["rating_history"] = rating_history
-                except Exception:
-                    pass
-
-                try:
-                    lc_badges = fetch_lc_badges(leetcode_username)
-                    update_fields["lc_badges_json"] = json.dumps(lc_badges)
-                except Exception:
-                    pass
-        except Exception:
-            _mark("leetcode", "failed", "Failed to fetch LeetCode stats.")
-    else:
-        _mark("leetcode", "skipped")
-
-    if github_username:
-        try:
-            github_data = fetch_github(github_username)
-            if not github_data:
-                _mark("github", "failed", "No data returned (username may be invalid or rate-limited).")
-            else:
-                _mark("github", "synced")
-                for key, value in github_data.get("calendar", {}).items():
-                    combined_daily_counts[key] = combined_daily_counts.get(key, 0) + value
-                if github_data.get("stats"):
-                    platform_totals["GitHub_Issues"] = github_data["stats"]["issues"]
-                    platform_totals["GitHub_PRs"] = github_data["stats"]["prs"]
-                    platform_totals["GitHub_Merged_PRs"] = github_data["stats"]["merged_prs"]
-                    platform_totals["GitHub_Commits"] = github_data["stats"]["commits"]
-        except Exception:
-            _mark("github", "failed", "Failed to fetch GitHub stats.")
-    else:
-        _mark("github", "skipped")
-
-    if gfg_username:
-        try:
-            gfg_data = fetch_gfg(gfg_username)
-            if not gfg_data:
-                _mark("gfg", "failed", "No data returned (username may be invalid or rate-limited).")
-            else:
-                _mark("gfg", "synced")
-                if gfg_data.get("total") is not None:
-                    platform_totals["GFG"] = int(gfg_data.get("total", 0))
-        except Exception:
-            _mark("gfg", "failed", "Failed to fetch GFG stats.")
-    else:
-        _mark("gfg", "skipped")
-
-    if codingninjas_username:
-        try:
-            codingninjas_data = fetch_coding_ninjas(codingninjas_username)
-            if not codingninjas_data:
-                _mark("codingninjas", "failed", "No data returned (username may be invalid or rate-limited).")
-            else:
-                _mark("codingninjas", "synced")
-                if codingninjas_data.get("total") is not None:
-                    platform_totals["Coding Ninjas"] = int(codingninjas_data.get("total", 0))
-        except Exception:
-            _mark("codingninjas", "failed", "Failed to fetch Coding Ninjas stats.")
-    else:
-        _mark("codingninjas", "skipped")
-
-    if hackerrank_username:
-        try:
-            hr_badges, hr_solved = fetch_hr_badges(hackerrank_username)
-            update_fields["hr_badges_json"] = json.dumps(hr_badges)
-            if hr_solved > 0:
-                platform_totals["HackerRank"] = hr_solved
-            _mark("hackerrank", "synced")
-        except Exception:
-            _mark("hackerrank", "failed", "Failed to fetch HackerRank stats.")
-    else:
-        _mark("hackerrank", "skipped")
-
-    if atcoder_username:
-        try:
-            atcoder_data = fetch_atcoder(atcoder_username)
-            if not atcoder_data:
-                _mark("atcoder", "failed", "No data returned (handle may be invalid or rate-limited).")
-            else:
-                _mark("atcoder", "synced")
-                if atcoder_data.get("total") is not None:
-                    platform_totals["AtCoder"] = int(atcoder_data.get("total", 0))
-        except Exception:
-            _mark("atcoder", "failed", "Failed to fetch AtCoder stats.")
-    else:
-        _mark("atcoder", "skipped")
-
-    update_fields["external_daily_counts"] = combined_daily_counts
-    update_fields["external_totals"] = platform_totals
-    db.user.update_one({"_id": user_id}, {"$set": update_fields})
-    current_user.reload()
-
-    cache.clear()
-    return jsonify(build_sync_platforms_response(platform_status))
+    payload, status_code = sync_user_platforms(current_user, data, db, cache)
+    return jsonify(payload), status_code
 
 
 @profile_bp.route("/edit_profile", methods=["POST"])

--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -1,0 +1,201 @@
+import json
+
+from app.platforms.fetchers import (
+    fetch_atcoder,
+    fetch_coding_ninjas,
+    fetch_gfg,
+    fetch_github,
+    fetch_hr_badges,
+    fetch_lc_badges,
+    fetch_leetcode,
+    fetch_leetcode_rating_history,
+)
+from app.utils import ensure_utc_datetime, normalize_coding_ninjas_profile_id, utc_now
+
+
+def build_sync_platforms_response(platform_status: dict):
+    attempted = sum(1 for value in platform_status.values() if value.get("status") != "skipped")
+    synced = sum(1 for value in platform_status.values() if value.get("status") == "synced")
+    failed = sum(1 for value in platform_status.values() if value.get("status") == "failed")
+    partial_success = bool(synced and failed)
+
+    if attempted == 0:
+        return {"success": False, "error": "No platforms provided to sync.", "platforms": platform_status}
+    if synced == 0 and failed > 0:
+        return {"success": False, "error": "Sync failed for all platforms.", "platforms": platform_status}
+
+    return {"success": True, "partial_success": partial_success, "platforms": platform_status}
+
+
+def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
+    now = now or utc_now()
+    user_id = user.id
+
+    last_sync = user.last_sync
+    if last_sync:
+        last_sync = ensure_utc_datetime(last_sync)
+        diff = (now - last_sync).total_seconds()
+        if diff < 600:
+            remaining = int(600 - diff)
+            mins = remaining // 60
+            secs = remaining % 60
+            return {
+                "success": False,
+                "error": f"Please wait {mins}m {secs}s before syncing again.",
+            }, 200
+
+    update_fields = {"last_sync": now}
+
+    leetcode_username = user.leetcode_username or ""
+    github_username = user.github_username or ""
+    gfg_username = user.gfg_username or ""
+    hackerrank_username = user.hackerrank_username or ""
+    codingninjas_username = user.codingninjas_username or ""
+    atcoder_username = user.atcoder_username or ""
+
+    if "leetcode" in data:
+        leetcode_username = data.get("leetcode", "").strip()
+        update_fields["leetcode_username"] = leetcode_username
+    if "github" in data:
+        github_username = data.get("github", "").strip()
+        update_fields["github_username"] = github_username
+    if "gfg" in data:
+        gfg_username = data.get("gfg", "").strip()
+        update_fields["gfg_username"] = gfg_username
+    if "hackerrank" in data:
+        hackerrank_username = data.get("hackerrank", "").strip()
+        update_fields["hackerrank_username"] = hackerrank_username
+    if "codingninjas" in data:
+        codingninjas_username = normalize_coding_ninjas_profile_id(data.get("codingninjas", ""))
+        update_fields["codingninjas_username"] = codingninjas_username
+    if "atcoder" in data:
+        atcoder_username = data.get("atcoder", "").strip()
+        update_fields["atcoder_username"] = atcoder_username
+
+    combined_daily_counts = {}
+    platform_totals = {}
+    platform_status = {}
+
+    def _mark(platform_key: str, status: str, error: str = None):
+        payload = {"status": status}
+        if error:
+            payload["error"] = error
+        platform_status[platform_key] = payload
+
+    if leetcode_username:
+        try:
+            leetcode_data = fetch_leetcode(leetcode_username)
+            if not leetcode_data:
+                _mark("leetcode", "failed", "No data returned (username may be invalid or rate-limited).")
+            else:
+                _mark("leetcode", "synced")
+                for key, value in leetcode_data.get("calendar", {}).items():
+                    combined_daily_counts[key] = combined_daily_counts.get(key, 0) + value
+                if leetcode_data.get("total") is not None:
+                    platform_totals["LeetCode"] = leetcode_data.get("total")
+                if leetcode_data.get("difficulty"):
+                    platform_totals["LeetCode_Easy"] = leetcode_data["difficulty"].get("Easy", 0)
+                    platform_totals["LeetCode_Medium"] = leetcode_data["difficulty"].get("Medium", 0)
+                    platform_totals["LeetCode_Hard"] = leetcode_data["difficulty"].get("Hard", 0)
+                if leetcode_data.get("contest"):
+                    platform_totals["LeetCode_Contests"] = leetcode_data["contest"].get("attendedContestsCount", 0)
+                    platform_totals["LeetCode_Rating"] = int(leetcode_data["contest"].get("rating", 0))
+                    platform_totals["LeetCode_GlobalRank"] = leetcode_data["contest"].get("globalRanking", 0)
+
+                try:
+                    rating_history = fetch_leetcode_rating_history(leetcode_username)
+                    if rating_history:
+                        update_fields["rating_history"] = rating_history
+                except Exception:
+                    pass
+
+                try:
+                    lc_badges = fetch_lc_badges(leetcode_username)
+                    update_fields["lc_badges_json"] = json.dumps(lc_badges)
+                except Exception:
+                    pass
+        except Exception:
+            _mark("leetcode", "failed", "Failed to fetch LeetCode stats.")
+    else:
+        _mark("leetcode", "skipped")
+
+    if github_username:
+        try:
+            github_data = fetch_github(github_username)
+            if not github_data:
+                _mark("github", "failed", "No data returned (username may be invalid or rate-limited).")
+            else:
+                _mark("github", "synced")
+                for key, value in github_data.get("calendar", {}).items():
+                    combined_daily_counts[key] = combined_daily_counts.get(key, 0) + value
+                if github_data.get("stats"):
+                    platform_totals["GitHub_Issues"] = github_data["stats"]["issues"]
+                    platform_totals["GitHub_PRs"] = github_data["stats"]["prs"]
+                    platform_totals["GitHub_Merged_PRs"] = github_data["stats"]["merged_prs"]
+                    platform_totals["GitHub_Commits"] = github_data["stats"]["commits"]
+        except Exception:
+            _mark("github", "failed", "Failed to fetch GitHub stats.")
+    else:
+        _mark("github", "skipped")
+
+    if gfg_username:
+        try:
+            gfg_data = fetch_gfg(gfg_username)
+            if not gfg_data:
+                _mark("gfg", "failed", "No data returned (username may be invalid or rate-limited).")
+            else:
+                _mark("gfg", "synced")
+                if gfg_data.get("total") is not None:
+                    platform_totals["GFG"] = int(gfg_data.get("total", 0))
+        except Exception:
+            _mark("gfg", "failed", "Failed to fetch GFG stats.")
+    else:
+        _mark("gfg", "skipped")
+
+    if codingninjas_username:
+        try:
+            codingninjas_data = fetch_coding_ninjas(codingninjas_username)
+            if not codingninjas_data:
+                _mark("codingninjas", "failed", "No data returned (username may be invalid or rate-limited).")
+            else:
+                _mark("codingninjas", "synced")
+                if codingninjas_data.get("total") is not None:
+                    platform_totals["Coding Ninjas"] = int(codingninjas_data.get("total", 0))
+        except Exception:
+            _mark("codingninjas", "failed", "Failed to fetch Coding Ninjas stats.")
+    else:
+        _mark("codingninjas", "skipped")
+
+    if hackerrank_username:
+        try:
+            hr_badges, hr_solved = fetch_hr_badges(hackerrank_username)
+            update_fields["hr_badges_json"] = json.dumps(hr_badges)
+            if hr_solved > 0:
+                platform_totals["HackerRank"] = hr_solved
+            _mark("hackerrank", "synced")
+        except Exception:
+            _mark("hackerrank", "failed", "Failed to fetch HackerRank stats.")
+    else:
+        _mark("hackerrank", "skipped")
+
+    if atcoder_username:
+        try:
+            atcoder_data = fetch_atcoder(atcoder_username)
+            if not atcoder_data:
+                _mark("atcoder", "failed", "No data returned (handle may be invalid or rate-limited).")
+            else:
+                _mark("atcoder", "synced")
+                if atcoder_data.get("total") is not None:
+                    platform_totals["AtCoder"] = int(atcoder_data.get("total", 0))
+        except Exception:
+            _mark("atcoder", "failed", "Failed to fetch AtCoder stats.")
+    else:
+        _mark("atcoder", "skipped")
+
+    update_fields["external_daily_counts"] = combined_daily_counts
+    update_fields["external_totals"] = platform_totals
+    db_handle.user.update_one({"_id": user_id}, {"$set": update_fields})
+    user.reload()
+
+    cache_backend.clear()
+    return build_sync_platforms_response(platform_status), 200

--- a/app/utils.py
+++ b/app/utils.py
@@ -99,12 +99,13 @@ EXTERNAL_SOLVED_TOTAL_KEYS = ("LeetCode", "GFG", "Coding Ninjas", "HackerRank", 
 
 
 def compute_total_solved(progress, external_totals, all_questions=None):
-    solved_items = {question_id: item for question_id, item in (progress or {}).items() if item.get("done")}
+    progress = progress or {}
     if all_questions is not None:
+        solved_items = {question_id: item for question_id, item in progress.items() if item.get("done")}
         platforms = compute_user_platforms(solved_items, external_totals or {}, all_questions)
         return sum(max(value, 0) for value in platforms.values())
 
-    dsa_done = len(solved_items)
+    dsa_done = sum(1 for progress_item in progress.values() if progress_item.get("done"))
     external_total = sum(max(value, 0) for key, value in (external_totals or {}).items() if key in EXTERNAL_SOLVED_TOTAL_KEYS)
     return max(dsa_done, external_total)
 
@@ -123,14 +124,21 @@ def compute_c_score(user_doc, all_questions=None):
     gfg_total = max(ext.get("GFG", 0), 0)
     hr_total = max(ext.get("HackerRank", 0), 0)
     cn_total = max(ext.get("Coding Ninjas", 0), 0)
+    external_total = sum(max(value, 0) for key, value in ext.items() if key in EXTERNAL_SOLVED_TOTAL_KEYS)
 
     ext_daily = user_doc.get("external_daily_counts", {})
-    daily_dates = set(ext_daily.keys()) if ext_daily else set()
+    extra_progress_days = set()
     for progress_item in progress.values():
         timestamp = progress_item.get("timestamp")
-        if timestamp and progress_item.get("done"):
-            daily_dates.add(timestamp.strftime("%Y-%m-%d"))
-    active_days = len(daily_dates)
+        if not timestamp or not progress_item.get("done"):
+            continue
+        if isinstance(timestamp, str):
+            day_key = timestamp[:10]
+        else:
+            day_key = timestamp.date().isoformat()
+        if day_key not in ext_daily:
+            extra_progress_days.add(day_key)
+    active_days = len(ext_daily) + len(extra_progress_days)
 
     s_dsa = min(dsa_done / 450, 1.0) * 250
     s_lc_total = min(lc_total / 500, 1.0) * 200
@@ -142,7 +150,7 @@ def compute_c_score(user_doc, all_questions=None):
     c_score = int(round(s_dsa + s_lc_total + s_lc_diff + s_lc_rating + s_other + s_consistency))
     c_score = min(c_score, 999)
 
-    global_total = compute_total_solved(progress, ext, all_questions)
+    global_total = compute_total_solved(progress, ext, all_questions) if all_questions is not None else max(dsa_done, external_total)
 
     return {
         "c_score": c_score,

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -126,7 +126,7 @@ def test_create_app_caches_faq_page_render(monkeypatch):
     rendered_templates = []
 
     monkeypatch.setattr(app_module, "db", FakeDB())
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
     monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -1,0 +1,131 @@
+from datetime import datetime, timedelta, timezone
+
+from app.profile.sync_service import build_sync_platforms_response, sync_user_platforms
+
+
+class FakeUser:
+    def __init__(self, **kwargs):
+        self.id = kwargs.get("id", "user-1")
+        self.last_sync = kwargs.get("last_sync")
+        self.leetcode_username = kwargs.get("leetcode_username", "")
+        self.github_username = kwargs.get("github_username", "")
+        self.gfg_username = kwargs.get("gfg_username", "")
+        self.hackerrank_username = kwargs.get("hackerrank_username", "")
+        self.codingninjas_username = kwargs.get("codingninjas_username", "")
+        self.atcoder_username = kwargs.get("atcoder_username", "")
+        self.reload_calls = 0
+
+    def reload(self):
+        self.reload_calls += 1
+
+
+class FakeUserCollection:
+    def __init__(self):
+        self.updates = []
+
+    def update_one(self, query, update):
+        self.updates.append((query, update))
+
+
+class FakeDB:
+    def __init__(self):
+        self.user = FakeUserCollection()
+
+
+class FakeCache:
+    def __init__(self):
+        self.clear_calls = 0
+
+    def clear(self):
+        self.clear_calls += 1
+
+
+def test_sync_user_platforms_respects_cooldown():
+    now = datetime.now(timezone.utc)
+    user = FakeUser(last_sync=now - timedelta(seconds=120))
+    db = FakeDB()
+    cache = FakeCache()
+
+    payload, status_code = sync_user_platforms(user, {}, db, cache, now=now)
+
+    assert status_code == 200
+    assert payload["success"] is False
+    assert "Please wait" in payload["error"]
+    assert db.user.updates == []
+    assert cache.clear_calls == 0
+    assert user.reload_calls == 0
+
+
+def test_sync_user_platforms_updates_totals_and_clears_cache(monkeypatch):
+    now = datetime.now(timezone.utc)
+    user = FakeUser()
+    db = FakeDB()
+    cache = FakeCache()
+
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_leetcode",
+        lambda username: {
+            "calendar": {"2026-05-24": 3},
+            "total": 25,
+            "difficulty": {"Easy": 10, "Medium": 12, "Hard": 3},
+            "contest": {"attendedContestsCount": 4, "rating": 1725.7, "globalRanking": 3210},
+        },
+    )
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_leetcode_rating_history",
+        lambda username: [{"rating": 1700}],
+    )
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_lc_badges",
+        lambda username: [{"name": "100 Days"}],
+    )
+
+    payload, status_code = sync_user_platforms(
+        user,
+        {"leetcode": "  alice  "},
+        db,
+        cache,
+        now=now,
+    )
+
+    assert status_code == 200
+    assert payload["success"] is True
+    assert payload["platforms"]["leetcode"]["status"] == "synced"
+    assert payload["platforms"]["github"]["status"] == "skipped"
+
+    assert db.user.updates == [
+        (
+            {"_id": "user-1"},
+            {
+                "$set": {
+                    "last_sync": now,
+                    "leetcode_username": "alice",
+                    "rating_history": [{"rating": 1700}],
+                    "lc_badges_json": '[{"name": "100 Days"}]',
+                    "external_daily_counts": {"2026-05-24": 3},
+                    "external_totals": {
+                        "LeetCode": 25,
+                        "LeetCode_Easy": 10,
+                        "LeetCode_Medium": 12,
+                        "LeetCode_Hard": 3,
+                        "LeetCode_Contests": 4,
+                        "LeetCode_Rating": 1725,
+                        "LeetCode_GlobalRank": 3210,
+                    },
+                }
+            },
+        )
+    ]
+    assert cache.clear_calls == 1
+    assert user.reload_calls == 1
+
+
+def test_build_sync_platforms_response_all_failed():
+    result = build_sync_platforms_response(
+        {
+            "leetcode": {"status": "failed", "error": "timeout"},
+            "github": {"status": "failed", "error": "not found"},
+        }
+    )
+    assert result["success"] is False
+    assert "all platforms" in result["error"].lower()


### PR DESCRIPTION
## Summary
- extract sync-platform orchestration into `app/profile/sync_service.py`
- keep `/sync_platforms` focused on request validation and JSON response creation
- add focused service tests while preserving the existing route/response tests

## Testing
- `python3 -m pytest tests/test_sync_service.py tests/test_sync_platforms.py tests/test_sync_platforms_response.py -q`
- `python3 -m py_compile app/profile/sync_service.py app/profile/routes.py tests/test_sync_service.py`
- `git diff --check`

Closes #407