### PR TITLE
refactor: add external link badge macro

### DIFF
--- a/templates/bookmarks.html
+++ b/templates/bookmarks.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros/external_link_badges.html" import external_link_badge %}
 {% block content %}
 <style>
   .back-btn {
@@ -182,6 +183,24 @@
     border: 1px solid rgba(34, 197, 94, .25)
   }
 
+  .badge-hr {
+    background: rgba(0, 189, 108, .15);
+    color: #00bd6c;
+    border: 1px solid rgba(0, 189, 108, .25)
+  }
+
+  .badge-cn {
+    background: rgba(239, 68, 68, .15);
+    color: var(--danger);
+    border: 1px solid rgba(239, 68, 68, .25)
+  }
+
+  .badge-yt {
+    background: rgba(255, 0, 0, .15);
+    color: #ff0000;
+    border: 1px solid rgba(255, 0, 0, .25)
+  }
+
   .badge-link {
     background: rgba(99, 102, 241, .15);
     color: #818cf8;
@@ -353,12 +372,8 @@
         <td>
           <div class="q-name">{{ q.problem }}</div>
           <div class="q-links">
-            {% if q.url %}<a href="{{ q.url }}" target="_blank" rel="noopener noreferrer"
-              class="q-badge {% if 'leetcode' in q.url %}badge-lc{% elif 'geeksforgeeks' in q.url %}badge-gfg{% else %}badge-link{% endif %}"><i
-                class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{ q.url|platform_name }}</a>{% endif %}
-            {% if q.url2 %}<a href="{{ q.url2 }}" target="_blank" rel="noopener noreferrer"
-              class="q-badge badge-link"><i class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{
-              q.url2|platform_name }}</a>{% endif %}
+            {% if q.url %}{{ external_link_badge(q.url, q.url|platform_name, aria_label="View on " ~ (q.url|platform_name) ~ " (opens in new tab)") }}{% endif %}
+            {% if q.url2 %}{{ external_link_badge(q.url2, q.url2|platform_name, aria_label="View on " ~ (q.url2|platform_name) ~ " (opens in new tab)") }}{% endif %}
           </div>
         </td>
         <td>

