### PR TITLE
docs: standardize OpenAPI route docstrings

### DIFF
--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -56,7 +56,7 @@ def leaderboard():
 @leaderboard_bp.route("/api/leaderboard")
 @cache.cached(timeout=300, query_string=True)
 def api_leaderboard():
-    """Get leaderboard rankings.
+    """Return paginated leaderboard rankings for the selected mode.
     ---
     tags:
       - Leaderboard

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -43,7 +43,7 @@ def build_sync_platforms_response(platform_status: dict):
 @login_required
 @limiter.limit("5 per minute")
 def sync_platforms():
-    """Sync coding platform statistics for the authenticated user.
+    """Sync linked coding platform statistics for the authenticated user.
     ---
     tags:
       - Profile
@@ -98,6 +98,8 @@ def sync_platforms():
                     type: string
       401:
         description: Login required.
+      400:
+        description: Request body must be a JSON object.
       429:
         description: Rate limit exceeded.
     """
@@ -278,7 +280,7 @@ def sync_platforms():
 @profile_bp.route("/edit_profile", methods=["POST"])
 @login_required
 def edit_profile():
-    """Update profile fields for the authenticated user.
+    """Update editable profile fields for the authenticated user.
     ---
     tags:
       - Profile
@@ -378,7 +380,7 @@ def public_card(user_id):
 
 @profile_bp.route("/search_universities")
 def search_universities():
-    """Search universities by name.
+    """Return matching universities for an autocomplete query.
     ---
     tags:
       - Profile
@@ -434,7 +436,7 @@ def search_universities():
 @login_required
 @limiter.limit("10 per minute")
 def upload_photo():
-    """Upload a profile photo.
+    """Upload and save a profile photo for the authenticated user.
     ---
     tags:
       - Profile

--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -16,7 +16,7 @@ def search():
 @search_bp.route("/api/search_questions")
 @limiter.limit("30 per minute")
 def api_search_questions():
-    """Search DSA questions.
+    """Return question search results and external search suggestions.
     ---
     tags:
       - Search

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -106,7 +106,7 @@ def export_topic_notes(topic_id):
 @tracker_bp.route("/update_question/<question_id>", methods=["POST"])
 @login_required
 def update_question(question_id):
-    """Update the authenticated user's progress for a question.
+    """Update the authenticated user's saved progress for one question.
     ---
     tags:
       - Tracker
@@ -144,6 +144,8 @@ def update_question(question_id):
               example: true
       401:
         description: Login required.
+      400:
+        description: Invalid JSON payload.
       404:
         description: Question not found.
         schema:


### PR DESCRIPTION
Closes #413

## Summary
- normalize the documented route docstrings across search, leaderboard, tracker, and profile endpoints
- keep parameter/response ordering and one-line endpoint summaries more consistent
- preserve generated Swagger paths and endpoint behavior

## Validation
- `python3 -m pytest tests/test_app_factory.py -q`
- `python3 -m py_compile app/search/routes.py app/leaderboard/routes.py app/tracker/routes.py app/profile/routes.py`
- `git diff --check`