### PR TITLE
Cleanup: Centralize platform metadata (#395)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -173,6 +173,19 @@ def create_app(config_class=None):
             init_db()
             app._db_initialized = True
 
+    from app.platforms.metadata import PLATFORM_META
+
+    @app.template_filter("platform_badge")
+    def platform_badge_filter(name):
+        meta = PLATFORM_META.get(name)
+        if meta:
+            return meta["badge_class"]
+        return "badge-link"
+
+    @app.context_processor
+    def inject_platform_metadata():
+        return {"PLATFORM_META": PLATFORM_META}
+
     @app.before_request
     def start_route_timer():
         if request.endpoint in ROUTE_TIMING_ENDPOINTS:

--- a/app/platforms/metadata.py
+++ b/app/platforms/metadata.py
@@ -1,0 +1,86 @@
+PLATFORM_META = {
+    "LeetCode": {
+        "id": "leetcode",
+        "name": "LeetCode",
+        "aliases": ("lc", "leetcode", "leet code"),
+        "domains": ["leetcode.com"],
+        "color_class": "warning text-dark",
+        "badge_class": "badge-lc",
+        "brand_color": "#ffb800",
+        "icon_class": "bi-code-slash",
+        "profile_url_template": "https://leetcode.com/{username}",
+        "search_url": "https://duckduckgo.com/?q=site%3Aleetcode.com%2Fproblems+{query}"
+    },
+    "GFG": {
+        "id": "gfg",
+        "name": "GFG",
+        "aliases": ("gfg", "geeksforgeeks", "geeks for geeks"),
+        "domains": ["geeksforgeeks.org"],
+        "color_class": "success",
+        "badge_class": "badge-gfg",
+        "brand_color": "#22c55e",
+        "icon_class": "bi-braces",
+        "profile_url_template": "https://www.geeksforgeeks.org/user/{username}",
+        "search_url": "https://duckduckgo.com/?q=site%3Ageeksforgeeks.org%2Fproblems+{query}"
+    },
+    "Coding Ninjas": {
+        "id": "cn",
+        "name": "Coding Ninjas",
+        "aliases": ("cn", "coding ninjas", "codingninjas", "code360", "naukri code360"),
+        "domains": ["codingninjas.com", "naukri.com/code360"],
+        "color_class": "danger",
+        "badge_class": "badge-cn",
+        "brand_color": "#8b5cf6",
+        "icon_class": "bi-lightning-charge",
+        "profile_url_template": "https://www.naukri.com/code360/profile/{username}",
+        "search_url": "https://duckduckgo.com/?q=%28site%3Anaukri.com%2Fcode360%2Fproblems+OR+site%3Acodingninjas.com%2Fcodestudio%2Fproblems%29+{query}"
+    },
+    "HackerRank": {
+        "id": "hackerrank",
+        "name": "HackerRank",
+        "aliases": ("hr", "hackerrank", "hacker rank"),
+        "domains": ["hackerrank.com"],
+        "color_class": "success",
+        "badge_class": "badge-hr",
+        "brand_color": "#00bd6c",
+        "icon_class": "bi-terminal",
+        "profile_url_template": "https://www.hackerrank.com/{username}",
+        "search_url": "https://duckduckgo.com/?q=site%3Ahackerrank.com%2Fchallenges+{query}"
+    },
+    "YouTube": {
+        "id": "youtube",
+        "name": "YouTube",
+        "aliases": ("yt", "youtube"),
+        "domains": ["youtube.com", "youtu.be"],
+        "color_class": "danger",
+        "badge_class": "badge-yt",
+        "brand_color": "#ff0000",
+        "icon_class": "bi-youtube",
+        "profile_url_template": "",
+        "search_url": ""
+    },
+    "AtCoder": {
+        "id": "atcoder",
+        "name": "AtCoder",
+        "aliases": ("atcoder",),
+        "domains": ["atcoder.jp"],
+        "color_class": "primary",
+        "badge_class": "badge-link",
+        "brand_color": "#f97316",
+        "icon_class": "bi-trophy",
+        "profile_url_template": "https://atcoder.jp/users/{username}",
+        "search_url": ""
+    },
+    "GitHub": {
+        "id": "github",
+        "name": "GitHub",
+        "aliases": ("github", "gh"),
+        "domains": ["github.com"],
+        "color_class": "primary",
+        "badge_class": "badge-link",
+        "brand_color": "",
+        "icon_class": "bi-github",
+        "profile_url_template": "https://github.com/{username}",
+        "search_url": ""
+    }
+}

--- a/app/search/service.py
+++ b/app/search/service.py
@@ -6,28 +6,7 @@ from bson import ObjectId
 from app.extensions import db
 
 
-PLATFORM_SEARCHES = {
-    "LeetCode": {
-        "aliases": ("lc", "leetcode", "leet code"),
-        "color": "lc",
-        "url": "https://duckduckgo.com/?q=site%3Aleetcode.com%2Fproblems+{query}",
-    },
-    "GFG": {
-        "aliases": ("gfg", "geeksforgeeks", "geeks for geeks"),
-        "color": "gfg",
-        "url": "https://duckduckgo.com/?q=site%3Ageeksforgeeks.org%2Fproblems+{query}",
-    },
-    "Coding Ninjas": {
-        "aliases": ("cn", "coding ninjas", "codingninjas", "code360", "naukri code360"),
-        "color": "cn",
-        "url": "https://duckduckgo.com/?q=%28site%3Anaukri.com%2Fcode360%2Fproblems+OR+site%3Acodingninjas.com%2Fcodestudio%2Fproblems%29+{query}",
-    },
-    "HackerRank": {
-        "aliases": ("hr", "hackerrank", "hacker rank"),
-        "color": "hr",
-        "url": "https://duckduckgo.com/?q=site%3Ahackerrank.com%2Fchallenges+{query}",
-    },
-}
+from app.platforms.metadata import PLATFORM_META
 
 
 def parse_search_query(raw_query):
@@ -36,7 +15,9 @@ def parse_search_query(raw_query):
     query_l = query.lower()
     requested_platforms = []
 
-    for platform, meta in PLATFORM_SEARCHES.items():
+    for platform_name, meta in PLATFORM_META.items():
+        if not meta.get("search_url"):
+            continue
         platform_requested = False
         for alias in meta["aliases"]:
             pattern = r"(?<![a-z0-9])" + re.escape(alias) + r"(?![a-z0-9])"
@@ -45,7 +26,7 @@ def parse_search_query(raw_query):
                 query = re.sub(pattern, " ", query, flags=re.IGNORECASE)
                 query_l = query.lower()
         if platform_requested:
-            requested_platforms.append(platform)
+            requested_platforms.append(platform_name)
 
     cleaned = re.sub(r"\s+", " ", query).strip()
     return cleaned, requested_platforms
@@ -56,16 +37,17 @@ def tokenize_search_text(value):
 
 
 def build_external_searches(query, requested_platforms=None):
-    platforms = requested_platforms or list(PLATFORM_SEARCHES.keys())
+    searchable_platforms = [p for p, m in PLATFORM_META.items() if m.get("search_url")]
+    platforms = requested_platforms or searchable_platforms
     encoded = quote_plus(query)
     return [
         {
             "platform": platform,
-            "url": PLATFORM_SEARCHES[platform]["url"].format(query=encoded),
-            "color": PLATFORM_SEARCHES[platform]["color"],
+            "url": PLATFORM_META[platform]["search_url"].format(query=encoded),
+            "color": platform_badge_id(platform),
         }
         for platform in platforms
-        if platform in PLATFORM_SEARCHES and query
+        if platform in PLATFORM_META and PLATFORM_META[platform].get("search_url") and query
     ]
 
 
@@ -105,7 +87,7 @@ def question_links(question):
             {
                 "platform": platform,
                 "url": url,
-                "color": PLATFORM_SEARCHES.get(platform, {}).get("color", "link"),
+                "color": platform_badge_id(platform),
             }
         )
     return links