--- a/templates/macros/external_link_badges.html
+++ b/templates/macros/external_link_badges.html
@@ -1,0 +1,62 @@
+{% macro badge_class(platform_name) -%}
+  {%- set platform = (platform_name or '')|lower -%}
+  {%- if platform in ('lc', 'leetcode') or 'leetcode' in platform -%}badge-lc
+  {%- elif platform in ('gfg', 'geeksforgeeks') or 'geeksforgeeks' in platform -%}badge-gfg
+  {%- elif platform in ('hr', 'hackerrank') or 'hackerrank' in platform -%}badge-hr
+  {%- elif platform in ('cn', 'coding ninjas') or 'coding ninjas' in platform -%}badge-cn
+  {%- elif platform in ('yt', 'youtube') or 'youtube' in platform -%}badge-yt
+  {%- else -%}badge-link
+  {%- endif -%}
+{%- endmacro %}
+
+{% macro profile_link_class(platform_name) -%}
+  {%- set platform = (platform_name or '')|lower -%}
+  {%- if platform in ('lc', 'leetcode') or 'leetcode' in platform -%}platform-link-lc
+  {%- elif platform in ('gfg', 'geeksforgeeks') or 'geeksforgeeks' in platform -%}platform-link-gfg
+  {%- elif platform in ('hr', 'hackerrank') or 'hackerrank' in platform -%}platform-link-hr
+  {%- elif platform in ('cn', 'coding ninjas') or 'coding ninjas' in platform -%}platform-link-cn
+  {%- elif platform in ('atcoder',) or 'atcoder' in platform -%}platform-link-atcoder
+  {%- elif platform in ('github',) or 'github' in platform -%}platform-link-github
+  {%- else -%}platform-link-default
+  {%- endif -%}
+{%- endmacro %}
+
+{% macro badge_icon(kind='external') -%}
+  {{- 'bi-search' if kind == 'search' else 'bi-box-arrow-up-right' -}}
+{%- endmacro %}
+
+{% macro external_link_badge(url, platform_name, aria_label=None, kind='external', class_name='q-badge', label=None) -%}
+<a href="{{ url }}" target="_blank" rel="noopener noreferrer"
+   class="{{ class_name }} {{ badge_class(platform_name) }}"
+   aria-label="{{ aria_label or (platform_name ~ ' link (opens in new tab)') }}">
+  <i class="bi {{ badge_icon(kind) }}" aria-hidden="true"></i>
+  <span class="badge-label">{{ label or platform_name }}</span>
+</a>
+{%- endmacro %}
+
+{% macro profile_platform_link(url=None, platform_name='', aria_label=None, connect_handler='openSyncModal();return false;') -%}
+  {%- set link_class = profile_link_class(platform_name) -%}
+  {%- if url -%}
+<a href="{{ url }}" target="_blank" rel="noopener noreferrer"
+   class="link-out {{ link_class }}"
+   aria-label="{{ aria_label or (platform_name ~ ' profile (opens in new tab)') }}">
+  <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
+</a>
+  {%- else -%}
+<a href="#" class="link-out {{ link_class }}" onclick="{{ connect_handler }}"
+   aria-label="{{ aria_label or ('Connect ' ~ platform_name ~ ' account') }}">
+  <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
+</a>
+  {%- endif -%}
+{%- endmacro %}
+
+{% macro search_badge_template(template_id, color_key, kind='external') -%}
+<template id="{{ template_id }}">
+  <a href="#" target="_blank" rel="noopener noreferrer"
+     class="q-badge {{ badge_class(color_key) }}"
+     aria-label="Open external link (opens in new tab)">
+    <i class="bi {{ badge_icon(kind) }}" aria-hidden="true"></i>
+    <span class="badge-label"></span>
+  </a>
+</template>
+{%- endmacro %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros/external_link_badges.html" import profile_platform_link %}
 {% block head %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js" onerror="this.remove();var s=document.createElement('script');s.src='https://unpkg.com/chart.js@4/dist/chart.umd.js';document.head.appendChild(s);"></script>
 {% endblock %}
@@ -25,6 +26,13 @@
 .check-ok{color:var(--success);font-size:0.9rem}
 .link-out{color:var(--text-muted);font-size:0.85rem;text-decoration:none}
 .link-out:hover{color:var(--accent)}
+.platform-link-lc{color:#ffb800}
+.platform-link-gfg{color:var(--success)}
+.platform-link-cn{color:#8b5cf6}
+.platform-link-hr{color:#00bd6c}
+.platform-link-atcoder{color:#f97316}
+.platform-link-github{color:var(--text-primary)}
+.platform-link-default{color:var(--text-muted)}
 .add-btn{width:100%;padding:7px;border:1px dashed var(--border-color);border-radius:8px;background:none;color:var(--text-muted);font-size:0.8rem;cursor:pointer;font-family:inherit;transition:all 0.2s;margin-top:4px}
 .add-btn:hover{border-color:var(--accent);color:var(--accent)}
 .rank-card{background:linear-gradient(135deg,rgba(255,107,0,.08),rgba(255,55,95,.06));border:1px solid var(--border-color);border-radius:14px;padding:14px}
@@ -193,31 +201,31 @@ body.modal-open {
     <div class="platform-row">
       <span><i class="bi bi-code-slash" style="color:#ffb800;margin-right:6px" aria-hidden="true"></i>LeetCode</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.leetcode_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="https://leetcode.com/{{ user.leetcode_username }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="LeetCode profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect LeetCode account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.leetcode_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ profile_platform_link("https://leetcode.com/" ~ user.leetcode_username, "LeetCode", aria_label="LeetCode profile (opens in new tab)") }}{% else %}{{ profile_platform_link(platform_name="LeetCode", aria_label="Connect LeetCode account") }}{% endif %}
       </span>
     </div>
     <div class="platform-row">
       <span><i class="bi bi-braces" style="color:var(--success);margin-right:6px" aria-hidden="true"></i>GeeksForGeeks</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.gfg_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="https://www.geeksforgeeks.org/user/{{ user.gfg_username }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="GFG profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect GFG account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.gfg_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ profile_platform_link("https://www.geeksforgeeks.org/user/" ~ user.gfg_username, "GFG", aria_label="GFG profile (opens in new tab)") }}{% else %}{{ profile_platform_link(platform_name="GFG", aria_label="Connect GFG account") }}{% endif %}
       </span>
     </div>
     <div class="platform-row">
       <span><i class="bi bi-lightning-charge" style="color:#8b5cf6;margin-right:6px" aria-hidden="true"></i>Coding Ninjas</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.codingninjas_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="https://www.naukri.com/code360/profile/{{ user.codingninjas_username }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="Coding Ninjas profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect Coding Ninjas account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.codingninjas_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ profile_platform_link("https://www.naukri.com/code360/profile/" ~ user.codingninjas_username, "Coding Ninjas", aria_label="Coding Ninjas profile (opens in new tab)") }}{% else %}{{ profile_platform_link(platform_name="Coding Ninjas", aria_label="Connect Coding Ninjas account") }}{% endif %}
       </span>
     </div>
     <div class="platform-row">
       <span><i class="bi bi-terminal" style="color:#00bd6c;margin-right:6px" aria-hidden="true"></i>HackerRank</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.hackerrank_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="https://www.hackerrank.com/{{ user.hackerrank_username }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="HackerRank profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect HackerRank account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.hackerrank_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ profile_platform_link("https://www.hackerrank.com/" ~ user.hackerrank_username, "HackerRank", aria_label="HackerRank profile (opens in new tab)") }}{% else %}{{ profile_platform_link(platform_name="HackerRank", aria_label="Connect HackerRank account") }}{% endif %}
       </span>
     </div>
     <div class="platform-row">
       <span><i class="bi bi-trophy" style="color:#f97316;margin-right:6px" aria-hidden="true"></i>AtCoder</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.atcoder_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="https://atcoder.jp/users/{{ user.atcoder_username }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="AtCoder profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect AtCoder account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.atcoder_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ profile_platform_link("https://atcoder.jp/users/" ~ user.atcoder_username, "AtCoder", aria_label="AtCoder profile (opens in new tab)") }}{% else %}{{ profile_platform_link(platform_name="AtCoder", aria_label="Connect AtCoder account") }}{% endif %}
       </span>
     </div>
     <button class="add-btn" onclick="openSyncModal()" aria-label="Add or connect coding platform accounts"><i class="bi bi-plus" aria-hidden="true"></i> Add Platform</button>
