### PR TITLE
chore: normalize template encoding artifacts

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -187,7 +187,7 @@
             }
         }
 
-        /* ─── Left Sidebar ─── */
+        /* Left Sidebar */
         .sidebar {
             position: fixed;
             left: 0;
@@ -287,7 +287,7 @@
             padding-bottom: 8px;
         }
 
-        /* ─── Top Bar ─── */
+        /* Top Bar */
         .topbar {
             position: fixed;
             top: 0;
@@ -406,7 +406,7 @@
             text-decoration: none;
         }
 
-        /* ─── Main Content ─── */
+        /* Main Content */
         .main-wrapper {
             margin-left: var(--sidebar-width);
             margin-top: var(--topbar-height);
@@ -414,7 +414,7 @@
             padding: 24px;
         }
 
-        /* ─── Cards ─── */
+        /* Cards */
         .card-dark {
             background: var(--bg-card);
             border: 1px solid var(--border-color);
@@ -449,7 +449,7 @@
             color: var(--text-secondary);
         }
 
-        /* ─── Toast Notifications - TOP RIGHT ─── */
+        /* Toast Notifications - Top Right */
         .toast-container {
             position: fixed;
             top: calc(var(--topbar-height) + 12px);
@@ -597,7 +597,7 @@
             }
         }
 
-        /* ─── Footer ─── */
+        /* Footer */
         .site-footer {
             background: var(--bg-secondary);
             border-top: 1px solid var(--border-color);
@@ -656,7 +656,7 @@
             font-size: 0.78rem;
         }
 
-        /* ─── Scrollbars ─── */
+        /* Scrollbars */
         ::-webkit-scrollbar {
             width: 6px;
             height: 6px;
@@ -675,7 +675,7 @@
             background: #444;
         }
 
