### PR TITLE
fix: wrap db.user.update_many in try-except to prevent vercel cold st…

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -97,12 +97,11 @@ def create_app(config_class=None):
         db.user.create_index("is_admin")
         db.topic.create_index("name", unique=True)
         db.question.create_index([("problem", "text")], name="problem_text")
+        
+        # Lightweight schema backfill for legacy user documents.
+        db.user.update_many({"is_admin": {"$exists": False}}, {"$set": {"is_admin": False}})
     except Exception:
         pass
-
-    # Lightweight schema backfill for legacy user documents.
-    db.user.update_many({"is_admin": {"$exists": False}}, {"$set": {"is_admin": False}})
-
     data_path = Path(app.root_path).parent / "data.json"
     app._db_initialized = False
 


### PR DESCRIPTION
# Description

This PR prevents a `FUNCTION_INVOCATION_FAILED` crash on Vercel during cold starts. Previously, the `db.user.update_many()` call in `app/__init__.py` was placed outside the `try-except` block. If the MongoDB connection was delayed during a serverless cold start, this unprotected call would throw an unhandled exception and crash the app. 

This fix moves the `update_many()` call safely inside the existing `try` block alongside the `create_index()` calls, allowing the app to handle transient database connection delays gracefully without crashing.

Fixes #388

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which improves code structure)
- [ ] Documentation (non-breaking change which improves documentation)
- [ ] Performance (non-breaking change which improves performance)
- [ ] Chore (non-breaking change which does not modify src or test files)
- [ ] Build / CI (non-breaking change which does not modify src or test files)
- [ ] Security (non-breaking change which improves security)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Verified that placing the database update operation inside the exception handler prevents the application from throwing a fatal startup error when the MongoDB instance is temporarily unreachable during server initialization.

- [x] Tested in Local

## Checklist
- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs
*(Drag and drop the screenshot of your VS Code fix here if you want, but it's optional!)*