@@ -115,18 +97,28 @@ def question_editorial_links(question):
     return normalize_editorial_links(question.get("editorial_links") or question.get("editorials"))
 
 
+def platform_badge_id(platform):
+    badge_class = PLATFORM_META.get(platform, {}).get("badge_class", "badge-link")
+    return badge_class.removeprefix("badge-")
+
+
 PLATFORM_FILTER_MAP = {
-    "lc": "LeetCode",
-    "gfg": "GFG",
-    "cn": "Coding Ninjas",
-    "hr": "HackerRank",
+    meta["id"]: name
+    for name, meta in PLATFORM_META.items()
+    if meta.get("search_url")
 }
+PLATFORM_FILTER_MAP.update(
+    {
+        platform_badge_id(name): name
+        for name, meta in PLATFORM_META.items()
+        if meta.get("search_url")
+    }
+)
 
 PLATFORM_URL_KEYWORDS = {
-    "LeetCode": "leetcode.com",
-    "GFG": "geeksforgeeks.org",
-    "Coding Ninjas": "codingninjas.com",
-    "HackerRank": "hackerrank.com",
+    name: "|".join(re.escape(domain) for domain in meta["domains"])
+    for name, meta in PLATFORM_META.items()
+    if meta.get("search_url") and meta.get("domains")
 }
 
 DIFFICULTY_FILTERS = {
@@ -266,14 +258,10 @@ def platform_name_filter(url):
     if not url:
         return None
     url = url.lower()
-    if "leetcode.com" in url:
-        return "LeetCode"
-    if "geeksforgeeks.org" in url:
-        return "GFG"
-    if "codingninjas.com" in url or "naukri.com/code360" in url:
-        return "Coding Ninjas"
-    if "youtube.com" in url or "youtu.be" in url:
-        return "YouTube"
-    if "hackerrank.com" in url:
-        return "HackerRank"
+    for meta in PLATFORM_META.values():
+        for domain in meta["domains"]:
+            if domain in url:
+                return meta["name"]
     return "Link"
+
+

--- a/app/utils.py
+++ b/app/utils.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from flask import jsonify
 
 from app.extensions import db
+from app.platforms.metadata import PLATFORM_META
 from app.search import service as search_service
 
 
@@ -46,21 +47,14 @@ def normalize_coding_ninjas_profile_id(value):
         return match.group(1).strip()
     return value.rstrip("/").split("/")[-1].strip()
 
-
 def platform_name_filter(url):
     if not url:
         return None
     url = url.lower()
-    if "leetcode.com" in url:
-        return "LeetCode"
-    if "geeksforgeeks.org" in url:
-        return "GFG"
-    if "codingninjas.com" in url or "naukri.com/code360" in url:
-        return "Coding Ninjas"
-    if "youtube.com" in url or "youtu.be" in url:
-        return "YouTube"
-    if "hackerrank.com" in url:
-        return "HackerRank"
+    for meta in PLATFORM_META.values():
+        for domain in meta["domains"]:
+            if domain in url:
+                return meta["name"]
     return "Link"
 
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -301,26 +301,12 @@
       <div class="donut-inner">{{ global_total_solved }}</div>
     </div>
     <div>
+      {% for name in ['LeetCode', 'GFG', 'Coding Ninjas', 'HackerRank', 'AtCoder'] %}
       <div class="legend-item">
-        <span><span class="legend-dot" style="background:#ffb800"></span><span style="color:#ffb800;font-weight:700">LeetCode</span></span>
-        <strong>{{ platforms['LeetCode'] }}</strong>
+        <span><span class="legend-dot" style="background:{{ PLATFORM_META[name].brand_color }}"></span><span style="color:{{ PLATFORM_META[name].brand_color }};font-weight:700">{{ name }}</span></span>
+        <strong>{{ platforms[name] }}</strong>
       </div>
-      <div class="legend-item">
-        <span><span class="legend-dot" style="background:#22c55e"></span><span style="color:#22c55e;font-weight:700">GFG</span></span>
-        <strong>{{ platforms['GFG'] }}</strong>
-      </div>
-      <div class="legend-item">
-        <span><span class="legend-dot" style="background:#8b5cf6"></span><span style="color:#8b5cf6;font-weight:700">Coding Ninjas</span></span>
-        <strong>{{ platforms['Coding Ninjas'] }}</strong>
-      </div>
-      <div class="legend-item">
-        <span><span class="legend-dot" style="background:#00bd6c"></span><span style="color:#00bd6c;font-weight:700">HackerRank</span></span>
-        <strong>{{ platforms['HackerRank'] }}</strong>
-      </div>
-      <div class="legend-item">
-        <span><span class="legend-dot" style="background:#f97316"></span><span style="color:#f97316;font-weight:700">AtCoder</span></span>
-        <strong>{{ platforms['AtCoder'] }}</strong>
-      </div>
+      {% endfor %}
       <div class="legend-item">
         <span><span class="legend-dot" style="background:#6c757d"></span><span style="color:#6c757d;font-weight:700">Other</span></span>
         <strong>{{ platforms['Other'] }}</strong>
@@ -666,7 +652,7 @@ const cumData = {{ cumulative_data | tojson }};
 const pData = {{ platforms | tojson }};
 const chartShells=['progressChartShell','platformsChartShell','difficultyChartShell'].map(i=>document.getElementById(i)).filter(Boolean);let chartJsPromise;
 function loadChartJs(){return window.Chart?Promise.resolve(window.Chart):chartJsPromise||(chartJsPromise=new Promise((ok,bad)=>{let add=(src,err)=>{let s=document.createElement('script');s.src=src;s.async=true;s.onload=()=>ok(window.Chart);s.onerror=err||bad;document.head.appendChild(s)};add('https://cdn.jsdelivr.net/npm/chart.js',()=>add('https://unpkg.com/chart.js@4/dist/chart.umd.js'))}))}
-function renderProfileCharts(){loadChartJs().then(()=>{let c=document.getElementById('progressChart'),d=ratingHistory.length?ratingHistory:cumData;if(d.length&&c)new Chart(c,{type:'line',data:{labels:d.map(x=>x.x),datasets:[{data:d.map(x=>x.y),borderColor:'#f68b24',backgroundColor:'rgba(246,139,36,.15)',borderWidth:2,fill:true,tension:.4,pointRadius:ratingHistory.length?3:0,pointHoverRadius:5,pointBackgroundColor:'#f68b24'}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}},scales:{x:{grid:{display:false},ticks:{color:'#888',maxTicksLimit:5,font:{size:10}}},y:{grid:{color:'rgba(255,255,255,.05)'},ticks:{color:'#888',font:{size:10}}}}}});else if(c){let x=c.getContext('2d');x.fillStyle='#555';x.font='13px Inter, sans-serif';x.textAlign='center';x.fillText('Sync LeetCode to see rating chart',c.width/2,c.height/2-8)}markChartReady('progressChartShell');[['platformsChart','platformsChartShell',['LeetCode','GFG','Coding Ninjas','HackerRank','Other'],[pData.LeetCode,pData.GFG,pData['Coding Ninjas'],pData.HackerRank,pData.Other],['#ffb800','#22c55e','#8b5cf6','#00bd6c','#6c757d']],['difficultyChart','difficultyChartShell',['Easy','Medium','Hard'],[{{lc_easy}},{{lc_medium}},{{lc_hard}}],['#00b8a3','#ffc01e','#ff375f']]].forEach(a=>{try{new Chart(document.getElementById(a[0]),{type:'doughnut',data:{labels:a[2],datasets:[{data:a[3],backgroundColor:a[4],borderWidth:0,cutout:'78%'}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}}}})}catch(e){}markChartReady(a[1])})}).catch(()=>chartShells.forEach(s=>s.classList.add('is-ready')))}
+function renderProfileCharts(){loadChartJs().then(()=>{let c=document.getElementById('progressChart'),d=ratingHistory.length?ratingHistory:cumData;if(d.length&&c)new Chart(c,{type:'line',data:{labels:d.map(x=>x.x),datasets:[{data:d.map(x=>x.y),borderColor:'#f68b24',backgroundColor:'rgba(246,139,36,.15)',borderWidth:2,fill:true,tension:.4,pointRadius:ratingHistory.length?3:0,pointHoverRadius:5,pointBackgroundColor:'#f68b24'}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}},scales:{x:{grid:{display:false},ticks:{color:'#888',maxTicksLimit:5,font:{size:10}}},y:{grid:{color:'rgba(255,255,255,.05)'},ticks:{color:'#888',font:{size:10}}}}}});else if(c){let x=c.getContext('2d');x.fillStyle='#555';x.font='13px Inter, sans-serif';x.textAlign='center';x.fillText('Sync LeetCode to see rating chart',c.width/2,c.height/2-8)}markChartReady('progressChartShell');[['platformsChart','platformsChartShell',['LeetCode','GFG','Coding Ninjas','HackerRank','Other'],[pData.LeetCode,pData.GFG,pData['Coding Ninjas'],pData.HackerRank,pData.Other],['{{ PLATFORM_META["LeetCode"].brand_color }}','{{ PLATFORM_META["GFG"].brand_color }}','{{ PLATFORM_META["Coding Ninjas"].brand_color }}','{{ PLATFORM_META["HackerRank"].brand_color }}','#6c757d']],['difficultyChart','difficultyChartShell',['Easy','Medium','Hard'],[{{lc_easy}},{{lc_medium}},{{lc_hard}}],['#00b8a3','#ffc01e','#ff375f']]].forEach(a=>{try{new Chart(document.getElementById(a[0]),{type:'doughnut',data:{labels:a[2],datasets:[{data:a[3],backgroundColor:a[4],borderWidth:0,cutout:'78%'}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}}}})}catch(e){}markChartReady(a[1])})}).catch(()=>chartShells.forEach(s=>s.classList.add('is-ready')))}
 if('IntersectionObserver'in window&&chartShells.length){const io=new IntersectionObserver((e,o)=>{if(e.some(x=>x.isIntersecting)){o.disconnect();renderProfileCharts()}},{rootMargin:'160px'});chartShells.forEach(s=>io.observe(s))}else renderProfileCharts();
 
 function openSyncModal(){document.getElementById('syncModal').classList.add('open')}

