### PR TITLE
refactor: move template routes into config

### DIFF
--- a/templates/bookmarks.html
+++ b/templates/bookmarks.html
@@ -402,6 +402,9 @@
 
 {% block scripts %}
 <script>
+  const endpointConfig = {{ {
+    "updateQuestionBase": url_for('tracker.update_question', question_id='__QUESTION_ID__'),
+  }|tojson }};
   const FOCUSABLE = 'button, [href], input, textarea, select, [tabindex]:not([tabindex="-1"])';
   const modal = document.getElementById('notesModal');
 
@@ -430,7 +433,7 @@
   }
 
   function updateQuestion(id, data, callback) {
-    fetch('/update_question/' + id, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) })
+    fetch(endpointConfig.updateQuestionBase.replace('__QUESTION_ID__', encodeURIComponent(id)), { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) })
       .then(r => r.json()).then(res => { if (res.success) callback(); })
       .catch(() => alert('Error updating.'));
   }

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -278,6 +278,9 @@
 {% block scripts %}
 <script>
 const CURRENT_USER_ID = {{ current_user_id | tojson }};
+const endpointConfig = {{ {
+  "publicProfileBase": url_for('public.public_profile', user_id='__USER_ID__'),
+}|tojson }};
 let activeMode = 'cscore';
 let currentPage = 1;
 let totalPages = 1;
