### PR TITLE
feat: add loading skeletons and busy states

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,9 @@
     <title>450 DSA Tracker</title>
     <meta name="description"
         content="Track your 450 DSA progress, connect coding platforms, and visualize your growth.">
+    <script>
+        document.documentElement.classList.add('page-loading');
+    </script>
    
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
     
@@ -60,6 +63,69 @@
             color: var(--text-primary);
             min-height: 100vh;
             overflow-x: hidden;
+        }
+
+        .page-load-target {
+            transition: opacity 0.18s ease;
+        }
+
+        .page-load-skeleton {
+            display: none;
+            gap: 14px;
+            margin-bottom: 20px;
+        }
+
+        .page-loading .page-load-target {
+            opacity: 0;
+        }
+
+        .page-loading .page-load-skeleton {
+            display: grid;
+        }
+
+        .skeleton-block,
+        .skeleton-line,
+        .skeleton-chip {
+            position: relative;
+            overflow: hidden;
+            background: rgba(255, 255, 255, 0.06);
+        }
+
+        .skeleton-block::after,
+        .skeleton-line::after,
+        .skeleton-chip::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            transform: translateX(-100%);
+            background: linear-gradient(
+                90deg,
+                transparent,
+                rgba(255, 255, 255, 0.12),
+                transparent
+            );
+            animation: skeleton-shimmer 1.15s linear infinite;
+        }
+
+        .skeleton-block {
+            border-radius: var(--radius-lg);
+            min-height: 120px;
+        }
+
+        .skeleton-line {
+            border-radius: 999px;
+            height: 12px;
+        }
+
+        .skeleton-chip {
+            border-radius: 8px;
+            height: 32px;
+        }
+
+        @keyframes skeleton-shimmer {
+            100% {
+                transform: translateX(100%);
+            }
         }
 
         /* ========== ACCESSIBILITY IMPROVEMENTS ========== */
@@ -920,6 +986,10 @@
             const fc = document.getElementById('flash-container');
             if (fc) fc.style.opacity = '0', fc.style.transition = '0.5s', setTimeout(() => fc.remove(), 500);
         }, 4000);
+
+        window.addEventListener('load', () => {
+            document.documentElement.classList.remove('page-loading');
+        });
     </script>
     {% block scripts %}{% endblock %}
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -189,10 +189,28 @@
     outline-offset: 2px;
     transform: translateY(-2px);
 }
+.topic-skeleton-grid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+.topic-skeleton-card {
+    min-height: 160px;
+}
 </style>
 {% endblock %}
 
 {% block content %}
+<div class="page-load-skeleton">
+    <div class="skeleton-line" style="width: 180px;"></div>
+    <div class="skeleton-line" style="width: 320px;"></div>
+    <div class="skeleton-block" style="min-height: 96px;"></div>
+    <div class="page-load-skeleton topic-skeleton-grid">
+        {% for _ in range(8) %}
+        <div class="skeleton-block topic-skeleton-card"></div>
+        {% endfor %}
+    </div>
+</div>
+
+<div class="page-load-target">
 <div class="page-header">
     <h1>DSA Topics</h1>
     <p>Track your progress across all 450 DSA questions</p>
@@ -262,5 +280,6 @@
         </div>
     </a>
     {% endfor %}
+</div>
 </div>
 {% endblock %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -7,7 +7,9 @@
 .prof-layout{display:grid;grid-template-columns:240px 1fr 260px;gap:16px;align-items:start}
 .prof-sidebar,.prof-main,.prof-right{display:flex;flex-direction:column;gap:14px}
 .card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:18px;color:var(--text-primary)}
