### PR TITLE
Handle OAuth provider exceptions safely

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -2,7 +2,7 @@ import re
 import secrets
 
 from bson import ObjectId
-from flask import Blueprint, abort, flash, redirect, render_template, request, session, url_for
+from flask import Blueprint, abort, current_app, flash, redirect, render_template, request, session, url_for
 from flask_login import UserMixin, current_user, login_required, login_user, logout_user
 
 from app.extensions import bcrypt, db, github, google, login_manager
@@ -231,24 +231,45 @@ def login_github():
 
 @auth_bp.route("/login/github/authorize")
 def authorize_github():
-    token = github.authorize_access_token()
+    try:
+        token = github.authorize_access_token()
+    except Exception:
+        current_app.logger.exception("GitHub OAuth token exchange failed")
+        flash("GitHub sign-in is temporarily unavailable. Please try again.", "danger")
+        return redirect(url_for("auth.login"))
+
     if not token:
         return "GitHub authorization failed", 400
 
-    response = github.get("user")
+    try:
+        response = github.get("user")
+    except Exception:
+        current_app.logger.exception("GitHub OAuth user fetch failed")
+        flash("GitHub sign-in is temporarily unavailable. Please try again.", "danger")
+        return redirect(url_for("auth.login"))
+
     if not response.ok:
         return "Failed to fetch GitHub user", 400
 
-    user_info = response.json()
+    try:
+        user_info = response.json()
+    except Exception:
+        current_app.logger.exception("GitHub OAuth user payload parsing failed")
+        flash("GitHub sign-in is temporarily unavailable. Please try again.", "danger")
+        return redirect(url_for("auth.login"))
+
     github_id = str(user_info["id"])
 
-    response_emails = github.get("user/emails")
     email = None
