### PR TITLE
refactor: dedupe profile route imports

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -4,8 +4,7 @@ import requests
 from flask import Blueprint, current_app, jsonify, render_template, request, send_file
 from flask_login import current_user, login_required
 
-from app.extensions import db
-from app.extensions import limiter, cache
+from app.extensions import cache, db, limiter
 from app.platforms.fetchers import (
     fetch_atcoder,
     fetch_coding_ninjas,


### PR DESCRIPTION
Fixes #402

## Summary
- collapse the repeated `app.extensions` imports in `app/profile/routes.py` into one import line
- keep the change mechanical and behavior-neutral

## Validation
- python3 -m py_compile app/profile/routes.py
- python3 -m pytest tests/test_progress_card_copy.py tests/test_public_profile.py -q
- git diff --check