### PR TITLE
test: add shared app fixtures for route tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
 import sys
 from unittest.mock import MagicMock
 
+import mongomock
 import pytest
+
+import app as app_module
+import app.auth.routes as auth_routes
 
 # Pillow (PIL) doesn't support Python 3.14 yet.
 # Mock it only when it is unavailable so normal CI can exercise the real
@@ -24,3 +28,33 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if item.nodeid.startswith("tests/test_progress_card.py"):
             item.add_marker(skip_progress_card)
+
+
+def build_test_app(monkeypatch, *, extra_db_targets=(), oauth_clients=None):
+    test_db = mongomock.MongoClient().db
+
+    for target in (app_module, auth_routes, *extra_db_targets):
+        monkeypatch.setattr(target, "db", test_db)
+
+    if oauth_clients:
+        for client_name, client in oauth_clients.items():
+            monkeypatch.setattr(auth_routes, client_name, client)
+
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
+
+    flask_app = app_module.create_app()
+    flask_app.config.update(TESTING=True)
+    flask_app._db_initialized = True
+    return flask_app, test_db
+
+
+def login_test_user(client, user_id):
+    if hasattr(user_id, "user"):
+        user_id = user_id.user.insert_one(
+            {"email": "user@example.com", "progress": {}, "is_admin": False}
+        ).inserted_id
+    with client.session_transaction() as session:
+        session["_user_id"] = str(user_id)
+        session["_fresh"] = True
+    return user_id

--- a/tests/test_google_oauth_nonce.py
+++ b/tests/test_google_oauth_nonce.py
@@ -1,7 +1,5 @@
-import mongomock
-
-import app as app_module
 import app.auth.routes as auth_routes
+from conftest import build_test_app
 
 
 class FakeGoogleClient:
@@ -32,27 +30,9 @@ class FakeGoogleClient:
         self.userinfo_called = True
         return self.parsed_user
 
-
-def create_test_app(monkeypatch, google_client):
-    test_db = mongomock.MongoClient().db
-
-    monkeypatch.setattr(app_module, "db", test_db)
-    monkeypatch.setattr(auth_routes, "db", test_db)
-    monkeypatch.setattr(auth_routes, "google", google_client)
-
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
-    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
-
-    flask_app = app_module.create_app()
-    flask_app.config.update(TESTING=True)
-    flask_app._db_initialized = True
-
-    return flask_app, test_db
-
-
 def test_google_login_generates_and_sends_nonce(monkeypatch):
     google_client = FakeGoogleClient()
-    flask_app, _ = create_test_app(monkeypatch, google_client)
+    flask_app, _ = build_test_app(monkeypatch, oauth_clients={"google": google_client})
 
     with flask_app.test_client() as client:
         response = client.get("/login/google")
@@ -69,7 +49,7 @@ def test_google_login_generates_and_sends_nonce(monkeypatch):
 
 def test_google_authorize_uses_and_consumes_nonce(monkeypatch):
     google_client = FakeGoogleClient()
-    flask_app, test_db = create_test_app(monkeypatch, google_client)
+    flask_app, test_db = build_test_app(monkeypatch, oauth_clients={"google": google_client})
 
     with flask_app.test_client() as client:
         with client.session_transaction() as session:
@@ -90,7 +70,7 @@ def test_google_authorize_uses_and_consumes_nonce(monkeypatch):
 
 def test_google_authorize_rejects_missing_nonce(monkeypatch):
     google_client = FakeGoogleClient()
-    flask_app, _ = create_test_app(monkeypatch, google_client)
+    flask_app, _ = build_test_app(monkeypatch, oauth_clients={"google": google_client})
 
     with flask_app.test_client() as client:
         response = client.get("/login/google/authorize")

--- a/tests/test_public_profile.py
+++ b/tests/test_public_profile.py
@@ -1,34 +1,15 @@
-import mongomock
 import werkzeug
 
-import app as app_module
-import app.auth.routes as auth_routes
 import app.web.routes as public_routes
+from conftest import build_test_app
 
 
 if not hasattr(werkzeug, "__version__"):
     werkzeug.__version__ = "3"
 
 
