### PR TITLE
perf: add missing topic and question indexes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -96,6 +96,8 @@ def create_app(config_class=None):
         db.user.create_index("google_id", unique=True, sparse=True)
         db.user.create_index("is_admin")
         db.topic.create_index("name", unique=True)
+        db.topic.create_index("position")
+        db.question.create_index("topic")
         db.question.create_index([("problem", "text")], name="problem_text")
     except Exception:
         pass

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -83,6 +83,9 @@ def test_create_app_preserves_routes_and_blueprints(monkeypatch):
     assert "/apispec_1.json" in routes
 
     question_indexes = app_module.db.question.indexes
+    topic_indexes = app_module.db.topic.indexes
+    assert (("position",), {}) in topic_indexes
+    assert (("topic",), {}) in question_indexes
     assert (([("problem", "text")],), {"name": "problem_text"}) in question_indexes
     assert "/admin" in routes
     assert "/admin/users/<user_id>/delete" in routes


### PR DESCRIPTION
## Summary
- add the missing `topic.position` and `question.topic` MongoDB indexes called out in issue #38
- keep the existing login/OAuth and text-search indexes unchanged
- extend the app factory test to assert the new indexes are created during startup

## Validation
- `python3 -m pytest tests/test_app_factory.py -q`
- `python3 -m py_compile app/__init__.py tests/test_app_factory.py`
- `git diff --check`

Closes #38