### PR TITLE
Add PWA install support

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -148,6 +148,12 @@ def create_app(config_class=None):
 
         return {"csrf_token": csrf_token}
 
+    @app.route("/service-worker.js")
+    def service_worker():
+        response = app.send_static_file("js/service-worker.js")
+        response.mimetype = "application/javascript"
+        return response
+
     app.register_blueprint(auth_bp)
     app.register_blueprint(faq_bp)  
     app.register_blueprint(tracker_bp)

--- a/static/icons/icon-192.svg
+++ b/static/icons/icon-192.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" role="img" aria-labelledby="title desc">
+  <title id="title">450 DSA Tracker app icon</title>
+  <desc id="desc">Dark rounded square with orange DSA lettering.</desc>
+  <rect width="192" height="192" rx="44" fill="#111111"/>
+  <rect x="16" y="16" width="160" height="160" rx="36" fill="#1a1a1a" stroke="#2a2a2a" stroke-width="4"/>
+  <circle cx="96" cy="68" r="34" fill="#ff6b00" opacity="0.18"/>
+  <text x="96" y="86" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="52" font-weight="800" fill="#ff8c38">450</text>
+  <text x="96" y="122" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700" fill="#f0f0f0">DSA</text>
+  <rect x="42" y="136" width="108" height="10" rx="5" fill="#ff6b00"/>
+</svg>

--- a/static/icons/icon-512.svg
+++ b/static/icons/icon-512.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">450 DSA Tracker app icon</title>
+  <desc id="desc">Dark rounded square with orange DSA lettering.</desc>
+  <rect width="512" height="512" rx="120" fill="#111111"/>
+  <rect x="40" y="40" width="432" height="432" rx="96" fill="#1a1a1a" stroke="#2a2a2a" stroke-width="10"/>
+  <circle cx="256" cy="180" r="92" fill="#ff6b00" opacity="0.18"/>
+  <text x="256" y="230" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="136" font-weight="800" fill="#ff8c38">450</text>
+  <text x="256" y="324" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="68" font-weight="700" fill="#f0f0f0">DSA</text>
+  <rect x="112" y="364" width="288" height="26" rx="13" fill="#ff6b00"/>
+</svg>

--- a/static/js/pwa-install.js
+++ b/static/js/pwa-install.js
@@ -1,0 +1,69 @@
+(function () {
+  if (!("serviceWorker" in navigator) || !window.isSecureContext) {
+    return;
+  }
+
+  let deferredPrompt = null;
+  let installButton = null;
+
+  function ensureInstallButton() {
+    if (installButton) {
+      return installButton;
+    }
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.hidden = true;
+    button.setAttribute("aria-label", "Install app");
+    button.textContent = "Install App";
+    button.style.position = "fixed";
+    button.style.right = "20px";
+    button.style.bottom = "20px";
+    button.style.zIndex = "10001";
+    button.style.padding = "10px 14px";
+    button.style.border = "1px solid rgba(255, 107, 0, 0.35)";
+    button.style.borderRadius = "999px";
+    button.style.background = "rgba(17, 17, 17, 0.96)";
+    button.style.color = "#f0f0f0";
+    button.style.font = "600 0.85rem Inter, -apple-system, BlinkMacSystemFont, sans-serif";
+    button.style.cursor = "pointer";
+    button.style.boxShadow = "0 10px 32px rgba(0, 0, 0, 0.28)";
+
+    button.addEventListener("click", async function () {
+      if (!deferredPrompt) {
+        return;
+      }
+
+      deferredPrompt.prompt();
+      try {
+        await deferredPrompt.userChoice;
+      } finally {
+        deferredPrompt = null;
+        button.hidden = true;
+      }
+    });
+
+    document.body.appendChild(button);
+    installButton = button;
+    return button;
+  }
+
+  window.addEventListener("beforeinstallprompt", (event) => {
+    event.preventDefault();
+    deferredPrompt = event;
+    ensureInstallButton().hidden = false;
+  });
+
+  window.addEventListener("appinstalled", () => {
+    deferredPrompt = null;
+    if (installButton) {
+      installButton.hidden = true;
+    }
+  });
+
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/service-worker.js", { scope: "/" }).catch(() => {
+      // Safe no-op: PWA install support should never break the page.
+    });
+  });
+})();

