### PR TITLE
perf: configure mongo client timeouts and pool settings

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -27,6 +27,15 @@ def _configure_rate_limit_storage(app, config_class):
         raise RuntimeError("Set RATELIMIT_STORAGE_URI to a persistent backend before running in production.")
 
 
+def _mongo_client_options(app):
+    return {
+        "serverSelectionTimeoutMS": app.config["MONGO_SERVER_SELECTION_TIMEOUT_MS"],
+        "connectTimeoutMS": app.config["MONGO_CONNECT_TIMEOUT_MS"],
+        "maxPoolSize": app.config["MONGO_MAX_POOL_SIZE"],
+        "minPoolSize": app.config["MONGO_MIN_POOL_SIZE"],
+    }
+
+
 def create_app(config_class=None):
     load_dotenv()
 
@@ -62,7 +71,7 @@ def create_app(config_class=None):
         },
     )
 
-    mongo.init_app(app)
+    mongo.init_app(app, **_mongo_client_options(app))
     bcrypt.init_app(app)
     login_manager.init_app(app)
     oauth.init_app(app)

--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,16 @@ def env_flag(name, default=False):
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def env_int(name, default):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        return int(value.strip())
+    except (TypeError, ValueError):
+        return default
+
+
 def current_environment_name():
     for key in ("APP_ENV", "FLASK_ENV", "ENV"):
         value = os.environ.get(key)
@@ -21,6 +31,10 @@ def current_environment_name():
 class BaseConfig:
     SECRET_KEY = "supersecretkey"
     MONGO_URI = "mongodb://localhost:27017/450_dsa"
+    MONGO_SERVER_SELECTION_TIMEOUT_MS = 5000
+    MONGO_CONNECT_TIMEOUT_MS = 5000
+    MONGO_MAX_POOL_SIZE = 20
+    MONGO_MIN_POOL_SIZE = 0
     CACHE_TYPE = "SimpleCache"
     CACHE_DEFAULT_TIMEOUT = 300
     SESSION_COOKIE_HTTPONLY = True
@@ -36,6 +50,22 @@ class BaseConfig:
     def apply_environment_overrides(cls, app):
         app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", cls.SECRET_KEY)
         app.config["MONGO_URI"] = os.environ.get("MONGO_URI", cls.MONGO_URI)