-        /* ─── Mobile Responsive ─── */
+        /* Mobile Responsive */
         @media (max-width: 768px) {
             .sidebar {
                 bottom: 0;
@@ -757,7 +757,7 @@
     <!-- Skip to main content link - Accessibility -->
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <!-- ─── Left Sidebar ─── -->
+    <!-- Left Sidebar -->
     <aside class="sidebar" role="navigation" aria-label="Main navigation">
         <a href="{{ url_for('tracker.index') }}" class="sidebar-logo" title="450 DSA" aria-label="Home">D</a>
         <nav class="sidebar-nav">
@@ -810,7 +810,7 @@
         </div>
     </aside>
 
-    <!-- ─── Top Bar ─── -->
+    <!-- Top Bar -->
     <header class="topbar" role="banner">
         <div class="topbar-left">
             <a href="{{ url_for('tracker.index') }}" class="topbar-brand">450 DSA Cracker</a>
@@ -840,10 +840,10 @@
         </div>
     </header>
 
-    <!-- ─── Toast Container (TOP RIGHT) ─── -->
+    <!-- Toast Container (Top Right) -->
     <div class="toast-container" id="toastContainer" role="status" aria-live="polite"></div>
 
-    <!-- ─── Flash Messages (legacy) ─── -->
+    <!-- Flash Messages (Legacy) -->
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
     <div class="flash-messages" id="flash-container" role="alert" aria-live="polite">
@@ -857,12 +857,12 @@
     {% endif %}
     {% endwith %}
 
-    <!-- ─── Main Content ─── -->
+    <!-- Main Content -->
     <main class="main-wrapper" id="main-content" tabindex="-1">
         {% block content %}{% endblock %}
     </main>
 
-    <!-- ─── Footer ─── -->
+    <!-- Footer -->
     <footer class="site-footer" role="contentinfo">
         <div class="footer-links">
             <a href="/faq">FAQ</a>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <style>
-/* ── Leaderboard Page ── */
+/* Leaderboard Page */
 .lb-header { margin-bottom: 24px; }
 .lb-header h1 { font-size: 1.6rem; font-weight: 800; color: var(--text-primary); display: flex; align-items: center; gap: 10px; }
 .lb-header p { color: var(--text-secondary); font-size: 0.88rem; margin-top: 4px; }
@@ -229,7 +229,7 @@
 
 <div class="lb-header">
   <h1><i class="bi bi-trophy-fill" style="color:var(--accent)" aria-hidden="true"></i> Leaderboard</h1>
-  <p>Compete with fellow coders — ranked across LeetCode, GFG, Coding Ninjas, HackerRank, and DSA progress</p>
+  <p>Compete with fellow coders - ranked across LeetCode, GFG, Coding Ninjas, HackerRank, and DSA progress</p>
 </div>
 
 <!-- Tab Switcher -->
@@ -268,9 +268,9 @@
 
 <!-- Pagination -->
 <div class="pagination" id="pagination" aria-label="Leaderboard pagination">
-  <button class="pagination-btn" id="prevBtn" disabled aria-label="Previous page">← Previous</button>
+  <button class="pagination-btn" id="prevBtn" disabled aria-label="Previous page">Previous</button>
   <span class="page-info" id="pageInfo" aria-live="polite">Page 1</span>
-  <button class="pagination-btn" id="nextBtn" aria-label="Next page">Next →</button>
+  <button class="pagination-btn" id="nextBtn" aria-label="Next page">Next</button>
 </div>
 
 {% endblock %}
@@ -378,7 +378,7 @@ function renderTable(entries, mode) {
     const rank = e.rank;
     const isMe = e.user_id === CURRENT_USER_ID;
     const rankClass = rank === 1 ? 'top-1' : rank === 2 ? 'top-2' : rank === 3 ? 'top-3' : '';
-    const rankIcon = rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : `#${rank}`;
+    const rankIcon = `#${rank}`;
     
     let score = 0;
     if (mode === 'cscore') score = e.c_score;
@@ -392,8 +392,8 @@ function renderTable(entries, mode) {
       : `<a href="${profileURL}" aria-label="View profile of ${escapeHTML(e.name)}">${escapeHTML(e.name)}</a>${isMe ? '<span class="me-tag" aria-label="This is you">YOU</span>' : ''}`;
     
     const subtitleHTML = isCollegeMode
-      ? `${e.member_count} coder${e.member_count === 1 ? '' : 's'} · Top: ${escapeHTML(e.top_user?.name || 'N/A')}`
-      : (escapeHTML(e.college) || '—');
+      ? `${e.member_count} coder${e.member_count === 1 ? '' : 's'} | Top: ${escapeHTML(e.top_user?.name || 'N/A')}`
+      : (escapeHTML(e.college) || 'N/A');
     
     const dsaHTML = `<span class="stat-badge dsa">${e.dsa_done} / 450</span>`;
     
@@ -429,7 +429,7 @@ function renderTable(entries, mode) {
       <td colspan="5" style="text-align: center; padding: 12px;">
         <i class="bi bi-pin-angle-fill" style="color: var(--accent);" aria-hidden="true"></i> 
         You are ranked #${escapeHTML(currentUserRank)} in this category. 
-        <a href="?page=${targetPage}" aria-label="Go to page ${targetPage} where your rank appears">Go to your rank →</a>
+        <a href="?page=${targetPage}" aria-label="Go to page ${targetPage} where your rank appears">Go to your rank</a>
       </td>
     </tr>`;
   }

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -137,22 +137,22 @@
 <!-- Filter Buttons with ARIA labels -->
 <div class="filter-buttons" role="group" aria-label="Filter questions by difficulty level">
     <button class="filter-btn {% if difficulty_filter == 'all' %}active{% endif %}" data-difficulty="all" aria-pressed="{% if difficulty_filter == 'all' %}true{% else %}false{% endif %}">
-        📋 All ({{ total_count }})
+        All ({{ total_count }})
     </button>
     <button class="filter-btn {% if difficulty_filter == 'Easy' %}active{% endif %}" data-difficulty="Easy" aria-pressed="{% if difficulty_filter == 'Easy' %}true{% else %}false{% endif %}">
-        🟢 Easy ({{ easy_count }})
+        Easy ({{ easy_count }})
     </button>
     <button class="filter-btn {% if difficulty_filter == 'Medium' %}active{% endif %}" data-difficulty="Medium" aria-pressed="{% if difficulty_filter == 'Medium' %}true{% else %}false{% endif %}">
-        🟡 Medium ({{ medium_count }})
+        Medium ({{ medium_count }})
     </button>
     <button class="filter-btn {% if difficulty_filter == 'Hard' %}active{% endif %}" data-difficulty="Hard" aria-pressed="{% if difficulty_filter == 'Hard' %}true{% else %}false{% endif %}">
-        🔴 Hard ({{ hard_count }})
+        Hard ({{ hard_count }})
     </button>
 </div>
 <!-- Practice Random Button -->
 <div style="margin-bottom: 16px;">
     <button id="practiceRandomBtn" type="button" class="filter-btn" style="background: var(--accent); color: white; border-color: var(--accent);">
-        🎲 Practice Random
+        Practice Random
     </button>
 </div>
 
@@ -208,7 +208,6 @@
                 </td>
                 <td>
                     <span class="difficulty-badge difficulty-{{ difficulty|lower }}" aria-label="{{ difficulty }} difficulty question">
-                        <span aria-hidden="true">{% if difficulty == 'Easy' %}🟢{% elif difficulty == 'Medium' %}🟡{% else %}🔴{% endif %}</span>
                         {{ difficulty }}
                     </span>
                 </td>

--- a/tests/test_template_encoding_cleanup.py
+++ b/tests/test_template_encoding_cleanup.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+TEMPLATE_PATHS = [
+    Path("templates/base.html"),
+    Path("templates/topic.html"),
+    Path("templates/leaderboard.html"),
+]
+
+
+def test_cleaned_templates_use_ascii_only():
+    for path in TEMPLATE_PATHS:
+        contents = path.read_text(encoding="utf-8")
+        assert contents.isascii(), f"{path} still contains non-ASCII characters"


### PR DESCRIPTION
Fixes #414

## Summary
- replace non-ASCII decorative markers in shared templates with plain ASCII text
- normalize leaderboard arrows, separators, and rank display for cleaner source rendering
- add a focused regression test to keep the cleaned templates ASCII-only

## Validation
- python3 -m pytest tests/test_template_encoding_cleanup.py tests/test_leaderboard_template.py -q
- python3 -m py_compile tests/test_template_encoding_cleanup.py
- git diff --check