-.avatar-ring{width:90px;height:90px;border-radius:50%;background:linear-gradient(135deg,var(--accent),#ff375f);display:flex;align-items:center;justify-content:center;font-size:2rem;font-weight:800;color:#fff;margin:0 auto 12px;border:3px solid var(--border-color)}
+.avatar-ring{width:90px;height:90px;border-radius:50%;background:linear-gradient(135deg,var(--accent),#ff375f);display:flex;align-items:center;justify-content:center;font-size:2rem;font-weight:800;color:#fff;margin:0 auto 12px;border:3px solid var(--border-color);position:relative;overflow:hidden}
+.avatar-ring::after{content:"";position:absolute;inset:0;transform:translateX(-100%);background:linear-gradient(90deg,transparent,rgba(255,255,255,.18),transparent);animation:skeleton-shimmer 1.15s linear infinite}
+.avatar-ring img{position:relative;z-index:1}
 .prof-name{font-size:1.1rem;font-weight:800;text-align:center;margin-bottom:2px}
 .prof-handle{text-align:center;font-size:0.8rem;color:var(--accent);margin-bottom:12px;display:flex;align-items:center;justify-content:center;gap:4px}
 .card-btn{display:block;width:100%;padding:9px;background:var(--accent);border:none;border-radius:9px;color:#fff;font-weight:700;font-size:0.82rem;font-family:inherit;cursor:pointer;text-align:center;text-decoration:none;margin-bottom:12px}
@@ -45,6 +47,11 @@
 /* contest row */
 .contest-grid{display:grid;grid-template-columns:1fr 2fr;gap:12px;min-height:160px}
 .empty-chart{display:flex;flex-direction:column;align-items:center;justify-content:center;height:110px;color:var(--text-muted);font-size:.8rem;gap:6px}
+.chart-shell{position:relative;min-height:130px}
+.chart-shell .chart-skeleton{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;border-radius:12px;background:rgba(255,255,255,.04);overflow:hidden}
+.chart-shell .chart-skeleton::after{content:"";position:absolute;inset:0;transform:translateX(-100%);background:linear-gradient(90deg,transparent,rgba(255,255,255,.12),transparent);animation:skeleton-shimmer 1.15s linear infinite}
+.chart-shell canvas{position:relative;z-index:1}
+.chart-shell.is-ready .chart-skeleton{display:none}
 .awards-grid{display:flex;gap:10px;flex-wrap:wrap;margin-top:4px}
 .award-badge{width:64px;height:74px;background:linear-gradient(135deg,rgba(255,107,0,.15),rgba(255,55,95,.1));border:1px solid var(--border-color);border-radius:12px;display:flex;flex-direction:column;align-items:center;justify-content:center;font-size:1.6rem;cursor:pointer;transition:all .2s;position:relative;overflow:hidden;padding:4px}
 .award-badge:hover{border-color:var(--accent);transform:translateY(-2px)}
@@ -289,7 +296,10 @@ body.modal-open {
           <div style="color:var(--warning)">Top {{ '%.1f'|format(lc_rank / 500000 * 100) if lc_rank > 0 else 0 }}%</div>
         </div>
       </div>
-      <div style="height:130px;margin-top:4px"><canvas id="progressChart" aria-label="Rating progress chart"></canvas></div>
+      <div class="chart-shell" id="progressChartShell" style="height:130px;margin-top:4px">
+        <div class="chart-skeleton" aria-hidden="true"></div>
+        <canvas id="progressChart" aria-label="Rating progress chart"></canvas>
+      </div>
     </div>
   </div>
 
@@ -376,7 +386,8 @@ body.modal-open {
     </div>
 
     <!-- Fundamentals -->
-    <div class="donut-wrap">
+    <div class="donut-wrap chart-shell" id="platformsChartShell">
+      <div class="chart-skeleton" aria-hidden="true"></div>
       <canvas id="platformsChart" aria-label="Platforms solved distribution chart"></canvas>
       <div class="donut-inner">{{ global_total_solved }}</div>
     </div>
@@ -411,7 +422,8 @@ body.modal-open {
 
     <!-- DSA difficulty -->
     <div style="font-size:.8rem;font-weight:700;text-align:center;color:var(--text-secondary);margin-bottom:12px">DSA</div>
-    <div class="donut-wrap">
+    <div class="donut-wrap chart-shell" id="difficultyChartShell">
+      <div class="chart-skeleton" aria-hidden="true"></div>
       <canvas id="difficultyChart" aria-label="Difficulty distribution chart"></canvas>
       <div class="donut-inner">{{ lc_easy + lc_medium + lc_hard }}</div>
     </div>
@@ -718,6 +730,10 @@ window.handleSyncProfile = function(btn){
 // ── Chart & Visualization Code ──
 const dailyCounts = {{ daily_counts | tojson }};
 const heatmap = document.getElementById('heatmap');
+function markChartReady(id){
+  const shell = document.getElementById(id);
+  if (shell) shell.classList.add('is-ready');
+}
 const today = new Date();
 const days = 168;
 let start = new Date(); start.setDate(today.getDate() - days + 1);
@@ -741,6 +757,7 @@ if(chartData.length > 0 && chartCanvas && typeof Chart !== 'undefined'){
     data:{labels:chartData.map(d=>d.x),datasets:[{data:chartData.map(d=>d.y),borderColor:'#f68b24',backgroundColor:'rgba(246,139,36,.15)',borderWidth:2,fill:true,tension:.4,pointRadius:ratingHistory.length>0?3:0,pointHoverRadius:5,pointBackgroundColor:'#f68b24'}]},
     options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false},tooltip:{callbacks:{title:items=>items[0].label,label:ctx=>ratingHistory.length>0?'Rating: '+ctx.raw:'Solved: '+ctx.raw}}},scales:{x:{grid:{display:false},ticks:{color:'#888',maxTicksLimit:5,font:{size:10}}},y:{grid:{color:'rgba(255,255,255,.05)'},ticks:{color:'#888',font:{size:10}}}}}
   });
+  markChartReady('progressChartShell');
 } else if(chartCanvas && typeof Chart !== 'undefined') {
   // Show empty state inside canvas area
   const ctx = chartCanvas.getContext('2d');
@@ -750,6 +767,7 @@ if(chartData.length > 0 && chartCanvas && typeof Chart !== 'undefined'){
   ctx.font = '13px Inter, sans-serif';
   ctx.textAlign = 'center';
   ctx.fillText('Sync LeetCode to see rating chart', chartCanvas.width/2, chartCanvas.height/2 - 8);
+  markChartReady('progressChartShell');
 }
 
 const pData = {{ platforms | tojson }};
@@ -757,13 +775,13 @@ try{new Chart(document.getElementById('platformsChart'),{
   type:'doughnut',
   data:{labels:['LeetCode','GFG','Coding Ninjas','HackerRank','Other'],datasets:[{data:[pData['LeetCode'],pData['GFG'],pData['Coding Ninjas'],pData['HackerRank'],pData['Other']],backgroundColor:['#ffb800','#22c55e','#8b5cf6','#00bd6c','#6c757d'],borderWidth:0,cutout:'78%'}]},
   options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}}}
-});}catch(e){console.warn('Chart.js load failed:',e);}
+}); markChartReady('platformsChartShell');}catch(e){console.warn('Chart.js load failed:',e); markChartReady('platformsChartShell');}
 
 try{new Chart(document.getElementById('difficultyChart'),{
   type:'doughnut',
   data:{labels:['Easy','Medium','Hard'],datasets:[{data:[{{lc_easy}},{{lc_medium}},{{lc_hard}}],backgroundColor:['#00b8a3','#ffc01e','#ff375f'],borderWidth:0,cutout:'78%'}]},
   options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}}}