-    if response_emails.status_code == 200:
-        for email_item in response_emails.json():
-            if email_item["primary"] and email_item["verified"]:
-                email = email_item["email"]
-                break
+    try:
+        response_emails = github.get("user/emails")
+        if response_emails.status_code == 200:
+            for email_item in response_emails.json():
+                if email_item["primary"] and email_item["verified"]:
+                    email = email_item["email"]
+                    break
+    except Exception:
+        current_app.logger.exception("GitHub OAuth email lookup failed")
 
     user_doc, action = resolve_oauth_user(
         "github_id",
@@ -279,10 +300,27 @@ def authorize_google():
     if not nonce:
         return "Google OAuth nonce missing", 400
 
-    token = google.authorize_access_token()
-    user_info = google.parse_id_token(token, nonce=nonce)
+    try:
+        token = google.authorize_access_token()
+    except Exception:
+        current_app.logger.exception("Google OAuth token exchange failed")
+        flash("Google sign-in is temporarily unavailable. Please try again.", "danger")
+        return redirect(url_for("auth.login"))
+
+    try:
+        user_info = google.parse_id_token(token, nonce=nonce)
+    except Exception:
+        current_app.logger.exception("Google OAuth ID token parsing failed")
+        flash("Google sign-in is temporarily unavailable. Please try again.", "danger")
+        return redirect(url_for("auth.login"))
+
     if not user_info:
-        user_info = google.userinfo()
+        try:
+            user_info = google.userinfo()
+        except Exception:
+            current_app.logger.exception("Google OAuth userinfo fetch failed")
+            flash("Google sign-in is temporarily unavailable. Please try again.", "danger")
+            return redirect(url_for("auth.login"))
 
     if not user_info:
         return "Failed to fetch Google user info", 400

--- a/tests/test_oauth_linking.py
+++ b/tests/test_oauth_linking.py
@@ -146,6 +146,11 @@ def _make_google_mock(user_info=GOOGLE_USER_INFO):
     return mock
 
 
+def _get_flashed_messages(client):
+    with client.session_transaction() as session:
+        return list(session.get("_flashes", []))
+
+
 # ── GitHub Tests ──────────────────────────────────────────────────────────────
 
 def test_github_links_existing_email_user(monkeypatch):
@@ -190,6 +195,68 @@ def test_github_failed_user_fetch_returns_400(monkeypatch):
         with patch("app.auth.routes.github", new=_make_github_mock(user_ok=False)):
             resp = client.get("/login/github/authorize")
             assert resp.status_code == 400
+
+
+def test_github_token_exchange_exception_redirects_to_login(monkeypatch):
+    db = make_fake_db()
+    flask_app = make_app(monkeypatch, db)
+
+    mock = MagicMock()
+    mock.authorize_access_token = MagicMock(side_effect=RuntimeError("secret boom"))
+
+    with flask_app.test_client() as client:
+        with patch("app.auth.routes.github", new=mock):
+            resp = client.get("/login/github/authorize")
+
+        flashes = _get_flashed_messages(client)
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/login"
+    assert ("danger", "GitHub sign-in is temporarily unavailable. Please try again.") in flashes
+    assert all("secret boom" not in message for _, message in flashes)
+
+
+def test_github_user_fetch_exception_redirects_to_login(monkeypatch):
+    db = make_fake_db()
+    flask_app = make_app(monkeypatch, db)
+
+    mock = MagicMock()
+    mock.authorize_access_token = MagicMock(return_value={"access_token": "tok"})
+    mock.get = MagicMock(side_effect=RuntimeError("provider outage"))
+
+    with flask_app.test_client() as client:
+        with patch("app.auth.routes.github", new=mock):
+            resp = client.get("/login/github/authorize")
+
+        flashes = _get_flashed_messages(client)
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/login"
+    assert ("danger", "GitHub sign-in is temporarily unavailable. Please try again.") in flashes
+    assert all("provider outage" not in message for _, message in flashes)
+
+
+def test_github_email_fetch_exception_does_not_fail_login(monkeypatch):
+    inserted = {}
+    db = make_fake_db(inserted=inserted)
+    flask_app = make_app(monkeypatch, db)
+
+    mock = MagicMock()
+    mock.authorize_access_token = MagicMock(return_value={"access_token": "tok"})
+    user_resp = MagicMock()
+    user_resp.ok = True
+    user_resp.json = MagicMock(return_value=GITHUB_USER_INFO)
+    mock.get = MagicMock(
+        side_effect=lambda url: user_resp if url == "user" else (_ for _ in ()).throw(RuntimeError("email fetch down"))
+    )
+
+    with flask_app.test_client() as client:
+        with patch("app.auth.routes.github", new=mock):
+            resp = client.get("/login/github/authorize")
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/"
+    assert inserted.get("github_id") == str(GITHUB_USER_INFO["id"])
 
 
 # ── Google Tests ──────────────────────────────────────────────────────────────
@@ -237,6 +304,72 @@ def test_google_missing_userinfo_returns_400(monkeypatch):
         with patch("app.auth.routes.google", new=mock):
             resp = client.get("/login/google/authorize")
             assert resp.status_code == 400
+
+
+def test_google_token_exchange_exception_redirects_to_login(monkeypatch):
+    db = make_fake_db()
+    flask_app = make_app(monkeypatch, db)
+
+    mock = MagicMock()
+    mock.authorize_access_token = MagicMock(side_effect=RuntimeError("token failed"))
+
+    with flask_app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["google_oauth_nonce"] = "test-nonce"
+        with patch("app.auth.routes.google", new=mock):
+            resp = client.get("/login/google/authorize")
+
+        flashes = _get_flashed_messages(client)
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/login"
+    assert ("danger", "Google sign-in is temporarily unavailable. Please try again.") in flashes
+    assert all("token failed" not in message for _, message in flashes)
+
+
+def test_google_id_token_parsing_exception_redirects_to_login(monkeypatch):
+    db = make_fake_db()
+    flask_app = make_app(monkeypatch, db)
+
+    mock = MagicMock()
+    mock.authorize_access_token = MagicMock(return_value={"access_token": "tok"})
+    mock.parse_id_token = MagicMock(side_effect=RuntimeError("parse failed"))
+
+    with flask_app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["google_oauth_nonce"] = "test-nonce"
+        with patch("app.auth.routes.google", new=mock):
+            resp = client.get("/login/google/authorize")
+
+        flashes = _get_flashed_messages(client)
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/login"
+    assert ("danger", "Google sign-in is temporarily unavailable. Please try again.") in flashes
+    assert all("parse failed" not in message for _, message in flashes)
+
+
+def test_google_userinfo_exception_redirects_to_login_when_id_token_missing(monkeypatch):
+    db = make_fake_db()
+    flask_app = make_app(monkeypatch, db)
+
+    mock = MagicMock()
+    mock.authorize_access_token = MagicMock(return_value={"access_token": "tok"})
+    mock.parse_id_token = MagicMock(return_value=None)
+    mock.userinfo = MagicMock(side_effect=RuntimeError("userinfo failed"))
+
+    with flask_app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["google_oauth_nonce"] = "test-nonce"
+        with patch("app.auth.routes.google", new=mock):
+            resp = client.get("/login/google/authorize")
+
+        flashes = _get_flashed_messages(client)
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/login"
+    assert ("danger", "Google sign-in is temporarily unavailable. Please try again.") in flashes
+    assert all("userinfo failed" not in message for _, message in flashes)
 
 
 def test_resolve_oauth_user_returns_existing_provider_match(monkeypatch):


### PR DESCRIPTION
# Description

Handles OAuth provider/network exceptions gracefully so GitHub and Google callback failures do not bubble into 500 pages.

Changes include:
- Wrapped GitHub token exchange, user fetch, email fetch, and response parsing in safe exception handling
- Wrapped Google token exchange, ID-token parsing, and userinfo fetch in safe exception handling
- Logged provider failures server-side with `current_app.logger.exception(...)`
- Redirected users back to login with safe auth error messages
- Preserved existing successful OAuth login behavior
- Kept missing Google nonce behavior unchanged
- Added mocked provider exception tests

Fixes #231

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Tested in Local

Ran:

git diff --check  
python3 -m pytest

Result:

137 passed in 1.37s

## Checklist

- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs

137 passed in 1.37s