### PR TITLE
refactor: centralize content security policy construction

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,6 +14,7 @@ from app.extensions import bcrypt, db, limiter, login_manager, mongo, oauth, cac
 from app.leaderboard import leaderboard_bp
 from app.web.routes import public_bp
 from app.profile import profile_bp
+from app.security import build_content_security_policy
 from app.search import search_bp
 from app.tracker import tracker_bp
 from app.utils import platform_color_filter, platform_name_filter
@@ -191,13 +192,7 @@ def create_app():
 
     @app.after_request
     def add_security_headers(response):
-        response.headers['Content-Security-Policy'] = (
-            "default-src 'self'; "
-            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; "
-            "font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; "
-            "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com; "
-            "img-src 'self' data: https:;"
-        )
+        response.headers["Content-Security-Policy"] = build_content_security_policy()
         return response
 
 

--- a/app/security.py
+++ b/app/security.py
@@ -1,0 +1,14 @@
+DEFAULT_CSP_DIRECTIVES = {
+    "default-src": ["'self'"],
+    "style-src": ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com", "https://cdn.jsdelivr.net"],
+    "font-src": ["'self'", "https://fonts.gstatic.com", "https://cdn.jsdelivr.net"],
+    "script-src": ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net", "https://unpkg.com"],
+    "img-src": ["'self'", "data:", "https:"],
+}
+
+
+def build_content_security_policy(directives=None):
+    policy_directives = directives or DEFAULT_CSP_DIRECTIVES
+    return "; ".join(
+        f"{directive} {' '.join(sources)}" for directive, sources in policy_directives.items()
+    ) + ";"

--- a/tests/test_security_policy.py
+++ b/tests/test_security_policy.py
@@ -1,0 +1,35 @@
+from app.security import DEFAULT_CSP_DIRECTIVES, build_content_security_policy
+
+
+def test_build_content_security_policy_uses_default_directives():
+    policy = build_content_security_policy()
+
+    assert policy.endswith(";")
+    assert "default-src 'self';" in policy
+    assert "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com;" in policy
+    assert "https://code.jquery.com" not in policy
+
+
+def test_build_content_security_policy_accepts_custom_directives():
+    policy = build_content_security_policy(
+        {
+            "default-src": ["'self'"],
+            "connect-src": ["'self'", "https://api.example.com"],
+        }
+    )
+
+    assert policy == "default-src 'self'; connect-src 'self' https://api.example.com;"
+
+
+def test_default_csp_directives_keep_expected_origins():
+    assert DEFAULT_CSP_DIRECTIVES["style-src"] == [
+        "'self'",
+        "'unsafe-inline'",
+        "https://fonts.googleapis.com",
+        "https://cdn.jsdelivr.net",
+    ]
+    assert DEFAULT_CSP_DIRECTIVES["font-src"] == [
+        "'self'",
+        "https://fonts.gstatic.com",
+        "https://cdn.jsdelivr.net",
+    ]


### PR DESCRIPTION
Closes #424

## Summary
- move CSP directives into a structured helper module
- generate the Content-Security-Policy header from reusable directives
- add focused tests for default and custom policy generation

## Validation
- `python3 -m pytest tests/test_security_policy.py tests/test_security_headers.py tests/test_app_factory.py -q`
- `python3 -m py_compile app/__init__.py app/security.py tests/test_security_policy.py`
- `git diff --check`