### PR TITLE
refactor: normalize button utility classes

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -262,6 +262,74 @@
             gap: 10px;
         }
 
+        .ui-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 6px;
+            border: 1px solid transparent;
+            border-radius: 8px;
+            color: var(--text-secondary);
+            cursor: pointer;
+            font-family: inherit;
+            font-size: 0.82rem;
+            font-weight: 600;
+            line-height: 1.2;
+            text-decoration: none;
+            transition: var(--transition);
+            white-space: nowrap;
+        }
+
+        .ui-btn:hover {
+            text-decoration: none;
+        }
+
+        .ui-btn--primary {
+            background: var(--accent);
+            border-color: var(--accent);
+            color: white;
+        }
+
+        .ui-btn--primary:hover {
+            background: var(--accent-hover);
+            border-color: var(--accent-hover);
+            color: white;
+        }
+
+        .ui-btn--secondary {
+            background: var(--bg-card);
+            border-color: var(--border-color);
+            color: var(--text-secondary);
+        }
+
+        .ui-btn--secondary:hover {
+            border-color: var(--accent);
+            color: var(--accent);
+        }
+
+        .ui-btn--danger {
+            background: none;
+            border-color: #ef4444;
+            color: #ef4444;
+        }
+
+        .ui-btn--danger:hover {
+            background: rgba(239, 68, 68, 0.1);
+            color: #ef4444;
+        }
+
+        .ui-btn--icon {
+            width: 36px;
+            height: 36px;
+            padding: 0;
+            border-radius: 50%;
+        }
+
+        .ui-btn--pill {
+            padding: 6px 14px;
+            border-radius: 50px;
+        }
+
         .pill-btn {
             display: flex;
             align-items: center;
@@ -750,15 +818,15 @@
             <a href="{{ url_for('tracker.index') }}" class="topbar-brand">450 DSA Cracker</a>
         </div>
         <div class="topbar-right">
-            <a href="#" class="pill-btn" id="monthly-rewind-btn" aria-label="Monthly Rewind">
+            <a href="#" class="pill-btn ui-btn ui-btn--pill ui-btn--secondary" id="monthly-rewind-btn" aria-label="Monthly Rewind">
                 <i class="bi bi-rewind-fill" style="color: var(--accent);" aria-hidden="true"></i>
                 <span>Monthly Rewind</span>
             </a>
-            <a href="https://github.com/mohitkumhar/companywise-dsa-interview-question" class="pill-btn accent" id="company-kit-btn" target="_blank" rel="noopener noreferrer">
+            <a href="https://github.com/mohitkumhar/companywise-dsa-interview-question" class="pill-btn accent ui-btn ui-btn--pill ui-btn--primary" id="company-kit-btn" target="_blank" rel="noopener noreferrer">
                 <i class="bi bi-briefcase-fill"></i>
                 <span>Company Wise Kit</span>
             </a>
-            <button class="icon-btn" id="theme-toggle" aria-label="Toggle dark/light theme">
+            <button class="icon-btn ui-btn ui-btn--icon ui-btn--secondary" id="theme-toggle" aria-label="Toggle dark/light theme">
                 <i class="bi bi-moon-fill" id="theme-icon" aria-hidden="true"></i>
             </button>
             {% if current_user.is_authenticated %}
@@ -766,7 +834,7 @@
                 {{ current_user.name[0]|upper }}
             </a>
             {% else %}
-            <a href="{{ url_for('auth.login') }}" class="pill-btn" aria-label="Login">
+            <a href="{{ url_for('auth.login') }}" class="pill-btn ui-btn ui-btn--pill ui-btn--secondary" aria-label="Login">
                 <i class="bi bi-person" aria-hidden="true"></i>
                 <span>Login</span>
             </a>

--- a/templates/bookmarks.html
+++ b/templates/bookmarks.html
@@ -322,7 +322,7 @@
   }
 </style>
 
-<a href="{{ url_for('tracker.index') }}" class="back-btn"><i class="bi bi-arrow-left"></i> Back to Topics</a>
+<a href="{{ url_for('tracker.index') }}" class="back-btn ui-btn ui-btn--secondary"><i class="bi bi-arrow-left"></i> Back to Topics</a>
 <div class="page-title">Bookmarks</div>
 <div class="page-sub">Your saved questions for quick review</div>
 