@@ -386,7 +389,9 @@ function renderTable(entries, mode) {
     else if (mode === 'rating') score = e.lc_rating;
     else if (mode === 'college') score = e.c_score;
     
-    const profileURL = !isCollegeMode && e.user_id ? `/u/${encodeURIComponent(e.user_id)}` : '';
+    const profileURL = !isCollegeMode && e.user_id
+      ? endpointConfig.publicProfileBase.replace('__USER_ID__', encodeURIComponent(e.user_id))
+      : '';
     const nameHTML = isCollegeMode
       ? `${escapeHTML(e.college)}`
       : `<a href="${profileURL}" aria-label="View profile of ${escapeHTML(e.name)}">${escapeHTML(e.name)}</a>${isMe ? '<span class="me-tag" aria-label="This is you">YOU</span>' : ''}`;

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -146,7 +146,7 @@ body.modal-open {
       }
 
       function copyProgressCardUrl() {
-        const url = window.location.origin + '/u/{{ user.id }}/card.png';
+        const url = window.location.origin + endpointConfig.publicCardPath;
         if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
           showProgressCardUrlFallback(url);
           return;
@@ -580,6 +580,13 @@ body.modal-open {
 
 {% block scripts %}
 <script>
+const endpointConfig = {{ {
+  "editProfile": url_for('profile.edit_profile'),
+  "syncPlatforms": url_for('profile.sync_platforms'),
+  "searchUniversities": url_for('profile.search_universities'),
+  "publicCardPath": url_for('profile.public_card', user_id=user.id),
+}|tojson }};
+
 // ── Event Listeners (registered first so Chart.js failure can't break them) ──
 window.handleSaveProfile = function(btn){
   const contentEl=document.getElementById('saveProfileContent');
@@ -596,7 +603,7 @@ window.handleSaveProfile = function(btn){
   };
   btn.disabled=true;
   contentEl.innerHTML='<span class="btn-spinner"></span> Saving...';
-  fetch('/edit_profile',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)})
+  fetch(endpointConfig.editProfile,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)})
     .then(r=>r.json())
     .then(res=>{
       if(res.success){
@@ -635,7 +642,7 @@ window.handleQuickSync = function(btn) {
   icon.className = 'bi bi-arrow-clockwise btn-spinner';
   showToast('⏳ Syncing profiles...');
   
-  fetch('/sync_platforms', {
+  fetch(endpointConfig.syncPlatforms, {
     method:'POST',
     headers:{'Content-Type':'application/json'},
     body:JSON.stringify({leetcode:lc,github:gh,gfg:gfg,hackerrank:hr,codingninjas:cn})
@@ -693,7 +700,7 @@ window.handleSyncProfile = function(btn){
   const ctrl=new AbortController();
   const timer=setTimeout(()=>ctrl.abort(),90000);
 
-  fetch('/sync_platforms',{
+  fetch(endpointConfig.syncPlatforms,{
     method:'POST',
     headers:{'Content-Type':'application/json'},
     body:JSON.stringify({leetcode:lc,github:gh,gfg:gfg,hackerrank:hr,codingninjas:cn}),
@@ -868,7 +875,7 @@ function handlePhotoUpload(e){
     const q = this.value.trim();
     if(q.length < 2){ dd.style.display='none'; return; }
     timer = setTimeout(() => {
-      fetch('/search_universities?q=' + encodeURIComponent(q))
+      fetch(endpointConfig.searchUniversities + '?q=' + encodeURIComponent(q))
         .then(r => r.json())
         .then(data => renderItems(data))
         .catch(() => { dd.style.display='none'; });

--- a/templates/search.html
+++ b/templates/search.html
@@ -207,6 +207,9 @@
 
 {% block scripts %}
 <script>
+const endpointConfig = {{ {
+  "searchQuestions": url_for('search.api_search_questions'),
+}|tojson }};
 const input = document.getElementById('searchInput');
 const results = document.getElementById('results');
 const meta = document.getElementById('searchMeta');
@@ -335,7 +338,7 @@ async function runSearch() {
   meta.setAttribute('aria-busy', 'true');
 
   try {
-    const res = await fetch(`/api/search_questions?q=${encodeURIComponent(query)}`, { signal: controller.signal });
+    const res = await fetch(`${endpointConfig.searchQuestions}?q=${encodeURIComponent(query)}`, { signal: controller.signal });
     renderResults(await res.json());
     meta.setAttribute('aria-busy', 'false');
   } catch (err) {

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -263,6 +263,9 @@
 
 {% block scripts %}
 <script>
+const endpointConfig = {{ {
+  "updateQuestionBase": url_for('tracker.update_question', question_id='__QUESTION_ID__'),
+}|tojson }};
 const isAuthenticated = {{ 'true' if current_user.is_authenticated else 'false' }};
 const topicStatus = document.getElementById('topicStatus');
 
@@ -283,7 +286,7 @@ function setBookmarkState(btn, isBookmarked) {
 }
 
 function updateQuestion(id, data, callback) {
-    return fetch('/update_question/' + id, {
+    return fetch(endpointConfig.updateQuestionBase.replace('__QUESTION_ID__', encodeURIComponent(id)), {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(data)

--- a/tests/test_template_route_config.py
+++ b/tests/test_template_route_config.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "templates"
+
+
+def test_profile_template_uses_url_for_endpoint_config():
+    template = (TEMPLATE_DIR / "profile.html").read_text(encoding="utf-8")
+
+    assert '"editProfile": url_for(\'profile.edit_profile\')' in template
+    assert '"syncPlatforms": url_for(\'profile.sync_platforms\')' in template
+    assert '"searchUniversities": url_for(\'profile.search_universities\')' in template
+    assert '"publicCardPath": url_for(\'profile.public_card\'' in template
+    assert "fetch('/edit_profile'" not in template
+    assert "fetch('/sync_platforms'" not in template
+    assert "fetch('/search_universities?q='" not in template
+    assert "window.location.origin + '/u/" not in template
+
+
+def test_tracker_templates_use_configured_update_question_route():
+    topic_template = (TEMPLATE_DIR / "topic.html").read_text(encoding="utf-8")
+    bookmarks_template = (TEMPLATE_DIR / "bookmarks.html").read_text(encoding="utf-8")
+
+    assert '"updateQuestionBase": url_for(\'tracker.update_question\'' in topic_template
+    assert '"updateQuestionBase": url_for(\'tracker.update_question\'' in bookmarks_template
+    assert "fetch('/update_question/' + id" not in topic_template
+    assert "fetch('/update_question/' + id" not in bookmarks_template
+
+
+def test_search_and_leaderboard_templates_use_url_for_route_config():
+    search_template = (TEMPLATE_DIR / "search.html").read_text(encoding="utf-8")
+    leaderboard_template = (TEMPLATE_DIR / "leaderboard.html").read_text(encoding="utf-8")
+
+    assert '"searchQuestions": url_for(\'search.api_search_questions\')' in search_template
+    assert "fetch(`/api/search_questions?q=${encodeURIComponent(query)}`" not in search_template
+
+    assert '"publicProfileBase": url_for(\'public.public_profile\'' in leaderboard_template
+    assert "`/u/${encodeURIComponent(e.user_id)}`" not in leaderboard_template


### PR DESCRIPTION
## Summary
- replace hard-coded frontend route strings with template-provided endpoint config
- use `url_for` as the source of truth for profile, tracker, search, and public-profile links
- add template tests that guard against route literals creeping back in

## Testing
- python3 -m pytest tests/test_template_route_config.py tests/test_search_template.py tests/test_leaderboard_template.py tests/test_progress_card_copy.py tests/test_template_link_security.py -q
- python3 -m py_compile tests/test_template_route_config.py tests/test_search_template.py tests/test_leaderboard_template.py tests/test_progress_card_copy.py tests/test_template_link_security.py
- git diff --check
