### PR TITLE
perf: load admin error logs asynchronously

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from bson import ObjectId
-from flask import Blueprint, abort, flash, redirect, render_template, request, url_for
+from flask import Blueprint, abort, flash, jsonify, redirect, render_template, request, url_for
 from flask import session
 from flask_login import current_user, login_required
 
@@ -130,8 +130,6 @@ def dashboard():
     )
 
     stats = _compute_system_stats()
-    logs = _recent_error_logs(max_entries=80)
-
     return render_template(
         "admin/dashboard.html",
         users=users,
@@ -141,8 +139,14 @@ def dashboard():
         total_matching=total_matching,
         total_pages=total_pages,
         stats=stats,
-        logs=logs,
     )
+
+
+@admin_bp.route("/logs", methods=["GET"])
+@login_required
+@admin_required
+def recent_logs():
+    return jsonify({"logs": _recent_error_logs(max_entries=80)})
 
 
 @admin_bp.route("/users/<user_id>/delete", methods=["POST"])

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1,4 +1,70 @@
 (function () {
+    const logArea = document.getElementById("admin-log-area");
+    if (logArea) {
+        const logsUrl = logArea.getAttribute("data-logs-url");
+        const escapeHtml = function (value) {
+            return String(value || "").replace(/[&<>"']/g, function (char) {
+                return {
+                    "&": "&amp;",
+                    "<": "&lt;",
+                    ">": "&gt;",
+                    '"': "&quot;",
+                    "'": "&#39;",
+                }[char];
+            });
+        };
+
+        const renderLogState = function (html, isBusy) {
+            logArea.innerHTML = html;
+            logArea.setAttribute("aria-busy", isBusy ? "true" : "false");
+        };
+
+        const renderLogs = function (entries) {
+            if (!entries.length) {
+                renderLogState(
+                    '<p class="empty-state">No log files found yet. Add app logging to populate this panel.</p>',
+                    false
+                );
+                return;
+            }
+
+                renderLogState(
+                    entries
+                        .map(function (entry) {
+                        const source = escapeHtml(entry.source);
+                        const line = escapeHtml(entry.line);
+                        return '<div class="log-line"><span class="log-source">[' + source + ']</span>' + line + "</div>";
+                    })
+                    .join(""),
+                false
+            );
+        };
+
+        const loadLogs = async function () {
+            try {
+                const response = await fetch(logsUrl, {
+                    headers: { Accept: "application/json" },
+                });
+                const payload = await response.json();
+
+                if (!response.ok || !Array.isArray(payload.logs)) {
+                    throw new Error("Invalid log response");
+                }
+
+                renderLogs(payload.logs);
+            } catch (error) {
+                renderLogState(
+                    '<p class="empty-state">Could not load logs right now. Refresh to try again.</p>',
+                    false
+                );
+            }
+        };
+
+        loadLogs();
+    }
+})();
+
+(function () {
     const modal = document.getElementById("delete-modal");
     if (!modal) {
         return;

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -424,14 +424,8 @@
             </div>
         </div>
 
-        <div class="log-area">
-            {% if logs %}
-                {% for entry in logs %}
-                <div class="log-line"><span class="log-source">[{{ entry.source }}]</span>{{ entry.line }}</div>
-                {% endfor %}
-            {% else %}
-                <p class="empty-state">No log files found yet. Add app logging to populate this panel.</p>
-            {% endif %}
+        <div class="log-area" id="admin-log-area" data-logs-url="{{ url_for('admin.recent_logs') }}" aria-busy="true">
+            <p class="empty-state">Loading recent logs...</p>
         </div>
     </article>
 </section>

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -106,6 +106,57 @@ def test_admin_dashboard_supports_search_and_pagination(monkeypatch):
     assert "Page 1 of 1" in body
 
 
+def test_admin_dashboard_shell_loads_logs_asynchronously(monkeypatch):
+    flask_app, test_db = create_test_app(monkeypatch)
+    admin_id = test_db.user.insert_one(
+        {
+            "name": "Admin",
+            "email": "admin@example.com",
+            "is_admin": True,
+            "progress": {},
+        }
+    ).inserted_id
+    monkeypatch.setattr(
+        admin_routes,
+        "_recent_error_logs",
+        lambda max_entries=80: [{"source": "logs/error.log", "line": "should not render inline"}],
+    )
+
+    with flask_app.test_client() as client:
+        login_as(client, admin_id)
+        response = client.get("/admin")
+
+    body = response.data.decode("utf-8")
+    assert response.status_code == 200
+    assert "Loading recent logs..." in body
+    assert "should not render inline" not in body
+    assert 'data-logs-url="/admin/logs"' in body
+
+
+def test_admin_logs_endpoint_returns_recent_entries(monkeypatch):
+    flask_app, test_db = create_test_app(monkeypatch)
+    admin_id = test_db.user.insert_one(
+        {
+            "name": "Admin",
+            "email": "admin@example.com",
+            "is_admin": True,
+            "progress": {},
+        }
+    ).inserted_id
+    monkeypatch.setattr(
+        admin_routes,
+        "_recent_error_logs",
+        lambda max_entries=80: [{"source": "logs/error.log", "line": "boom"}],
+    )
+
+    with flask_app.test_client() as client:
+        login_as(client, admin_id)
+        response = client.get("/admin/logs")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"logs": [{"source": "logs/error.log", "line": "boom"}]}
+
+
 def test_admin_cannot_delete_self(monkeypatch):
     flask_app, test_db = create_test_app(monkeypatch)
     admin_id = test_db.user.insert_one(


### PR DESCRIPTION
## Summary
- move recent admin log retrieval behind an admin-only JSON endpoint
- render a loading shell on the dashboard and hydrate the log panel after the page loads
- add route tests for the async shell and logs endpoint

## Testing
- `python3 -m pytest tests/test_admin_routes.py -q`
- `node --check static/js/admin.js`
- `git diff --check`