@@ -362,13 +362,13 @@
           </div>
         </td>
         <td>
-          <button class="action-icon bookmark-btn" data-id="{{ q_id_str }}" data-bookmarked="true"
+          <button class="action-icon ui-btn ui-btn--icon ui-btn--secondary bookmark-btn" data-id="{{ q_id_str }}" data-bookmarked="true"
             aria-label="Remove bookmark for {{ q.problem }}" aria-pressed="true">
             <i class="bi bi-bookmark-fill" aria-hidden="true"></i>
           </button>
         </td>
         <td>
-          <button class="notes-btn-sm {% if p and p.notes %}has-notes{% endif %} notes-btn" data-id="{{ q_id_str }}"
+          <button class="notes-btn-sm ui-btn ui-btn--secondary {% if p and p.notes %}has-notes{% endif %} notes-btn" data-id="{{ q_id_str }}"
             data-notes="{{ p.notes if p and p.notes else '' }}"
             aria-label="{% if p and p.notes %}Edit notes for {{ q.problem }}{% else %}Add notes for {{ q.problem }}{% endif %}">
             <i class="bi bi-journal-text" aria-hidden="true"></i> {% if p and p.notes %}Edit{% else %}Add{% endif %}
@@ -393,8 +393,8 @@
     <textarea class="modal-textarea" id="notesTextarea" placeholder="Write your notes here..." aria-label="Notes"></textarea>
     <input type="hidden" id="currentQuestionId">
     <div class="modal-actions">
-      <button class="btn-cancel" id="modalCancel">Cancel</button>
-      <button class="btn-save" id="saveNotesBtn">Save Notes</button>
+      <button class="btn-cancel ui-btn ui-btn--secondary" id="modalCancel">Cancel</button>
+      <button class="btn-save ui-btn ui-btn--primary" id="saveNotesBtn">Save Notes</button>
     </div>
   </div>
 </div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -114,8 +114,8 @@ body.modal-open {
       @{{ user.leetcode_username or user.github_username or user.name|lower|replace(' ','') }}
       <i class="bi bi-patch-check-fill" style="color:var(--success);font-size:.85rem" aria-hidden="true"></i>
     </div>
-    <button class="card-btn" onclick="showCodelioCard()" aria-label="Get your Codolio profile card">Get your Codolio Card</button>
-    <button class="card-btn" onclick="copyProgressCardUrl()" style="background:#10b981;" aria-label="Share progress image URL">
+    <button class="card-btn ui-btn ui-btn--primary" onclick="showCodelioCard()" aria-label="Get your Codolio profile card">Get your Codolio Card</button>
+    <button class="card-btn ui-btn ui-btn--primary" onclick="copyProgressCardUrl()" style="background:#10b981;border-color:#10b981;" aria-label="Share progress image URL">
       <i class="bi bi-share-fill" style="margin-right:6px" aria-hidden="true"></i> Share Progress (Image)
     </button>
     <div id="progress-card-copy-fallback" style="display:none;margin-top:8px">
@@ -154,7 +154,7 @@ body.modal-open {
         });
       }
     </script>
-    <a class="card-btn" href="{{ url_for('tracker.export_csv') }}" style="background:var(--bg-secondary);border:1px solid var(--border-color);color:var(--text-secondary)" aria-label="Export progress as CSV file">
+    <a class="card-btn ui-btn ui-btn--secondary" href="{{ url_for('tracker.export_csv') }}" aria-label="Export progress as CSV file">
       <i class="bi bi-download" style="margin-right:6px" aria-hidden="true"></i> Export Progress CSV
     </a>
     <div class="prof-bio">{{ user.bio or 'Software Engineer | Problem Solver | DSA Enthusiast' }}</div>