+        app.config["MONGO_SERVER_SELECTION_TIMEOUT_MS"] = env_int(
+            "MONGO_SERVER_SELECTION_TIMEOUT_MS",
+            cls.MONGO_SERVER_SELECTION_TIMEOUT_MS,
+        )
+        app.config["MONGO_CONNECT_TIMEOUT_MS"] = env_int(
+            "MONGO_CONNECT_TIMEOUT_MS",
+            cls.MONGO_CONNECT_TIMEOUT_MS,
+        )
+        app.config["MONGO_MAX_POOL_SIZE"] = env_int(
+            "MONGO_MAX_POOL_SIZE",
+            cls.MONGO_MAX_POOL_SIZE,
+        )
+        app.config["MONGO_MIN_POOL_SIZE"] = env_int(
+            "MONGO_MIN_POOL_SIZE",
+            cls.MONGO_MIN_POOL_SIZE,
+        )
         app.config["SESSION_COOKIE_SAMESITE"] = os.environ.get(
             "SESSION_COOKIE_SAMESITE",
             cls.SESSION_COOKIE_SAMESITE,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def build_test_app(monkeypatch, *, extra_db_targets=(), oauth_clients=None):
         for client_name, client in oauth_clients.items():
             monkeypatch.setattr(auth_routes, client_name, client)
 
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
     monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
 
     flask_app = app_module.create_app()

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -15,7 +15,7 @@ def create_test_app(monkeypatch):
     monkeypatch.setattr(admin_routes, "db", test_db)
     monkeypatch.setattr(auth_routes, "db", test_db)
 
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
     monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
 
     flask_app = app_module.create_app()

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -35,10 +35,15 @@ class FakeDB:
 
 def test_create_app_preserves_routes_and_blueprints(monkeypatch):
     registered_clients = []
+    mongo_init_calls = []
 
     monkeypatch.setenv("MONGO_URI", "mongodb://localhost:27017/450_dsa")
     monkeypatch.setattr(app_module, "db", FakeDB())
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(
+        app_module.mongo,
+        "init_app",
+        lambda flask_app, **kwargs: mongo_init_calls.append(kwargs),
+    )
     monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
@@ -51,7 +56,19 @@ def test_create_app_preserves_routes_and_blueprints(monkeypatch):
     flask_app = app_module.create_app()
 
     assert flask_app.config["MONGO_URI"] == "mongodb://localhost:27017/450_dsa"
+    assert flask_app.config["MONGO_SERVER_SELECTION_TIMEOUT_MS"] == 5000
+    assert flask_app.config["MONGO_CONNECT_TIMEOUT_MS"] == 5000
+    assert flask_app.config["MONGO_MAX_POOL_SIZE"] == 20
+    assert flask_app.config["MONGO_MIN_POOL_SIZE"] == 0
     assert flask_app.config["RATELIMIT_STORAGE_URI"] == "memory://"
+    assert mongo_init_calls == [
+        {
+            "serverSelectionTimeoutMS": 5000,
+            "connectTimeoutMS": 5000,
+            "maxPoolSize": 20,
+            "minPoolSize": 0,
+        }
+    ]
     assert login_manager.login_view == "auth.login"
     assert registered_clients == ["github", "google"]
     assert {"auth", "tracker", "profile", "leaderboard", "search", "admin", "public"} <= set(flask_app.blueprints)
@@ -110,7 +127,7 @@ def test_create_app_sets_secure_session_cookie_defaults(monkeypatch):
     monkeypatch.delenv("FLASK_DEBUG", raising=False)
     monkeypatch.delenv("SESSION_COOKIE_SECURE", raising=False)
     monkeypatch.setattr(app_module, "db", FakeDB())
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
     monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
@@ -128,7 +145,7 @@ def test_create_app_allows_insecure_session_cookie_in_development(monkeypatch):
     monkeypatch.setenv("FLASK_ENV", "development")
     monkeypatch.delenv("SESSION_COOKIE_SECURE", raising=False)
     monkeypatch.setattr(app_module, "db", FakeDB())
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
     monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
@@ -145,7 +162,7 @@ def test_create_app_allows_insecure_session_cookie_in_development(monkeypatch):
 def test_create_app_uses_configured_rate_limit_storage(monkeypatch):
     monkeypatch.setenv("RATELIMIT_STORAGE_URI", "redis://localhost:6379/0")
     monkeypatch.setattr(app_module, "db", FakeDB())
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
     monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
@@ -171,8 +188,13 @@ def test_create_app_requires_persistent_rate_limit_storage_in_production(monkeyp
 
 
 def test_create_app_uses_testing_config_class(monkeypatch):
+    mongo_init_calls = []
     monkeypatch.setattr(app_module, "db", FakeDB())
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(
+        app_module.mongo,
+        "init_app",
+        lambda flask_app, **kwargs: mongo_init_calls.append(kwargs),
+    )
     monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
@@ -183,12 +205,20 @@ def test_create_app_uses_testing_config_class(monkeypatch):
 
     assert flask_app.config["TESTING"] is True
     assert flask_app.config["SESSION_COOKIE_SECURE"] is False
+    assert mongo_init_calls == [
+        {
+            "serverSelectionTimeoutMS": 5000,
+            "connectTimeoutMS": 5000,
+            "maxPoolSize": 20,
+            "minPoolSize": 0,
+        }
+    ]
 
 
 def test_create_app_uses_production_config_class(monkeypatch):
     monkeypatch.setenv("RATELIMIT_STORAGE_URI", "redis://localhost:6379/0")
     monkeypatch.setattr(app_module, "db", FakeDB())
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
     monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
@@ -203,7 +233,7 @@ def test_create_app_uses_production_config_class(monkeypatch):
 
 def test_create_app_uses_development_config_class(monkeypatch):
     monkeypatch.setattr(app_module, "db", FakeDB())
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
     monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
@@ -213,3 +243,38 @@ def test_create_app_uses_development_config_class(monkeypatch):
     flask_app = app_module.create_app(config_class=DevelopmentConfig)
 
     assert flask_app.config["SESSION_COOKIE_SECURE"] is False
+
+
+def test_create_app_allows_mongo_timeout_and_pool_overrides(monkeypatch):
+    mongo_init_calls = []
+
+    monkeypatch.setenv("MONGO_SERVER_SELECTION_TIMEOUT_MS", "1200")
+    monkeypatch.setenv("MONGO_CONNECT_TIMEOUT_MS", "2300")
+    monkeypatch.setenv("MONGO_MAX_POOL_SIZE", "17")
+    monkeypatch.setenv("MONGO_MIN_POOL_SIZE", "3")
+    monkeypatch.setattr(app_module, "db", FakeDB())
+    monkeypatch.setattr(
+        app_module.mongo,
+        "init_app",
+        lambda flask_app, **kwargs: mongo_init_calls.append(kwargs),
+    )
+    monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.limiter, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
+
+    flask_app = app_module.create_app()
+
+    assert flask_app.config["MONGO_SERVER_SELECTION_TIMEOUT_MS"] == 1200
+    assert flask_app.config["MONGO_CONNECT_TIMEOUT_MS"] == 2300
+    assert flask_app.config["MONGO_MAX_POOL_SIZE"] == 17
+    assert flask_app.config["MONGO_MIN_POOL_SIZE"] == 3
+    assert mongo_init_calls == [
+        {
+            "serverSelectionTimeoutMS": 1200,
+            "connectTimeoutMS": 2300,
+            "maxPoolSize": 17,
+            "minPoolSize": 3,
+        }
+    ]

--- a/tests/test_oauth_linking.py
+++ b/tests/test_oauth_linking.py
@@ -109,7 +109,7 @@ def make_app(monkeypatch, db_override):
     monkeypatch.setattr(ext, "db", db_override)
     monkeypatch.setattr(ext.mongo, "db", db_override, raising=False)
 
-    monkeypatch.setattr(ext.mongo, "init_app", lambda a: None)
+    monkeypatch.setattr(ext.mongo, "init_app", lambda a, **kwargs: None)
     monkeypatch.setattr(ext.oauth, "init_app", lambda a: None)
     monkeypatch.setattr(ext.limiter, "init_app", lambda a: None)
     monkeypatch.setattr(ext.cache, "init_app", lambda a: None)


### PR DESCRIPTION
## Summary
- add configurable Mongo client defaults for server selection timeout, connect timeout, and pool sizing
- apply those options at app startup while still allowing MONGO_URI and env overrides to drive configuration
- extend app factory coverage to lock the defaults and override path in place

## Testing
- `python3 -m pytest tests/test_app_factory.py tests/test_admin_routes.py tests/test_oauth_linking.py -q`
- `python3 -m py_compile app/__init__.py app/config.py tests/test_app_factory.py tests/conftest.py tests/test_admin_routes.py tests/test_oauth_linking.py`
- `git diff --check`