--- a/static/js/service-worker.js
+++ b/static/js/service-worker.js
@@ -1,0 +1,81 @@
+const CACHE_VERSION = "pwa-v1";
+const OFFLINE_URL = "/static/offline.html";
+const PRECACHE_URLS = [
+  OFFLINE_URL,
+  "/static/manifest.webmanifest",
+  "/static/icons/icon-192.svg",
+  "/static/icons/icon-512.svg"
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_VERSION).then((cache) => cache.addAll(PRECACHE_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== CACHE_VERSION)
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+function isNavigationRequest(request) {
+  return request.mode === "navigate";
+}
+
+function isExcludedRequest(url, request) {
+  if (request.method !== "GET") {
+    return true;
+  }
+
+  return url.pathname.startsWith("/sync") ||
+    url.pathname.startsWith("/api/") ||
+    url.pathname.startsWith("/update_question") ||
+    url.pathname.startsWith("/sync_platforms");
+}
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (url.origin !== self.location.origin || isExcludedRequest(url, request)) {
+    return;
+  }
+
+  if (isNavigationRequest(request)) {
+    event.respondWith(
+      fetch(request)
+        .then((response) => response)
+        .catch(() => caches.match(OFFLINE_URL))
+    );
+    return;
+  }
+
+  if (url.pathname.startsWith("/static/")) {
+    event.respondWith(
+      caches.match(request).then((cached) => {
+        if (cached) {
+          return cached;
+        }
+
+        return fetch(request).then((response) => {
+          if (!response || response.status !== 200) {
+            return response;
+          }
+
+          const clone = response.clone();
+          caches.open(CACHE_VERSION).then((cache) => cache.put(request, clone));
+          return response;
+        });
+      })
+    );
+  }
+});

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -1,0 +1,24 @@
+{
+  "name": "450 DSA Tracker",
+  "short_name": "450 DSA",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "theme_color": "#111111",
+  "background_color": "#111111",
+  "description": "Track your 450 DSA progress, connect coding platforms, and visualize your growth.",
+  "icons": [
+    {
+      "src": "/static/icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/static/icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/static/offline.html
+++ b/static/offline.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Offline | 450 DSA Tracker</title>
+  <meta name="theme-color" content="#111111">
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #111111;
+      --panel: #1a1a1a;
+      --border: #2a2a2a;
+      --accent: #ff6b00;
+      --text: #f0f0f0;
+      --muted: #a0a0a0;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 24px;
+      font-family: Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+      background:
+        radial-gradient(circle at top, rgba(255, 107, 0, 0.16), transparent 32%),
+        var(--bg);
+      color: var(--text);
+    }
+
+    .offline-shell {
+      width: min(100%, 420px);
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 28px;
+      text-align: center;
+      box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35);
+    }
+
+    .badge {
+      width: 72px;
+      height: 72px;
+      margin: 0 auto 18px;
+      display: grid;
+      place-items: center;
+      border-radius: 22px;
+      background: linear-gradient(135deg, #ff6b00, #ff8c38);
+      font-size: 1.25rem;
+      font-weight: 800;
+      color: #fff;
+    }
+
+    h1 {
+      margin: 0 0 10px;
+      font-size: 1.4rem;
+    }
+
+    p {
+      margin: 0 0 20px;
+      color: var(--muted);
+      line-height: 1.5;
+      font-size: 0.95rem;
+    }
+
+    .actions {
+      display: flex;
+      justify-content: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    a,
+    button {
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 10px 16px;
+      background: #202020;
+      color: var(--text);
+      font: inherit;
+      text-decoration: none;
+      cursor: pointer;
+    }
+
+    .primary {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: white;
+    }
+  </style>
+</head>
+<body>
+  <main class="offline-shell">
+    <div class="badge">450</div>
+    <h1>You’re offline</h1>
+    <p>The app can still open this basic shell, but live progress sync and network-backed pages will resume when your connection returns.</p>
+    <div class="actions">
+      <button class="primary" type="button" onclick="window.location.reload()">Try again</button>
+      <a href="/">Go home</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,11 @@
     <title>450 DSA Tracker</title>
     <meta name="description"
         content="Track your 450 DSA progress, connect coding platforms, and visualize your growth.">
+    <meta name="theme-color" content="#111111">
+    <link rel="manifest" href="{{ url_for('static', filename='manifest.webmanifest') }}">
+    <link rel="icon" href="{{ url_for('static', filename='icons/icon-192.svg') }}" sizes="192x192" type="image/svg+xml">
+    <link rel="icon" href="{{ url_for('static', filename='icons/icon-512.svg') }}" sizes="512x512" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='icons/icon-192.svg') }}">
    
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
     