-def create_test_app(monkeypatch):
-    test_db = mongomock.MongoClient().db
-
-    monkeypatch.setattr(app_module, "db", test_db)
-    monkeypatch.setattr(auth_routes, "db", test_db)
-    monkeypatch.setattr(public_routes, "db", test_db)
-
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
-    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
-
-    flask_app = app_module.create_app()
-    flask_app.config.update(TESTING=True)
-    flask_app._db_initialized = True
-
-    return flask_app, test_db
-
-
 def test_public_profile_route_is_accessible_without_login(monkeypatch):
-    flask_app, test_db = create_test_app(monkeypatch)
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(public_routes,))
     user_id = test_db.user.insert_one(
         {
             "name": "Public User",
@@ -63,7 +44,7 @@ def test_public_profile_route_is_accessible_without_login(monkeypatch):
 
 
 def test_public_profile_invalid_id_returns_400(monkeypatch):
-    flask_app, _ = create_test_app(monkeypatch)
+    flask_app, _ = build_test_app(monkeypatch, extra_db_targets=(public_routes,))
 
     with flask_app.test_client() as client:
         response = client.get("/u/not-a-valid-objectid")
@@ -72,7 +53,7 @@ def test_public_profile_invalid_id_returns_400(monkeypatch):
 
 
 def test_public_profile_missing_user_returns_404(monkeypatch):
-    flask_app, _ = create_test_app(monkeypatch)
+    flask_app, _ = build_test_app(monkeypatch, extra_db_targets=(public_routes,))
 
     with flask_app.test_client() as client:
         response = client.get("/u/64b64c3f8f1d2b3c4d5e6f70")

--- a/tests/test_registration_password_validation.py
+++ b/tests/test_registration_password_validation.py
@@ -1,25 +1,9 @@
-import mongomock
-
-import app as app_module
 import app.auth.routes as auth_routes
-
-
-def create_test_app(monkeypatch):
-    test_db = mongomock.MongoClient().db
-
-    monkeypatch.setattr(app_module, "db", test_db)
-    monkeypatch.setattr(auth_routes, "db", test_db)
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
-    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
-
-    flask_app = app_module.create_app()
-    flask_app.config.update(TESTING=True)
-    flask_app._db_initialized = True
-    return flask_app, test_db
+from conftest import build_test_app
 
 
 def test_register_rejects_weak_password_before_insert(monkeypatch):
-    flask_app, test_db = create_test_app(monkeypatch)
+    flask_app, test_db = build_test_app(monkeypatch)
 
     response = flask_app.test_client().post(
         "/register",
@@ -37,7 +21,7 @@ def test_register_rejects_weak_password_before_insert(monkeypatch):
 
 
 def test_register_rejects_mismatched_confirmation(monkeypatch):
-    flask_app, test_db = create_test_app(monkeypatch)
+    flask_app, test_db = build_test_app(monkeypatch)
 
     response = flask_app.test_client().post(
         "/register",
@@ -55,7 +39,7 @@ def test_register_rejects_mismatched_confirmation(monkeypatch):
 
 
 def test_register_accepts_strong_confirmed_password(monkeypatch):
-    flask_app, test_db = create_test_app(monkeypatch)
+    flask_app, test_db = build_test_app(monkeypatch)
 
     response = flask_app.test_client().post(
         "/register",

--- a/tests/test_registration_validation.py
+++ b/tests/test_registration_validation.py
@@ -1,9 +1,9 @@
 import app.auth.routes as auth_routes
-from test_tracker_routes import create_test_app
+from conftest import build_test_app
 
 
 def test_register_rejects_blank_display_name(monkeypatch):
-    flask_app, test_db = create_test_app(monkeypatch)
+    flask_app, test_db = build_test_app(monkeypatch)
     monkeypatch.setattr(auth_routes, "db", test_db)
 
     with flask_app.test_client() as client:

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,8 +1,9 @@
-from test_tracker_routes import create_test_app
+import app.tracker.routes as tracker_routes
+from conftest import build_test_app
 
 
 def test_base_template_does_not_load_blocked_jquery(monkeypatch):
-    flask_app, _ = create_test_app(monkeypatch)
+    flask_app, _ = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
 
     with flask_app.test_client() as client:
         response = client.get("/")
@@ -13,7 +14,7 @@ def test_base_template_does_not_load_blocked_jquery(monkeypatch):
 
 
 def test_content_security_policy_matches_base_script_origins(monkeypatch):
-    flask_app, _ = create_test_app(monkeypatch)
+    flask_app, _ = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
 
     with flask_app.test_client() as client:
         response = client.get("/")

--- a/tests/test_tracker_routes.py
+++ b/tests/test_tracker_routes.py
@@ -1,40 +1,11 @@
-import mongomock
 from bson import ObjectId
 
-import app as app_module
-import app.auth.routes as auth_routes
 import app.tracker.routes as tracker_routes
-
-
-def create_test_app(monkeypatch):
-    test_db = mongomock.MongoClient().db
-
-    monkeypatch.setattr(app_module, "db", test_db)
-    monkeypatch.setattr(auth_routes, "db", test_db)
-    monkeypatch.setattr(tracker_routes, "db", test_db)
-
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
-    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
-
-    flask_app = app_module.create_app()
-    flask_app.config.update(TESTING=True)
-    flask_app._db_initialized = True
-
-    return flask_app, test_db
-
-
-def login_test_user(client, test_db):
-    user_id = test_db.user.insert_one(
-        {"email": "user@example.com", "progress": {}, "is_admin": False}
-    ).inserted_id
-    with client.session_transaction() as session:
-        session["_user_id"] = str(user_id)
-        session["_fresh"] = True
-    return user_id
+from conftest import build_test_app, login_test_user
 
 
 def test_topic_not_found_invalid_id(monkeypatch):
-    flask_app, _ = create_test_app(monkeypatch)
+    flask_app, _ = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
 
     with flask_app.test_client() as client:
         response = client.get("/topic/invalid-object-id")
@@ -44,7 +15,7 @@ def test_topic_not_found_invalid_id(monkeypatch):
 
 
 def test_topic_not_found_missing_id(monkeypatch):
-    flask_app, _ = create_test_app(monkeypatch)
+    flask_app, _ = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
     non_existent_id = str(ObjectId())
 
     with flask_app.test_client() as client:
@@ -55,7 +26,7 @@ def test_topic_not_found_missing_id(monkeypatch):
 
 
 def test_topic_page_all_and_filtered_counts(monkeypatch):
-    flask_app, test_db = create_test_app(monkeypatch)
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
 
     # Insert a test topic
     topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id
@@ -141,7 +112,7 @@ def test_topic_page_all_and_filtered_counts(monkeypatch):
 
 
 def test_update_question_rejects_missing_json_body(monkeypatch):
-    flask_app, test_db = create_test_app(monkeypatch)
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
     question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
 
     with flask_app.test_client() as client:
@@ -156,7 +127,7 @@ def test_update_question_rejects_missing_json_body(monkeypatch):
 
 
 def test_update_question_rejects_malformed_json(monkeypatch):
-    flask_app, test_db = create_test_app(monkeypatch)
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
     question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
 
     with flask_app.test_client() as client:
@@ -172,7 +143,7 @@ def test_update_question_rejects_malformed_json(monkeypatch):
 
 
 def test_update_question_rejects_json_array(monkeypatch):
-    flask_app, test_db = create_test_app(monkeypatch)
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
     question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
 
     with flask_app.test_client() as client:
@@ -184,7 +155,7 @@ def test_update_question_rejects_json_array(monkeypatch):
 
 
 def test_update_question_rejects_non_boolean_done(monkeypatch):
-    flask_app, test_db = create_test_app(monkeypatch)
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
     question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
 
     with flask_app.test_client() as client:
@@ -199,7 +170,7 @@ def test_update_question_rejects_non_boolean_done(monkeypatch):
 
 
 def test_update_question_accepts_valid_boolean_update(monkeypatch):
-    flask_app, test_db = create_test_app(monkeypatch)
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
     question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
 
     with flask_app.test_client() as client:


### PR DESCRIPTION
Closes #425

## Summary
- add a shared `build_test_app()` helper in `tests/conftest.py`
- add a shared login-session helper for tests
- migrate tracker, public-profile, registration-password, and Google OAuth nonce tests to the shared helpers

## Validation
- `python3 -m pytest tests/test_tracker_routes.py tests/test_public_profile.py tests/test_registration_password_validation.py tests/test_google_oauth_nonce.py -q`
- `python3 -m py_compile tests/conftest.py tests/test_tracker_routes.py tests/test_public_profile.py tests/test_registration_password_validation.py tests/test_google_oauth_nonce.py`
- `git diff --check`