@@ -225,7 +233,7 @@ body.modal-open {
     <div class="platform-row">
       <span><i class="bi bi-github" style="margin-right:6px" aria-hidden="true"></i>GitHub</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.github_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="https://github.com/{{ user.github_username }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="GitHub profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect GitHub account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.github_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ profile_platform_link("https://github.com/" ~ user.github_username, "GitHub", aria_label="GitHub profile (opens in new tab)") }}{% else %}{{ profile_platform_link(platform_name="GitHub", aria_label="Connect GitHub account") }}{% endif %}
       </span>
     </div>
   </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros/external_link_badges.html" import search_badge_template %}
 {% block content %}
 <style>
 .search-shell { max-width: 980px; }
@@ -171,6 +172,19 @@
 }
 </style>
 
+<div hidden aria-hidden="true">
+  {{ search_badge_template("search-badge-template-lc-external", "lc") }}
+  {{ search_badge_template("search-badge-template-gfg-external", "gfg") }}
+  {{ search_badge_template("search-badge-template-cn-external", "cn") }}
+  {{ search_badge_template("search-badge-template-hr-external", "hr") }}
+  {{ search_badge_template("search-badge-template-link-external", "link") }}
+  {{ search_badge_template("search-badge-template-lc-search", "lc", kind="search") }}
+  {{ search_badge_template("search-badge-template-gfg-search", "gfg", kind="search") }}
+  {{ search_badge_template("search-badge-template-cn-search", "cn", kind="search") }}
+  {{ search_badge_template("search-badge-template-hr-search", "hr", kind="search") }}
+  {{ search_badge_template("search-badge-template-link-search", "link", kind="search") }}
+</div>
+
 <div class="search-shell">
   <div class="search-head">
     <div class="search-title"><i class="bi bi-search" style="color:var(--accent)" aria-hidden="true"></i> Search</div>