-});}catch(e){console.warn('Difficulty chart error:',e);}
+}); markChartReady('difficultyChartShell');}catch(e){console.warn('Difficulty chart error:',e); markChartReady('difficultyChartShell');}
 
 function openSyncModal(){document.getElementById('syncModal').classList.add('open')}
 function closeSyncModal(){document.getElementById('syncModal').classList.remove('open')}

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -79,6 +79,16 @@
     font-weight: 600;
 }
 .topic-status:empty { display: none; }
+.topic-skeleton-shell { grid-template-columns: 1fr; }
+.topic-skeleton-toolbar { display: grid; grid-template-columns: repeat(4, minmax(90px, 1fr)); gap: 10px; }
+.topic-skeleton-card { min-height: 420px; }
+.btn-busy { pointer-events: none; opacity: 0.75; }
+.btn-busy::before { content: ""; width: 12px; height: 12px; border-radius: 50%; border: 2px solid currentColor; border-right-color: transparent; display: inline-block; animation: topic-spin 0.7s linear infinite; }
+.row-updating { opacity: 0.55; }
+
+@keyframes topic-spin {
+    to { transform: rotate(360deg); }
+}
 
 @media (max-width: 640px) {
     .topic-header { flex-direction: column; align-items: stretch; }
@@ -89,6 +99,19 @@
 }
 </style>
 
+<div class="page-load-skeleton topic-skeleton-shell">
+    <div class="skeleton-line" style="width: 140px;"></div>
+    <div class="skeleton-line" style="width: 260px;"></div>
+    <div class="topic-skeleton-toolbar">
+        <div class="skeleton-chip"></div>
+        <div class="skeleton-chip"></div>
+        <div class="skeleton-chip"></div>
+        <div class="skeleton-chip"></div>
+    </div>
+    <div class="skeleton-block topic-skeleton-card"></div>
+</div>
+
+<div class="page-load-target">
 <a href="{{ url_for('tracker.index') }}" class="back-btn" aria-label="Back to Topics">
     <i class="bi bi-arrow-left" aria-hidden="true"></i> Back to Topics
 </a>