@@ -173,8 +173,8 @@ body.modal-open {
     <div class="meta-row"><i class="bi bi-geo-alt" style="color:var(--accent)" aria-hidden="true"></i> India</div>
     <div class="meta-row"><i class="bi bi-mortarboard" style="color:var(--info)" aria-hidden="true"></i> Computer Science</div>
     {% endif %}
-    <button onclick="openEditProfile()" style="width:100%;margin-top:12px;padding:8px;border:1px solid var(--border-color);border-radius:9px;background:none;color:var(--text-secondary);font-size:.8rem;font-family:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:6px;transition:all .2s" onmouseover="this.style.borderColor='var(--accent)';this.style.color='var(--accent)'" onmouseout="this.style.borderColor='var(--border-color)';this.style.color='var(--text-secondary)'" aria-label="Edit your profile"><i class="bi bi-pencil-square" aria-hidden="true"></i> Edit Profile</button>
-    <button onclick="openDeleteModal()" style="width:100%;margin-top:8px;padding:8px;border:1px solid #ef4444;border-radius:9px;background:none;color:#ef4444;font-size:.8rem;font-family:inherit;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:6px;transition:all .2s" onmouseover="this.style.background='rgba(239,68,68,.1)'" onmouseout="this.style.background='none'" aria-label="Delete your account permanently"><i class="bi bi-trash3" aria-hidden="true"></i> Delete Account</button>
+    <button class="ui-btn ui-btn--secondary" onclick="openEditProfile()" style="width:100%;margin-top:12px;padding:8px;" onmouseover="this.style.borderColor='var(--accent)';this.style.color='var(--accent)'" onmouseout="this.style.borderColor='var(--border-color)';this.style.color='var(--text-secondary)'" aria-label="Edit your profile"><i class="bi bi-pencil-square" aria-hidden="true"></i> Edit Profile</button>
+    <button class="ui-btn ui-btn--danger" onclick="openDeleteModal()" style="width:100%;margin-top:8px;padding:8px;" onmouseover="this.style.background='rgba(239,68,68,.1)'" onmouseout="this.style.background='none'" aria-label="Delete your account permanently"><i class="bi bi-trash3" aria-hidden="true"></i> Delete Account</button>
   </div>
 
   <div class="card">
@@ -213,7 +213,7 @@ body.modal-open {
         {% if user.atcoder_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="https://atcoder.jp/users/{{ user.atcoder_username }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="AtCoder profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect AtCoder account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
       </span>
     </div>
-    <button class="add-btn" onclick="openSyncModal()" aria-label="Add or connect coding platform accounts"><i class="bi bi-plus" aria-hidden="true"></i> Add Platform</button>
+    <button class="add-btn ui-btn ui-btn--secondary" onclick="openSyncModal()" aria-label="Add or connect coding platform accounts"><i class="bi bi-plus" aria-hidden="true"></i> Add Platform</button>
     <div class="sec-title" style="margin-top:14px">Development Stats</div>
     <div class="platform-row">
       <span><i class="bi bi-github" style="margin-right:6px" aria-hidden="true"></i>GitHub</span>

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -89,7 +89,7 @@
 }
 </style>
 
-<a href="{{ url_for('tracker.index') }}" class="back-btn" aria-label="Back to Topics">
+<a href="{{ url_for('tracker.index') }}" class="back-btn ui-btn ui-btn--secondary" aria-label="Back to Topics">
     <i class="bi bi-arrow-left" aria-hidden="true"></i> Back to Topics
 </a>
 
@@ -105,7 +105,7 @@
         </div>
     </div>
     {% if current_user.is_authenticated %}
-    <a href="{{ url_for('tracker.export_topic_notes', topic_id=topic._id|string) }}" class="export-notes-btn" aria-label="Export notes for this topic">
+    <a href="{{ url_for('tracker.export_topic_notes', topic_id=topic._id|string) }}" class="export-notes-btn ui-btn ui-btn--secondary" aria-label="Export notes for this topic">
         <i class="bi bi-download" aria-hidden="true"></i> Export Notes
     </a>
     {% endif %}
@@ -113,22 +113,22 @@
 
 <!-- Filter Buttons with ARIA labels -->
 <div class="filter-buttons" role="group" aria-label="Filter questions by difficulty level">
-    <button class="filter-btn {% if difficulty_filter == 'all' %}active{% endif %}" data-difficulty="all" aria-pressed="{% if difficulty_filter == 'all' %}true{% else %}false{% endif %}">
+    <button class="filter-btn ui-btn ui-btn--pill ui-btn--secondary {% if difficulty_filter == 'all' %}active{% endif %}" data-difficulty="all" aria-pressed="{% if difficulty_filter == 'all' %}true{% else %}false{% endif %}">
         📋 All ({{ total_count }})
     </button>
-    <button class="filter-btn {% if difficulty_filter == 'Easy' %}active{% endif %}" data-difficulty="Easy" aria-pressed="{% if difficulty_filter == 'Easy' %}true{% else %}false{% endif %}">
+    <button class="filter-btn ui-btn ui-btn--pill ui-btn--secondary {% if difficulty_filter == 'Easy' %}active{% endif %}" data-difficulty="Easy" aria-pressed="{% if difficulty_filter == 'Easy' %}true{% else %}false{% endif %}">
         🟢 Easy ({{ easy_count }})
     </button>
-    <button class="filter-btn {% if difficulty_filter == 'Medium' %}active{% endif %}" data-difficulty="Medium" aria-pressed="{% if difficulty_filter == 'Medium' %}true{% else %}false{% endif %}">
+    <button class="filter-btn ui-btn ui-btn--pill ui-btn--secondary {% if difficulty_filter == 'Medium' %}active{% endif %}" data-difficulty="Medium" aria-pressed="{% if difficulty_filter == 'Medium' %}true{% else %}false{% endif %}">
         🟡 Medium ({{ medium_count }})
     </button>
-    <button class="filter-btn {% if difficulty_filter == 'Hard' %}active{% endif %}" data-difficulty="Hard" aria-pressed="{% if difficulty_filter == 'Hard' %}true{% else %}false{% endif %}">
+    <button class="filter-btn ui-btn ui-btn--pill ui-btn--secondary {% if difficulty_filter == 'Hard' %}active{% endif %}" data-difficulty="Hard" aria-pressed="{% if difficulty_filter == 'Hard' %}true{% else %}false{% endif %}">
         🔴 Hard ({{ hard_count }})
     </button>
 </div>
 <!-- Practice Random Button -->
 <div style="margin-bottom: 16px;">
-    <button id="practiceRandomBtn" type="button" class="filter-btn" style="background: var(--accent); color: white; border-color: var(--accent);">
+    <button id="practiceRandomBtn" type="button" class="filter-btn ui-btn ui-btn--pill ui-btn--primary">
         🎲 Practice Random
     </button>
 </div>
@@ -190,7 +190,7 @@
                     </span>
                 </td>
                 <td>
-                    <button class="action-icon bookmark-btn {% if p and p.bookmark %}bookmarked{% endif %}"
+                    <button class="action-icon ui-btn ui-btn--icon ui-btn--secondary bookmark-btn {% if p and p.bookmark %}bookmarked{% endif %}"
                         data-id="{{ q_id_str }}"
                         data-bookmarked="{{ 'true' if p and p.bookmark else 'false' }}"
                         aria-label="{% if p and p.bookmark %}Remove bookmark for '{{ q.problem }}'{% else %}Bookmark '{{ q.problem }}'{% endif %}"
@@ -199,7 +199,7 @@
                     </button>
                 </td>
                 <td>
-                    <button class="notes-btn-sm {% if p and p.notes %}has-notes{% endif %} notes-btn"
+                    <button class="notes-btn-sm ui-btn ui-btn--secondary {% if p and p.notes %}has-notes{% endif %} notes-btn"
                         data-id="{{ q_id_str }}"
                         data-notes="{{ p.notes if p and p.notes else '' }}"
                         aria-label="{% if p and p.notes %}Edit notes for '{{ q.problem }}'{% else %}Add notes for '{{ q.problem }}'{% endif %}">
@@ -214,7 +214,7 @@
                     <p style="margin-bottom: 0.75rem; color: var(--text-muted, #888);">
                         No questions match the selected difficulty.
                     </p>
-                    <button class="filter-btn" data-difficulty="all" onclick="document.querySelector('[data-difficulty=all]').click()" aria-label="Clear filter and show all questions">
+                    <button class="filter-btn ui-btn ui-btn--pill ui-btn--secondary" data-difficulty="all" onclick="document.querySelector('[data-difficulty=all]').click()" aria-label="Clear filter and show all questions">
                         Clear filter &amp; show all
                     </button>
                 </td>
@@ -230,8 +230,8 @@
         <textarea class="modal-textarea" id="notesTextarea" placeholder="Write your notes here..." aria-label="Notes for this question"></textarea>
         <input type="hidden" id="currentQuestionId">
         <div class="modal-actions">
-            <button class="btn-modal-cancel" id="modalCancel" aria-label="Cancel editing notes">Cancel</button>
-            <button class="btn-modal-save" id="saveNotesBtn" aria-label="Save notes">Save Notes</button>
+            <button class="btn-modal-cancel ui-btn ui-btn--secondary" id="modalCancel" aria-label="Cancel editing notes">Cancel</button>
+            <button class="btn-modal-save ui-btn ui-btn--primary" id="saveNotesBtn" aria-label="Save notes">Save Notes</button>
         </div>
     </div>
 </div>

--- a/tests/test_button_utilities.py
+++ b/tests/test_button_utilities.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "templates"
+
+
+def read_template(name: str) -> str:
+    return (TEMPLATE_DIR / name).read_text(encoding="utf-8")
+
+
+def test_base_template_defines_shared_button_utility_classes():
+    base = read_template("base.html")
+
+    assert ".ui-btn {" in base
+    assert ".ui-btn--primary {" in base
+    assert ".ui-btn--secondary {" in base
+    assert ".ui-btn--danger {" in base
+    assert ".ui-btn--icon {" in base
+    assert ".ui-btn--pill {" in base
+
+
+def test_base_topbar_uses_button_utilities():
+    base = read_template("base.html")
+
+    assert 'class="pill-btn ui-btn ui-btn--pill ui-btn--secondary"' in base
+    assert 'class="pill-btn accent ui-btn ui-btn--pill ui-btn--primary"' in base
+    assert 'class="icon-btn ui-btn ui-btn--icon ui-btn--secondary"' in base
+
+
+def test_topic_and_bookmarks_reuse_secondary_icon_and_pill_button_utilities():
+    topic = read_template("topic.html")
+    bookmarks = read_template("bookmarks.html")
+
+    assert 'class="back-btn ui-btn ui-btn--secondary"' in topic
+    assert 'class="export-notes-btn ui-btn ui-btn--secondary"' in topic
+    assert "filter-btn ui-btn ui-btn--pill ui-btn--secondary" in topic
+    assert 'class="action-icon ui-btn ui-btn--icon ui-btn--secondary bookmark-btn' in topic
+    assert 'class="notes-btn-sm ui-btn ui-btn--secondary' in topic
+    assert 'class="back-btn ui-btn ui-btn--secondary"' in bookmarks
+    assert 'class="action-icon ui-btn ui-btn--icon ui-btn--secondary bookmark-btn"' in bookmarks
+    assert 'class="notes-btn-sm ui-btn ui-btn--secondary' in bookmarks
+
+
+def test_profile_reuses_primary_secondary_and_danger_button_utilities():
+    profile = read_template("profile.html")
+
+    assert 'class="card-btn ui-btn ui-btn--primary"' in profile
+    assert 'class="card-btn ui-btn ui-btn--secondary"' in profile
+    assert 'class="ui-btn ui-btn--danger"' in profile
+    assert 'class="add-btn ui-btn ui-btn--secondary"' in profile


### PR DESCRIPTION
## Summary
- add shared utility classes for primary, secondary, danger, icon, and pill buttons in `base.html`
- migrate topbar, topic, bookmarks, and profile controls onto the shared button utility layer
- add focused template coverage so the utility classes stay wired into the main high-traffic templates

## Testing
- `python3 -m pytest tests/test_button_utilities.py -q`
- `python3 -m pytest tests/test_template_link_security.py -q`
- Jinja template load check for `base.html`, `topic.html`, `bookmarks.html`, and `profile.html`
- `git diff --check`

Closes #415