### PR TITLE
refactor: add shared external link badge macro

### DIFF
--- a/templates/_macros.html
+++ b/templates/_macros.html
@@ -1,0 +1,7 @@
+{% macro external_link_badge(url, label, badge_class='badge-link', aria_label=None, icon='bi-box-arrow-up-right', icon_only=False, extra_classes='q-badge', icon_style='') -%}
+<a href="{{ url }}" target="_blank" rel="noopener noreferrer"
+   class="{{ extra_classes }} {{ badge_class }}"
+   aria-label="{{ aria_label or (label ~ ' (opens in new tab)') }}">
+  <i class="bi {{ icon }}" aria-hidden="true"{% if icon_style %} style="{{ icon_style }}"{% endif %}></i>{% if not icon_only %} {{ label }}{% endif %}
+</a>
+{%- endmacro %}

--- a/templates/bookmarks.html
+++ b/templates/bookmarks.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros.html" import external_link_badge %}
 {% block content %}
 <style>
   .back-btn {
@@ -353,12 +354,34 @@
         <td>
           <div class="q-name">{{ q.problem }}</div>
           <div class="q-links">
-            {% if q.url %}<a href="{{ q.url }}" target="_blank" rel="noopener noreferrer"
-              class="q-badge {% if 'leetcode' in q.url %}badge-lc{% elif 'geeksforgeeks' in q.url %}badge-gfg{% else %}badge-link{% endif %}"><i
-                class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{ q.url|platform_name }}</a>{% endif %}
-            {% if q.url2 %}<a href="{{ q.url2 }}" target="_blank" rel="noopener noreferrer"
-              class="q-badge badge-link"><i class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{
-              q.url2|platform_name }}</a>{% endif %}
+            {% if q.url %}
+              {% set p1 = q.url|platform_name %}
+              {{ external_link_badge(
+                q.url,
+                p1,
+                'badge-lc' if p1 == 'LeetCode' else
+                'badge-gfg' if p1 == 'GFG' else
+                'badge-hr' if p1 == 'HackerRank' else
+                'badge-cn' if p1 == 'Coding Ninjas' else
+                'badge-yt' if p1 == 'YouTube' else
+                'badge-link',
+                'Open ' ~ p1 ~ ' problem link (opens in new tab)'
+              ) }}
+            {% endif %}
+            {% if q.url2 %}
+              {% set p2 = q.url2|platform_name %}
+              {{ external_link_badge(
+                q.url2,
+                p2,
+                'badge-lc' if p2 == 'LeetCode' else
+                'badge-gfg' if p2 == 'GFG' else
+                'badge-hr' if p2 == 'HackerRank' else
+                'badge-cn' if p2 == 'Coding Ninjas' else
+                'badge-yt' if p2 == 'YouTube' else
+                'badge-link',
+                'Open ' ~ p2 ~ ' problem link (opens in new tab)'
+              ) }}
+            {% endif %}
           </div>
         </td>
         <td>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros.html" import external_link_badge %}
 {% block head %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js" onerror="this.remove();var s=document.createElement('script');s.src='https://unpkg.com/chart.js@4/dist/chart.umd.js';document.head.appendChild(s);"></script>
 {% endblock %}
@@ -186,31 +187,31 @@ body.modal-open {
     <div class="platform-row">
       <span><i class="bi bi-code-slash" style="color:#ffb800;margin-right:6px" aria-hidden="true"></i>LeetCode</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.leetcode_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="https://leetcode.com/{{ user.leetcode_username }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="LeetCode profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect LeetCode account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.leetcode_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ external_link_badge("https://leetcode.com/" ~ user.leetcode_username, "LeetCode", badge_class="", aria_label="LeetCode profile (opens in new tab)", icon_only=True, extra_classes="link-out") }}{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect LeetCode account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
       </span>
     </div>
     <div class="platform-row">
       <span><i class="bi bi-braces" style="color:var(--success);margin-right:6px" aria-hidden="true"></i>GeeksForGeeks</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.gfg_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="https://www.geeksforgeeks.org/user/{{ user.gfg_username }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="GFG profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect GFG account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.gfg_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ external_link_badge("https://www.geeksforgeeks.org/user/" ~ user.gfg_username, "GFG", badge_class="", aria_label="GFG profile (opens in new tab)", icon_only=True, extra_classes="link-out") }}{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect GFG account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
       </span>
     </div>
     <div class="platform-row">
       <span><i class="bi bi-lightning-charge" style="color:#8b5cf6;margin-right:6px" aria-hidden="true"></i>Coding Ninjas</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.codingninjas_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="https://www.naukri.com/code360/profile/{{ user.codingninjas_username }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="Coding Ninjas profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect Coding Ninjas account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.codingninjas_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ external_link_badge("https://www.naukri.com/code360/profile/" ~ user.codingninjas_username, "Coding Ninjas", badge_class="", aria_label="Coding Ninjas profile (opens in new tab)", icon_only=True, extra_classes="link-out") }}{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect Coding Ninjas account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
       </span>
     </div>
     <div class="platform-row">
       <span><i class="bi bi-terminal" style="color:#00bd6c;margin-right:6px" aria-hidden="true"></i>HackerRank</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.hackerrank_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="https://www.hackerrank.com/{{ user.hackerrank_username }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="HackerRank profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect HackerRank account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.hackerrank_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ external_link_badge("https://www.hackerrank.com/" ~ user.hackerrank_username, "HackerRank", badge_class="", aria_label="HackerRank profile (opens in new tab)", icon_only=True, extra_classes="link-out") }}{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect HackerRank account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
       </span>
     </div>
     <div class="platform-row">
       <span><i class="bi bi-trophy" style="color:#f97316;margin-right:6px" aria-hidden="true"></i>AtCoder</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.atcoder_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="https://atcoder.jp/users/{{ user.atcoder_username }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="AtCoder profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect AtCoder account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.atcoder_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ external_link_badge("https://atcoder.jp/users/" ~ user.atcoder_username, "AtCoder", badge_class="", aria_label="AtCoder profile (opens in new tab)", icon_only=True, extra_classes="link-out") }}{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect AtCoder account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
       </span>
     </div>
     <button class="add-btn" onclick="openSyncModal()" aria-label="Add or connect coding platform accounts"><i class="bi bi-plus" aria-hidden="true"></i> Add Platform</button>
@@ -218,7 +219,7 @@ body.modal-open {
     <div class="platform-row">
       <span><i class="bi bi-github" style="margin-right:6px" aria-hidden="true"></i>GitHub</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.github_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="https://github.com/{{ user.github_username }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="GitHub profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect GitHub account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.github_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ external_link_badge("https://github.com/" ~ user.github_username, "GitHub", badge_class="", aria_label="GitHub profile (opens in new tab)", icon_only=True, extra_classes="link-out") }}{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect GitHub account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
       </span>
     </div>
   </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -260,6 +260,12 @@ function renderPlatformPrompt() {
   renderEmpty('bi-search-heart', `Type a search term to find ${platform} practice links.`);
 }
 
+function renderExternalLinkBadge({ url, label, color, icon, ariaLabel }) {
+  return `<a class="q-badge ${badgeClass(color)}" href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer" aria-label="${escapeHtml(ariaLabel)}">
+    <i class="bi ${icon}" aria-hidden="true"></i>${escapeHtml(label)}
+  </a>`;
+}
+
 function renderResults(payload) {
   const count = payload.results.length;
   const platforms = payload.requested_platforms || [];
@@ -278,9 +284,13 @@ function renderResults(payload) {
 
   if (!count) {
     const external = (payload.external_searches || []).map(link =>
-      `<a class="q-badge ${badgeClass(link.color)}" href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="Search ${escapeHtml(link.platform)} for your query (opens new tab)">
-        <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>${escapeHtml(link.platform)}
-      </a>`
+      renderExternalLinkBadge({
+        url: link.url,
+        label: link.platform,
+        color: link.color,
+        icon: 'bi-box-arrow-up-right',
+        ariaLabel: `Search ${link.platform} for your query (opens new tab)`,
+      })
     ).join('');
     results.innerHTML = `<div class="empty-search"><i class="bi bi-search-heart" aria-hidden="true"></i><p>No sheet match found.</p><div class="link-row" style="justify-content:center">${external}</div></div>`;
     return;
@@ -288,14 +298,22 @@ function renderResults(payload) {
 
   results.innerHTML = payload.results.map(item => {
     const directLinks = (item.links || []).map(link =>
-      `<a class="q-badge ${badgeClass(link.color)}" href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="View on ${escapeHtml(link.platform)} (opens new tab)">
-        <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>${escapeHtml(link.platform)}
-      </a>`
+      renderExternalLinkBadge({
+        url: link.url,
+        label: link.platform,
+        color: link.color,
+        icon: 'bi-box-arrow-up-right',
+        ariaLabel: `View on ${link.platform} (opens new tab)`,
+      })
     ).join('');
     const platformSearches = (item.external_searches || []).map(link =>
-      `<a class="q-badge ${badgeClass(link.color)}" href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="Search ${escapeHtml(link.platform)} for this problem (opens new tab)">
-        <i class="bi bi-search" aria-hidden="true"></i>${escapeHtml(link.platform)}
-      </a>`
+      renderExternalLinkBadge({
+        url: link.url,
+        label: link.platform,
+        color: link.color,
+        icon: 'bi-search',
+        ariaLabel: `Search ${link.platform} for this problem (opens new tab)`,
+      })
     ).join('');
     const topicUrl = `/topic/${encodeURIComponent(item.topic_id)}`;
 

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros.html" import external_link_badge %}
 {% block content %}
 <style>
 .back-btn { display: inline-flex; align-items: center; gap: 8px; color: var(--text-secondary); text-decoration: none; font-size: 0.85rem; font-weight: 600; margin-bottom: 20px; padding: 7px 14px; border: 1px solid var(--border-color); border-radius: 8px; transition: all 0.2s; }
@@ -167,19 +168,31 @@
                     <div class="q-links">
                         {% if q.url %}
                             {% set p1 = q.url|platform_name %}
-                            <a href="{{ q.url }}" target="_blank" rel="noopener noreferrer"
-                               class="q-badge {% if p1=='LeetCode' %}badge-lc{% elif p1=='GFG' %}badge-gfg{% elif p1=='HackerRank' %}badge-hr{% elif p1=='Coding Ninjas' %}badge-cn{% elif p1=='YouTube' %}badge-yt{% else %}badge-link{% endif %}"
-                               aria-label="Solve on {{ p1 }} (opens in new tab)">
-                               <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i> {{ p1 }}
-                            </a>
+                            {{ external_link_badge(
+                                q.url,
+                                p1,
+                                'badge-lc' if p1=='LeetCode' else
+                                'badge-gfg' if p1=='GFG' else
+                                'badge-hr' if p1=='HackerRank' else
+                                'badge-cn' if p1=='Coding Ninjas' else
+                                'badge-yt' if p1=='YouTube' else
+                                'badge-link',
+                                'Solve on ' ~ p1 ~ ' (opens in new tab)'
+                            ) }}
                         {% endif %}
                         {% if q.url2 %}
                             {% set p2 = q.url2|platform_name %}
-                            <a href="{{ q.url2 }}" target="_blank" rel="noopener noreferrer"
-                               class="q-badge {% if p2=='LeetCode' %}badge-lc{% elif p2=='GFG' %}badge-gfg{% elif p2=='HackerRank' %}badge-hr{% elif p2=='Coding Ninjas' %}badge-cn{% elif p2=='YouTube' %}badge-yt{% else %}badge-link{% endif %}"
-                               aria-label="Solve on {{ p2 }} (opens in new tab)">
-                               <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i> {{ p2 }}
-                            </a>
+                            {{ external_link_badge(
+                                q.url2,
+                                p2,
+                                'badge-lc' if p2=='LeetCode' else
+                                'badge-gfg' if p2=='GFG' else
+                                'badge-hr' if p2=='HackerRank' else
+                                'badge-cn' if p2=='Coding Ninjas' else
+                                'badge-yt' if p2=='YouTube' else
+                                'badge-link',
+                                'Solve on ' ~ p2 ~ ' (opens in new tab)'
+                            ) }}
                         {% endif %}
                     </div>
                 </td>

--- a/tests/test_external_link_badges.py
+++ b/tests/test_external_link_badges.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "templates"
+
+
+def read_template(name: str) -> str:
+    return (TEMPLATE_DIR / name).read_text(encoding="utf-8")
+
+
+def test_external_link_badge_macro_exists_with_safe_rel_attrs():
+    macros = read_template("_macros.html")
+
+    assert "{% macro external_link_badge(" in macros
+    assert 'target="_blank"' in macros
+    assert 'rel="noopener noreferrer"' in macros
+
+
+def test_topic_and_bookmarks_use_external_link_badge_macro():
+    topic = read_template("topic.html")
+    bookmarks = read_template("bookmarks.html")
+
+    assert '{% from "_macros.html" import external_link_badge %}' in topic
+    assert "external_link_badge(" in topic
+    assert '{% from "_macros.html" import external_link_badge %}' in bookmarks
+    assert "external_link_badge(" in bookmarks
+
+
+def test_profile_platform_links_use_external_link_badge_macro():
+    profile = read_template("profile.html")
+
+    assert '{% from "_macros.html" import external_link_badge %}' in profile
+    assert 'extra_classes="link-out"' in profile
+    assert 'icon_only=True' in profile
+
+
+def test_search_template_uses_shared_external_link_badge_renderer():
+    search = read_template("search.html")
+
+    assert "function renderExternalLinkBadge({" in search
+    assert "renderExternalLinkBadge({" in search


### PR DESCRIPTION
## Summary
- add a reusable `external_link_badge` macro in `templates/_macros.html`
- replace duplicated external link badge markup in topic, bookmarks, and profile platform sections
- add a shared renderer for search result/external search badges and cover the new reuse with focused template tests

## Testing
- `python3 -m pytest tests/test_external_link_badges.py tests/test_search_template.py -q`
- Jinja template load check for `topic.html`, `bookmarks.html`, and `profile.html`
- `git diff --check`

Closes #418