### PR TITLE
chore: split runtime and development deps

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Installing Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install ruff
+          pip install -r requirements-dev.txt
 
       - name: Run Ruff Linting
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest
+          pip install -r requirements-dev.txt
 
       - name: Run unit tests
         run: python -m pytest -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,10 @@ source venv/bin/activate
 
 **2. Install dependencies**
 ```bash
+# Runtime-only install
 pip install -r requirements.txt
 
-# For running tests
+# Development, linting, and test install
 pip install -r requirements-dev.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ venv\Scripts\activate
 source venv/bin/activate
 
 pip install -r requirements.txt
+
+# For development, linting, and tests
+pip install -r requirements-dev.txt
 ```
 
 **2. Configure environment variables**

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,6 @@
+-r requirements.txt
+
+mongomock==4.1.2
 pytest==8.2.2
 pytest-cov==5.0.0
 ruff==0.4.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ Flask-Bcrypt==1.0.1
 flask-bcrypt
 cloudinary==1.39.1
 Pillow==10.3.0
-mongomock==4.1.2
 Flask-Limiter==3.5.0
 redis==5.0.4
 # pyjson5==1.6.2

--- a/tests/test_dependency_manifests.py
+++ b/tests/test_dependency_manifests.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_runtime_requirements_exclude_test_only_packages():
+    runtime = (ROOT / "requirements.txt").read_text(encoding="utf-8")
+
+    assert "mongomock==" not in runtime
+
+
+def test_dev_requirements_extend_runtime_and_include_dev_packages():
+    dev = (ROOT / "requirements-dev.txt").read_text(encoding="utf-8")
+
+    assert dev.startswith("-r requirements.txt")
+    assert "mongomock==" in dev
+    assert "pytest==" in dev
+    assert "ruff==" in dev
+    assert "black==" in dev


### PR DESCRIPTION
## Summary
- move `mongomock` out of `requirements.txt` into `requirements-dev.txt`
- make `requirements-dev.txt` extend runtime requirements so dev/test installs stay complete
- update README, CONTRIBUTING, and CI workflows to install the right dependency set
- add a focused manifest test for the runtime/dev split

## Testing
- `python3 -m pytest tests/test_dependency_manifests.py -q`
- `git diff --check`

Closes #398