### PR TITLE
perf: cancel stale leaderboard fetches

### DIFF
--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -283,6 +283,7 @@ let currentPage = 1;
 let totalPages = 1;
 let currentUserRank = null;
 let isLoading = false;
+let leaderboardController = null;
 
 function escapeHTML(str) {
   if (typeof str !== 'string' && typeof str !== 'number') return '';
@@ -332,15 +333,20 @@ function renderLeaderboardError(error) {
 }
 
 async function loadLeaderboard(page = 1) {
-  if (isLoading) return;
+  if (leaderboardController) leaderboardController.abort();
+
+  const controller = new AbortController();
+  leaderboardController = controller;
   isLoading = true;
   
   document.getElementById('lbBody').innerHTML = '<tr><td colspan="5" class="loading" aria-label="Loading leaderboard data">Loading...</td><tr>';
   
   try {
     const url = `/api/leaderboard?mode=${activeMode}&page=${page}&per_page=20&current_user_id=${CURRENT_USER_ID || ''}`;
-    const response = await fetch(url);
+    const response = await fetch(url, { signal: controller.signal });
     const data = await response.json();
+
+    if (leaderboardController !== controller) return;
 
     if (!response.ok) {
       throw new Error(data.error || data.message || `Leaderboard request failed (${response.status})`);
@@ -357,11 +363,16 @@ async function loadLeaderboard(page = 1) {
     renderTable(data.entries, activeMode);
     renderPagination();
   } catch (error) {
+    if (error.name === 'AbortError') return;
+    if (leaderboardController !== controller) return;
     console.error('Error loading leaderboard:', error);
     renderLeaderboardError(error);
+  } finally {
+    if (leaderboardController === controller) {
+      leaderboardController = null;
+      isLoading = false;
+    }
   }
-  
-  isLoading = false;
 }
 
 function renderTable(entries, mode) {

--- a/tests/test_leaderboard_template.py
+++ b/tests/test_leaderboard_template.py
@@ -21,3 +21,14 @@ def test_leaderboard_error_state_resets_pagination():
     assert "totalPages = 1;" in template
     assert "currentUserRank = null;" in template
     assert "renderPagination();" in template
+
+
+def test_leaderboard_aborts_previous_requests_and_ignores_stale_results():
+    template = LEADERBOARD_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "let leaderboardController = null;" in template
+    assert "if (leaderboardController) leaderboardController.abort();" in template
+    assert "const controller = new AbortController();" in template
+    assert "const response = await fetch(url, { signal: controller.signal });" in template
+    assert "if (leaderboardController !== controller) return;" in template
+    assert "if (error.name === 'AbortError') return;" in template


### PR DESCRIPTION
## Summary
- abort the previous leaderboard fetch before starting a new one
- ignore stale responses that finish after a newer tab/page request takes over
- add focused template checks for the leaderboard abort-controller flow

## Testing
- `python3 -m pytest tests/test_leaderboard_template.py -q`
- `git diff --check`