### PR TITLE
refactor: add structured app config classes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ import os
 import secrets
 from pathlib import Path
 
+from app.config import resolve_config_class, env_flag, ProductionConfig
 from dotenv import load_dotenv
 from flasgger import Swagger
 from flask import Flask, session
@@ -20,45 +21,24 @@ from app.tracker import tracker_bp
 from app.utils import platform_color_filter, platform_name_filter
 
 
-def _env_flag(name, default=False):
-    value = os.environ.get(name)
-    if value is None:
-        return default
-    return value.strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _is_local_environment():
-    app_env = os.environ.get("FLASK_ENV") or os.environ.get("APP_ENV") or os.environ.get("ENV") or ""
-    return app_env.strip().lower() in {"development", "dev", "local", "test", "testing"} or _env_flag("FLASK_DEBUG")
-
-
-def _is_production_environment():
-    return os.environ.get("FLASK_ENV") == "production" or os.environ.get("APP_ENV") == "production"
-
-
-def _configure_rate_limit_storage(app):
-    storage_uri = os.environ.get("RATELIMIT_STORAGE_URI", "memory://")
-    if storage_uri == "memory://" and _is_production_environment():
+def _configure_rate_limit_storage(app, config_class):
+    storage_uri = app.config["RATELIMIT_STORAGE_URI"]
+    if storage_uri == "memory://" and config_class is ProductionConfig:
         raise RuntimeError("Set RATELIMIT_STORAGE_URI to a persistent backend before running in production.")
-    app.config["RATELIMIT_STORAGE_URI"] = storage_uri
 
 
-def create_app():
+def create_app(config_class=None):
     load_dotenv()
 
     app = Flask(__name__, template_folder="../templates", static_folder="../static")
-    app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "supersecretkey")
-    app.config["MONGO_URI"] = os.environ.get("MONGO_URI", "mongodb://localhost:27017/450_dsa")
-    _configure_rate_limit_storage(app)
-    app.config["SESSION_COOKIE_HTTPONLY"] = True
-    app.config["SESSION_COOKIE_SAMESITE"] = os.environ.get("SESSION_COOKIE_SAMESITE", "Lax")
-    app.config["SESSION_COOKIE_SECURE"] = _env_flag("SESSION_COOKIE_SECURE", default=not _is_local_environment())
-    app.config["CACHE_TYPE"] = "SimpleCache"
-    app.config["CACHE_DEFAULT_TIMEOUT"] = 300
-    app.config["SWAGGER"] = {
-        "title": "450 DSA Tracker API",
-        "uiversion": 3,
-    }
+    config_class = config_class or resolve_config_class()
+    app.config.from_object(config_class)
+    config_class.apply_environment_overrides(app)
+    _configure_rate_limit_storage(app, config_class)
+    app.config["SESSION_COOKIE_SECURE"] = env_flag(
+        "SESSION_COOKIE_SECURE",
+        default=app.config["SESSION_COOKIE_SECURE"],
+    )
     
     cache.init_app(app)
     Swagger(

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,74 @@
+import os
+
+
+def env_flag(name, default=False):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def current_environment_name():
+    for key in ("APP_ENV", "FLASK_ENV", "ENV"):
+        value = os.environ.get(key)
+        if value:
+            return value.strip().lower()
+    if env_flag("FLASK_DEBUG"):
+        return "development"
+    return ""
+
+
+class BaseConfig:
+    SECRET_KEY = "supersecretkey"
+    MONGO_URI = "mongodb://localhost:27017/450_dsa"
+    CACHE_TYPE = "SimpleCache"
+    CACHE_DEFAULT_TIMEOUT = 300
+    SESSION_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SAMESITE = "Lax"
+    SESSION_COOKIE_SECURE = True
+    SWAGGER = {
+        "title": "450 DSA Tracker API",
+        "uiversion": 3,
+    }
+    RATELIMIT_STORAGE_URI = "memory://"
+
+    @classmethod
+    def apply_environment_overrides(cls, app):
+        app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", cls.SECRET_KEY)
+        app.config["MONGO_URI"] = os.environ.get("MONGO_URI", cls.MONGO_URI)
+        app.config["SESSION_COOKIE_SAMESITE"] = os.environ.get(
+            "SESSION_COOKIE_SAMESITE",
+            cls.SESSION_COOKIE_SAMESITE,
+        )
+        app.config["RATELIMIT_STORAGE_URI"] = os.environ.get(
+            "RATELIMIT_STORAGE_URI",
+            cls.RATELIMIT_STORAGE_URI,
+        )
+
+
+class DevelopmentConfig(BaseConfig):
+    SESSION_COOKIE_SECURE = False
+
+
+class TestingConfig(BaseConfig):
+    TESTING = True
+    SESSION_COOKIE_SECURE = False
+
+
+class ProductionConfig(BaseConfig):
+    SESSION_COOKIE_SECURE = True
+
+
+CONFIG_BY_ENV = {
+    "development": DevelopmentConfig,
+    "dev": DevelopmentConfig,
+    "local": DevelopmentConfig,
+    "testing": TestingConfig,
+    "test": TestingConfig,
+    "production": ProductionConfig,
+    "prod": ProductionConfig,
+}
+
+
+def resolve_config_class():
+    return CONFIG_BY_ENV.get(current_environment_name(), BaseConfig)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import app as app_module
+from app.config import DevelopmentConfig, ProductionConfig, TestingConfig
 from app.extensions import login_manager
 
 
@@ -164,3 +165,48 @@ def test_create_app_requires_persistent_rate_limit_storage_in_production(monkeyp
         assert "RATELIMIT_STORAGE_URI" in str(exc)
     else:
         raise AssertionError("production startup should require persistent rate-limit storage")
+
+
+def test_create_app_uses_testing_config_class(monkeypatch):
+    monkeypatch.setattr(app_module, "db", FakeDB())
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.limiter, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
+
+    flask_app = app_module.create_app(config_class=TestingConfig)
+
+    assert flask_app.config["TESTING"] is True
+    assert flask_app.config["SESSION_COOKIE_SECURE"] is False
+
+
+def test_create_app_uses_production_config_class(monkeypatch):
+    monkeypatch.setenv("RATELIMIT_STORAGE_URI", "redis://localhost:6379/0")
+    monkeypatch.setattr(app_module, "db", FakeDB())
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.limiter, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
+
+    flask_app = app_module.create_app(config_class=ProductionConfig)
+
+    assert flask_app.config["SESSION_COOKIE_SECURE"] is True
+    assert flask_app.config["RATELIMIT_STORAGE_URI"] == "redis://localhost:6379/0"
+
+
+def test_create_app_uses_development_config_class(monkeypatch):
+    monkeypatch.setattr(app_module, "db", FakeDB())
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.limiter, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
+
+    flask_app = app_module.create_app(config_class=DevelopmentConfig)
+
+    assert flask_app.config["SESSION_COOKIE_SECURE"] is False


### PR DESCRIPTION
Closes #423

## Summary
- add a dedicated `app/config.py` with base, development, testing, and production config classes
- let `create_app()` load from a config class while preserving environment variable overrides
- extend app-factory tests to cover explicit development/testing/production config selection

## Validation
- `python3 -m pytest tests/test_app_factory.py -q`
- `python3 -m py_compile app/__init__.py app/config.py tests/test_app_factory.py`
- `git diff --check`