@@ -222,6 +245,7 @@
         </tbody>
     </table>
 </div>
+</div>
 
 <!-- Notes Modal -->
 <div class="modal-overlay" id="notesModal" role="dialog" aria-modal="true" aria-labelledby="notesModalTitle">
@@ -285,6 +309,7 @@ document.querySelectorAll('.status-checkbox').forEach(cb => {
         const previousChecked = !this.checked;
         const nextChecked = this.checked;
         this.disabled = true;
+        row.classList.add('row-updating');
         
         // Update ARIA label
         const problemName = row.querySelector('.q-name')?.textContent || 'Question';
@@ -299,6 +324,7 @@ document.querySelectorAll('.status-checkbox').forEach(cb => {
             })
             .finally(() => {
                 this.disabled = false;
+                row.classList.remove('row-updating');
             });
     });
 });
@@ -312,6 +338,7 @@ document.querySelectorAll('.bookmark-btn').forEach(btn => {
         const isBookmarked = this.dataset.bookmarked === 'true';
         const newStatus = !isBookmarked;
         this.disabled = true;
+        this.classList.add('row-updating');
         setBookmarkState(this, newStatus);
         updateQuestion(this.dataset.id, {bookmark: newStatus})
             .catch(() => {
@@ -320,6 +347,7 @@ document.querySelectorAll('.bookmark-btn').forEach(btn => {
             })
             .finally(() => {
                 this.disabled = false;
+                this.classList.remove('row-updating');
             });
     });
 });
@@ -330,6 +358,8 @@ document.querySelectorAll('.filter-btn[data-difficulty]').forEach(btn => {
         const difficulty = this.dataset.difficulty;
         const currentUrl = new URL(window.location.href);
         currentUrl.searchParams.set('difficulty', difficulty);
+        this.classList.add('btn-busy');
+        this.setAttribute('aria-busy', 'true');
         window.location.href = currentUrl.toString();
     });
 });
@@ -389,6 +419,9 @@ modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
 document.getElementById('saveNotesBtn').addEventListener('click', function() {
     const qId = document.getElementById('currentQuestionId').value;
     const notes = document.getElementById('notesTextarea').value;
+    const previousContent = this.innerHTML;
+    this.disabled = true;
+    this.textContent = 'Saving...';
     updateQuestion(qId, {notes: notes}, () => {
         closeModal();
         const btn = document.querySelector(`.notes-btn[data-id="${qId}"]`);
@@ -401,14 +434,21 @@ document.getElementById('saveNotesBtn').addEventListener('click', function() {
         }
     }).catch(() => {
         showUpdateError('Unable to save notes. Please try again.');
+    }).finally(() => {
+        this.disabled = false;
+        this.innerHTML = previousContent;
     });
 });
 //  Practice Random Button
 document.getElementById('practiceRandomBtn').addEventListener('click', function() {
+    this.classList.add('btn-busy');
+    this.setAttribute('aria-busy', 'true');
     const rows = Array.from(document.querySelectorAll('#questions-table tbody tr:not(#empty-state-row)'))
         .filter(row => row.style.display !== 'none');
     
     if (rows.length === 0) {
+        this.classList.remove('btn-busy');
+        this.removeAttribute('aria-busy');
         alert('No questions available!');
         return;
     }
@@ -416,7 +456,11 @@ document.getElementById('practiceRandomBtn').addEventListener('click', function(
     const randomRow = rows[Math.floor(Math.random() * rows.length)];
     randomRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
     randomRow.style.outline = '2px solid var(--accent)';
-    setTimeout(() => { randomRow.style.outline = ''; }, 2000);
+    setTimeout(() => {
+        randomRow.style.outline = '';
+        this.classList.remove('btn-busy');
+        this.removeAttribute('aria-busy');
+    }, 2000);
 });
 
 </script>


### PR DESCRIPTION
## Summary
- add first-paint skeleton shells for the dashboard and topic views
- show busy states for topic filters, random practice, question updates, and note saves
- add lightweight chart and avatar loading treatment on the profile page while keeping the existing sync overlay flow

## Validation
- `python3 -m pytest tests/test_app_factory.py tests/test_tracker_routes.py tests/test_public_profile.py tests/test_security_headers.py -q`
- `git diff --check`

Closes #49