@@ -19,6 +24,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">    
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+    <script src="{{ url_for('static', filename='js/pwa-install.js') }}" defer></script>
     <style>
         :root {
             --bg-primary: #111111;

--- a/tests/test_pwa_support.py
+++ b/tests/test_pwa_support.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+
+from tests.conftest import build_test_app
+
+
+def test_manifest_contains_expected_pwa_metadata(monkeypatch):
+    app, _ = build_test_app(monkeypatch)
+
+    with app.test_client() as client:
+        response = client.get("/static/manifest.webmanifest")
+
+    assert response.status_code == 200
+    manifest = json.loads(response.get_data(as_text=True))
+    assert manifest["name"] == "450 DSA Tracker"
+    assert manifest["short_name"] == "450 DSA"
+    assert manifest["start_url"] == "/"
+    assert manifest["scope"] == "/"
+    assert manifest["display"] == "standalone"
+    assert manifest["theme_color"] == "#111111"
+    assert manifest["background_color"] == "#111111"
+    assert len(manifest["icons"]) >= 2
+
+
+def test_base_template_links_manifest_icons_and_pwa_script():
+    template_path = Path(__file__).resolve().parents[1] / "templates" / "base.html"
+    html = template_path.read_text(encoding="utf-8")
+
+    assert 'rel="manifest"' in html
+    assert "manifest.webmanifest" in html
+    assert "icon-192.svg" in html
+    assert "icon-512.svg" in html
+    assert "js/pwa-install.js" in html
+
+
+def test_install_script_registers_root_service_worker_with_app_scope():
+    script_path = Path(__file__).resolve().parents[1] / "static" / "js" / "pwa-install.js"
+    script = script_path.read_text(encoding="utf-8")
+
+    assert 'register("/service-worker.js", { scope: "/" })' in script
+
+
+def test_offline_shell_and_service_worker_are_served(monkeypatch):
+    app, _ = build_test_app(monkeypatch)
+
+    with app.test_client() as client:
+        offline_response = client.get("/static/offline.html")
+        worker_response = client.get("/service-worker.js")
+
+    assert offline_response.status_code == 200
+    assert b"You\xe2\x80\x99re offline" in offline_response.data
+    assert worker_response.status_code == 200
+    assert worker_response.mimetype == "application/javascript"
+    assert b"fetch(request)" in worker_response.data
+    assert b"offline.html" in worker_response.data


### PR DESCRIPTION
# Description

Adds installable Progressive Web App support for the tracker.

Changes include:
- Added a web app manifest with app metadata, theme colors, start URL, scope, display mode, and icons
- Added app icons under `static/icons/`
- Added an offline fallback shell at `static/offline.html`
- Added a service worker for offline fallback support
- Registered the service worker with app-wide scope through `/service-worker.js`
- Added a lightweight install prompt script that safely no-ops in unsupported browsers
- Linked PWA assets from `templates/base.html`
- Added tests for manifest metadata, base template links, service worker registration, and offline shell support

Fixes #376

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Tested in Local

Ran:

git diff --check  
python3 -m pytest

Result:

135 passed in 1.33s

## Checklist

- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs

135 passed in 1.33s