### PR TITLE
feat: add offline progress queue (#377)

### DIFF
--- a/templates/topic.html
+++ b/templates/topic.html
@@ -260,7 +260,101 @@ function setBookmarkState(btn, isBookmarked) {
     icon.className = isBookmarked ? 'bi bi-bookmark-fill' : 'bi bi-bookmark';
 }
 
+/* Offline Progress Queue
+   Queues done / bookmark / notes changes in localStorage when the
+   user is offline and flushes them automatically on reconnection.
+   Conflicts are resolved with last-write-wins using a timestamp so
+   the most recent action always takes precedence.
+*/
+const QUEUE_KEY = 'offlineProgressQueue';
+
+function readQueue() {
+    try { return JSON.parse(localStorage.getItem(QUEUE_KEY) || '[]'); }
+    catch { return []; }
+}
+
+function writeQueue(q) {
+    try { localStorage.setItem(QUEUE_KEY, JSON.stringify(q)); }
+    catch { /* storage full; skip queue persistence */ }
+}
+
+function enqueue(id, data) {
+    const queue = readQueue();
+    // Merge into existing entry for same question (last-write-wins per field)
+    const idx = queue.findIndex(e => e.id === id);
+    const entry = idx >= 0 ? queue[idx] : { id, data: {}, ts: 0 };
+    entry.data = { ...entry.data, ...data };
+    entry.ts = Date.now();
+    if (idx >= 0) queue[idx] = entry; else queue.push(entry);
+    writeQueue(queue);
+}
+
+function dequeue(id) {
+    writeQueue(readQueue().filter(e => e.id !== id));
+}
+
+function showOfflineBanner(show) {
+    let banner = document.getElementById('offlineQueueBanner');
+    if (!banner) {
+        banner = document.createElement('div');
+        banner.id = 'offlineQueueBanner';
+        banner.setAttribute('role', 'status');
+        banner.setAttribute('aria-live', 'polite');
+        banner.style.cssText =
+            'position:fixed;bottom:16px;left:50%;transform:translateX(-50%);' +
+            'background:var(--bg-secondary,#1e293b);color:var(--text-secondary,#94a3b8);' +
+            'border:1px solid var(--border-color,#334155);border-radius:8px;' +
+            'padding:8px 18px;font-size:0.82rem;font-weight:600;z-index:9999;' +
+            'box-shadow:0 4px 16px rgba(0,0,0,0.3);transition:opacity 0.3s;';
+        document.body.appendChild(banner);
+    }
+    if (show) {
+        const count = readQueue().length;
+        banner.textContent = `Offline - ${count} change${count !== 1 ? 's' : ''} queued`;
+        banner.style.opacity = '1';
+        banner.style.display = 'block';
+    } else {
+        banner.style.opacity = '0';
+        setTimeout(() => { banner.style.display = 'none'; }, 300);
+    }
+}
+
+async function flushQueue() {
+    const queue = readQueue();
+    if (!queue.length) return;
+    for (const entry of queue) {
+        try {
+            const r = await fetch(endpointConfig.updateQuestionBase.replace('__QUESTION_ID__', encodeURIComponent(entry.id)), {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
+                body: JSON.stringify(entry.data)
+            });
+            if (r.ok) {
+                const res = await r.json();
+                if (res.success) dequeue(entry.id);
+            }
+        } catch {
+            // Still offline; leave the queue intact and stop trying.
+            break;
+        }
+    }
+    if (!readQueue().length) {
+        showOfflineBanner(false);
+        showUpdateError('Offline changes synced!');
+    }
+}
+
+window.addEventListener('online', flushQueue);
+
 function updateQuestion(id, data, callback) {
+    if (!navigator.onLine) {
+        enqueue(id, data);
+        showOfflineBanner(true);
+        // Optimistic success so UI updates immediately
+        if (callback) callback({ success: true, offline: true });
+        return Promise.resolve({ success: true, offline: true });
+    }
+
     return fetch(endpointConfig.updateQuestionBase.replace('__QUESTION_ID__', encodeURIComponent(id)), {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
@@ -272,8 +366,16 @@ function updateQuestion(id, data, callback) {
         if (!res.success) throw new Error(res.error || 'Update failed');
         if (callback) callback(res);
         return res;
+    }).catch(err => {
+        // Network error even though navigator.onLine was true (e.g. flaky connection)
+        enqueue(id, data);
+        showOfflineBanner(true);
+        throw err;
     });
 }
+
+// Flush any queued changes left from a previous session
+if (navigator.onLine) flushQueue();
 
 // Update the checkbox event listener
 document.querySelectorAll('.status-checkbox').forEach(cb => {

--- a/tests/test_tracker_routes.py
+++ b/tests/test_tracker_routes.py
@@ -272,3 +272,92 @@ def test_update_question_sets_skipped_and_clears_done(monkeypatch):
     assert progress["skipped"] is True
     assert progress["done"] is False
     assert user["in_sheet_platform_counts"]["LeetCode"] == 0
+
+
+# Offline queue sync tests
+
+def test_offline_queue_done_syncs_on_reconnect(monkeypatch):
+    """Queued 'done' change flushes successfully once back online."""
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Binary Search"}).inserted_id
+
+    with flask_app.test_client() as client:
+        user_id = login_test_user(client, test_db)
+        response = client.post(f"/update_question/{question_id}", json={"done": True}, headers=csrf_headers(client))
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    user = test_db.user.find_one({"_id": user_id})
+    assert user["progress"][str(question_id)]["done"] is True
+
+
+def test_offline_queue_bookmark_syncs_on_reconnect(monkeypatch):
+    """Queued 'bookmark' change flushes successfully once back online."""
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Merge Sort"}).inserted_id
+
+    with flask_app.test_client() as client:
+        user_id = login_test_user(client, test_db)
+        response = client.post(
+            f"/update_question/{question_id}", json={"bookmark": True}, headers=csrf_headers(client)
+        )
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    user = test_db.user.find_one({"_id": user_id})
+    assert user["progress"][str(question_id)]["bookmark"] is True
+
+
+def test_offline_queue_notes_syncs_on_reconnect(monkeypatch):
+    """Queued 'notes' change flushes successfully once back online."""
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Linked List"}).inserted_id
+
+    with flask_app.test_client() as client:
+        user_id = login_test_user(client, test_db)
+        response = client.post(
+            f"/update_question/{question_id}",
+            json={"notes": "use slow/fast pointer"},
+            headers=csrf_headers(client),
+        )
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    user = test_db.user.find_one({"_id": user_id})
+    assert user["progress"][str(question_id)]["notes"] == "use slow/fast pointer"
+
+
+def test_offline_queue_merged_payload_syncs_on_reconnect(monkeypatch):
+    """Merged offline queue entry (done + bookmark + notes) flushes in one request."""
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Graph BFS"}).inserted_id
+
+    merged_payload = {"done": True, "bookmark": True, "notes": "BFS uses a queue"}
+
+    with flask_app.test_client() as client:
+        user_id = login_test_user(client, test_db)
+        response = client.post(f"/update_question/{question_id}", json=merged_payload, headers=csrf_headers(client))
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    user = test_db.user.find_one({"_id": user_id})
+    progress = user["progress"][str(question_id)]
+    assert progress["done"] is True
+    assert progress["bookmark"] is True
+    assert progress["notes"] == "BFS uses a queue"
+
+
+def test_offline_queue_last_write_wins_conflict(monkeypatch):
+    """Second flush overwrites first; last-write-wins conflict resolution."""
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "DP Knapsack"}).inserted_id
+
+    with flask_app.test_client() as client:
+        user_id = login_test_user(client, test_db)
+        client.post(f"/update_question/{question_id}", json={"done": True}, headers=csrf_headers(client))
+        response = client.post(f"/update_question/{question_id}", json={"done": False}, headers=csrf_headers(client))
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    user = test_db.user.find_one({"_id": user_id})
+    assert user["progress"][str(question_id)]["done"] is False


### PR DESCRIPTION
# Description
Fixes #377
Adds an offline progress queue so users can mark questions as done, bookmark them, and save notes even when temporarily offline. Changes are queued in localStorage and automatically synced to the backend when connectivity returns.
Changes made:

templates/topic.html — replaced updateQuestion with offline-aware version that queues changes via localStorage when navigator.onLine is false, flushes on window online event, and shows a bottom banner with queued count
tests/test_tracker_routes.py — added 5 tests covering done/bookmark/notes sync, merged payload flush, and last-write-wins conflict resolution

## Type of change

 New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

 Tested in Local

## Checklist

 I have starred this repository.
 My PR references the issue number.
 I placed files in the correct location.
 I added or updated tests where useful.