@@ -228,12 +242,19 @@ function escapeHtml(value) {
   }[ch]));
 }
 
-function badgeClass(color) {
-  if (color === 'lc') return 'badge-lc';
-  if (color === 'gfg') return 'badge-gfg';
-  if (color === 'cn') return 'badge-cn';
-  if (color === 'hr') return 'badge-hr';
-  return 'badge-link';
+function badgeColorKey(color) {
+  if (color === 'lc' || color === 'gfg' || color === 'cn' || color === 'hr') return color;
+  return 'link';
+}
+
+function renderBadge(link, kind, ariaLabel) {
+  const templateId = `search-badge-template-${badgeColorKey(link.color)}-${kind}`;
+  const template = document.getElementById(templateId) || document.getElementById(`search-badge-template-link-${kind}`);
+  const anchor = template.content.firstElementChild.cloneNode(true);
+  anchor.href = link.url;
+  anchor.setAttribute('aria-label', ariaLabel);
+  anchor.querySelector('.badge-label').textContent = link.platform;
+  return anchor.outerHTML;
 }
 
 function currentQuery() {
@@ -278,9 +299,7 @@ function renderResults(payload) {
 
   if (!count) {
     const external = (payload.external_searches || []).map(link =>
-      `<a class="q-badge ${badgeClass(link.color)}" href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="Search ${escapeHtml(link.platform)} for your query (opens new tab)">
-        <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>${escapeHtml(link.platform)}
-      </a>`
+      renderBadge(link, 'external', `Search ${link.platform} for your query (opens new tab)`)
     ).join('');
     results.innerHTML = `<div class="empty-search"><i class="bi bi-search-heart" aria-hidden="true"></i><p>No sheet match found.</p><div class="link-row" style="justify-content:center">${external}</div></div>`;
     return;
@@ -288,14 +307,10 @@ function renderResults(payload) {
 
   results.innerHTML = payload.results.map(item => {
     const directLinks = (item.links || []).map(link =>
-      `<a class="q-badge ${badgeClass(link.color)}" href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="View on ${escapeHtml(link.platform)} (opens new tab)">
-        <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>${escapeHtml(link.platform)}
-      </a>`
+      renderBadge(link, 'external', `View on ${link.platform} (opens new tab)`)
     ).join('');
     const platformSearches = (item.external_searches || []).map(link =>
-      `<a class="q-badge ${badgeClass(link.color)}" href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="Search ${escapeHtml(link.platform)} for this problem (opens new tab)">
-        <i class="bi bi-search" aria-hidden="true"></i>${escapeHtml(link.platform)}
-      </a>`
+      renderBadge(link, 'search', `Search ${link.platform} for this problem (opens new tab)`)
     ).join('');
     const topicUrl = `/topic/${encodeURIComponent(item.topic_id)}`;
 

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros/external_link_badges.html" import external_link_badge %}
 {% block content %}
 <style>
 .back-btn { display: inline-flex; align-items: center; gap: 8px; color: var(--text-secondary); text-decoration: none; font-size: 0.85rem; font-weight: 600; margin-bottom: 20px; padding: 7px 14px; border: 1px solid var(--border-color); border-radius: 8px; transition: all 0.2s; }
@@ -190,19 +191,11 @@
                     <div class="q-links">
                         {% if q.url %}
                             {% set p1 = q.url|platform_name %}
-                            <a href="{{ q.url }}" target="_blank" rel="noopener noreferrer"
-                               class="q-badge {% if p1=='LeetCode' %}badge-lc{% elif p1=='GFG' %}badge-gfg{% elif p1=='HackerRank' %}badge-hr{% elif p1=='Coding Ninjas' %}badge-cn{% elif p1=='YouTube' %}badge-yt{% else %}badge-link{% endif %}"
-                               aria-label="Solve on {{ p1 }} (opens in new tab)">
-                               <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i> {{ p1 }}
-                            </a>
+                            {{ external_link_badge(q.url, p1, aria_label="Solve on " ~ p1 ~ " (opens in new tab)") }}
                         {% endif %}
                         {% if q.url2 %}
                             {% set p2 = q.url2|platform_name %}
-                            <a href="{{ q.url2 }}" target="_blank" rel="noopener noreferrer"
-                               class="q-badge {% if p2=='LeetCode' %}badge-lc{% elif p2=='GFG' %}badge-gfg{% elif p2=='HackerRank' %}badge-hr{% elif p2=='Coding Ninjas' %}badge-cn{% elif p2=='YouTube' %}badge-yt{% else %}badge-link{% endif %}"
-                               aria-label="Solve on {{ p2 }} (opens in new tab)">
-                               <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i> {{ p2 }}
-                            </a>
+                            {{ external_link_badge(q.url2, p2, aria_label="Solve on " ~ p2 ~ " (opens in new tab)") }}
                         {% endif %}
                     </div>
                 </td>

--- a/tests/test_external_link_badge_macro.py
+++ b/tests/test_external_link_badge_macro.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "templates"
+MACRO_TEMPLATE = TEMPLATE_DIR / "macros" / "external_link_badges.html"
+
+
+def test_external_link_badge_macro_exists_with_expected_helpers():
+    template = MACRO_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "macro external_link_badge" in template
+    assert "macro profile_platform_link" in template
+    assert "macro search_badge_template" in template
+
+
+def test_templates_import_and_use_external_link_badge_macro():
+    topic_template = (TEMPLATE_DIR / "topic.html").read_text(encoding="utf-8")
+    bookmarks_template = (TEMPLATE_DIR / "bookmarks.html").read_text(encoding="utf-8")
+    profile_template = (TEMPLATE_DIR / "profile.html").read_text(encoding="utf-8")
+    search_template = (TEMPLATE_DIR / "search.html").read_text(encoding="utf-8")
+
+    assert '{% from "macros/external_link_badges.html" import external_link_badge %}' in topic_template
+    assert '{{ external_link_badge(q.url, p1' in topic_template
+    assert '{{ external_link_badge(q.url2, p2' in topic_template
+
+    assert '{% from "macros/external_link_badges.html" import external_link_badge %}' in bookmarks_template
+    assert '{{ external_link_badge(q.url, q.url|platform_name' in bookmarks_template
+    assert '{{ external_link_badge(q.url2, q.url2|platform_name' in bookmarks_template
+
+    assert '{% from "macros/external_link_badges.html" import profile_platform_link %}' in profile_template
+    assert "profile_platform_link(" in profile_template
+
+    assert '{% from "macros/external_link_badges.html" import search_badge_template %}' in search_template
+    assert "search-badge-template-lc-external" in search_template
+    assert "renderBadge(link, 'external'" in search_template


### PR DESCRIPTION
## Summary
- add a shared Jinja macro file for external link badges and profile platform links
- reuse the macro in topic, bookmarks, search, and profile platform sections
- add a regression test that locks in macro usage across the target templates

## Testing
- python3 -m pytest tests/test_external_link_badge_macro.py tests/test_template_link_security.py tests/test_search_template.py tests/test_progress_card_copy.py -q
- python3 -m py_compile tests/test_external_link_badge_macro.py tests/test_template_link_security.py tests/test_search_template.py tests/test_progress_card_copy.py
- git diff --check