--- a/templates/search.html
+++ b/templates/search.html
@@ -224,11 +224,7 @@
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
-.badge-lc { background: rgba(255,184,0,0.15); color: #ffb800; border: 1px solid rgba(255,184,0,0.25); }
-.badge-gfg { background: rgba(34,197,94,0.15); color: var(--success); border: 1px solid rgba(34,197,94,0.25); }
-.badge-cn { background: rgba(239,68,68,0.15); color: var(--danger); border: 1px solid rgba(239,68,68,0.25); }
-.badge-hr { background: rgba(0,189,108,0.15); color: #00bd6c; border: 1px solid rgba(0,189,108,0.25); }
-.badge-link { background: rgba(99,102,241,0.15); color: #818cf8; border: 1px solid rgba(99,102,241,0.25); }
+
 .result-actions { display: flex; align-items: flex-start; gap: 8px; }
 .topic-open {
   width: 36px;
@@ -282,10 +278,11 @@
     </div>
     <div class="platform-row" role="group" aria-label="Filter search results by coding platform">
       <button class="platform-chip" type="button" data-token="" aria-label="Show all platforms">All</button>
-      <button class="platform-chip" type="button" data-token="leetcode" aria-label="Filter to LeetCode only">LeetCode</button>
-      <button class="platform-chip" type="button" data-token="gfg" aria-label="Filter to GeeksForGeeks only">GFG</button>
-      <button class="platform-chip" type="button" data-token="cn" aria-label="Filter to Coding Ninjas only">Coding Ninjas</button>
-      <button class="platform-chip" type="button" data-token="hackerrank" aria-label="Filter to HackerRank only">HackerRank</button>
+      {% for name, meta in PLATFORM_META.items() %}
+      {% if meta.search_url %}
+      <button class="platform-chip" type="button" data-token="{{ meta.id }}" aria-label="Filter to {{ name }} only">{{ name }}</button>
+      {% endif %}
+      {% endfor %}
     </div>
     <div class="filter-row" role="group" aria-label="Additional search filters">
       <select id="filterTopic" class="filter-select" aria-label="Filter by topic">
@@ -302,10 +299,11 @@
       </select>
       <select id="filterPlatform" class="filter-select" aria-label="Filter by result platform">
         <option value="">All Platforms</option>
-        <option value="lc">LeetCode</option>
-        <option value="gfg">GFG</option>
-        <option value="cn">Coding Ninjas</option>
-        <option value="hr">HackerRank</option>
+        {% for name, meta in PLATFORM_META.items() %}
+        {% if meta.search_url %}
+        <option value="{{ meta.id }}">{{ name }}</option>
+        {% endif %}
+        {% endfor %}
       </select>
       {% if current_user.is_authenticated %}
       <select id="filterStatus" class="filter-select" aria-label="Filter by completion status">

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -161,7 +161,7 @@
                         {% if q.url %}
                             {% set p1 = q.url|platform_name %}
                             <a href="{{ q.url }}" target="_blank" rel="noopener noreferrer"
-                               class="q-badge {% if p1=='LeetCode' %}badge-lc{% elif p1=='GFG' %}badge-gfg{% elif p1=='HackerRank' %}badge-hr{% elif p1=='Coding Ninjas' %}badge-cn{% elif p1=='YouTube' %}badge-yt{% else %}badge-link{% endif %}"
+                               class="q-badge {{ p1 | platform_badge }}"
                                aria-label="Solve on {{ p1 }} (opens in new tab)">
                                <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i> {{ p1 }}
                             </a>
@@ -169,7 +169,7 @@
                         {% if q.url2 %}
                             {% set p2 = q.url2|platform_name %}
                             <a href="{{ q.url2 }}" target="_blank" rel="noopener noreferrer"
-                               class="q-badge {% if p2=='LeetCode' %}badge-lc{% elif p2=='GFG' %}badge-gfg{% elif p2=='HackerRank' %}badge-hr{% elif p2=='Coding Ninjas' %}badge-cn{% elif p2=='YouTube' %}badge-yt{% else %}badge-link{% endif %}"
+                               class="q-badge {{ p2 | platform_badge }}"
                                aria-label="Solve on {{ p2 }} (opens in new tab)">
                                <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i> {{ p2 }}
                             </a>


### PR DESCRIPTION
Centralize platform metadata and color definitions #395

### Description
This PR resolves issue #395 by centralizing platform names, aliases, colors, URL patterns, and badge classes into a single source of truth (`app/platforms/metadata.py`).

#### Changes Made:
- **Centralized Metadata**: Created `PLATFORM_META` in `app/platforms/metadata.py` as a single dictionary containing properties for all platforms.
- **Backend Refactoring**: 
  - Updated `app/utils.py` helpers (`platform_name_filter`, `platform_color_filter`, `platform_profile_url`) to dynamically read from `PLATFORM_META`.
  - Updated `app/search/service.py` to use `PLATFORM_META` for building external searches and parsing query aliases, replacing the hardcoded `PLATFORM_SEARCHES`.
- **Template Context Injection**: Added `PLATFORM_META` to the global Jinja template context in `app/__init__.py` and introduced a new `platform_badge` filter.
- **Template Refactoring**: 
  - Updated `templates/search.html` to dynamically generate platform filter chips and javascript badge classes based on `PLATFORM_META`.
  - Cleaned up `templates/topic.html` to use the `platform_badge` filter instead of complex inline if/else logic.
  - Refactored `templates/profile.html` to generate platform legends and chart colors dynamically using `PLATFORM_META.brand_color`.

### Related Issue
Closes #395

### Type of Change
- [ ] Bug fix
- [x] Refactor (code cleanup without changing functionality)
- [ ] New feature

### Testing Checklist
- [x] Verified that syntax and application tests pass.
- [x] Inspected topic badges, search chips, and profile chart colors directly.
