### PR TITLE
refactor: add shared notes modal macro

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -327,6 +327,63 @@
             align-items: center;
             gap: 10px;
         }
+        .app-modal {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.7);
+            z-index: 9999;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .app-modal.open {
+            display: flex;
+        }
+
+        .app-modal__dialog {
+            background: var(--bg-card);
+            border: 1px solid var(--border-color);
+            border-radius: 16px;
+            padding: 28px;
+            width: 90%;
+            max-width: 480px;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+        }
+
+        .app-modal__title {
+            font-size: 1.05rem;
+            font-weight: 700;
+            margin-bottom: 16px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .app-modal__textarea {
+            width: 100%;
+            padding: 12px;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border-color);
+            border-radius: 10px;
+            color: var(--text-primary);
+            font-size: 0.88rem;
+            font-family: inherit;
+            resize: vertical;
+            min-height: 120px;
+            outline: none;
+        }
+
+        .app-modal__textarea:focus {
+            border-color: var(--accent);
+        }
+
+        .app-modal__actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 10px;
+            margin-top: 16px;
+        }
 
         .pill-btn {
             display: flex;

--- a/templates/bookmarks.html
+++ b/templates/bookmarks.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros/modals.html" import notes_modal %}
 {% block content %}
 <style>
   .back-btn {
@@ -226,88 +227,6 @@
     color: var(--info)
   }
 
-  .modal-ov {
-    display: none;
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, .7);
-    z-index: 9999;
-    align-items: center;
-    justify-content: center
-  }
-
-  .modal-ov.open {
-    display: flex
-  }
-
-  .modal-bx {
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    border-radius: 16px;
-    padding: 28px;
-    width: 90%;
-    max-width: 480px
-  }
-
-  .modal-bx h3 {
-    font-size: 1.1rem;
-    font-weight: 700;
-    margin-bottom: 16px
-  }
-
-  .modal-textarea {
-    width: 100%;
-    padding: 12px;
-    background: var(--bg-secondary);
-    border: 1px solid var(--border-color);
-    border-radius: 10px;
-    color: var(--text-primary);
-    font-size: .88rem;
-    font-family: inherit;
-    resize: vertical;
-    min-height: 120px;
-    outline: none
-  }
-
-  .modal-textarea:focus {
-    border-color: var(--accent)
-  }
-
-  .modal-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 10px;
-    margin-top: 16px
-  }
-
-  .btn-cancel {
-    padding: 9px 18px;
-    border-radius: 8px;
-    border: 1px solid var(--border-color);
-    background: none;
-    color: var(--text-secondary);
-    font-size: .85rem;
-    font-weight: 600;
-    cursor: pointer;
-    font-family: inherit
-  }
-
-  .btn-save {
-    padding: 9px 18px;
-    border-radius: 8px;
-    border: none;
-    background: var(--accent);
-    color: #fff;
-    font-size: .85rem;
-    font-weight: 700;
-    cursor: pointer;
-    font-family: inherit
-  }
-
-  .btn-save:hover {
-    background: var(--accent-hover)
-  }
-
   @media(max-width:640px) {
 
     .q-table thead th:nth-child(1),
@@ -387,17 +306,7 @@
 </div>
 {% endif %}
 
-<div class="modal-ov" id="notesModal" role="dialog" aria-modal="true" aria-labelledby="notesModalTitle">
-  <div class="modal-bx">
-    <h3 id="notesModalTitle"><i class="bi bi-journal-text" aria-hidden="true"></i> Notes</h3>
-    <textarea class="modal-textarea" id="notesTextarea" placeholder="Write your notes here..." aria-label="Notes"></textarea>
-    <input type="hidden" id="currentQuestionId">
-    <div class="modal-actions">
-      <button class="btn-cancel" id="modalCancel">Cancel</button>
-      <button class="btn-save" id="saveNotesBtn">Save Notes</button>
-    </div>
-  </div>
-</div>
+{{ notes_modal(textarea_label='Notes') }}
 {% endblock %}
 
 {% block scripts %}

--- a/templates/macros/modals.html
+++ b/templates/macros/modals.html
@@ -1,0 +1,16 @@
+{% macro notes_modal(modal_id='notesModal', title_id='notesModalTitle', textarea_id='notesTextarea', question_id_input='currentQuestionId', cancel_id='modalCancel', save_id='saveNotesBtn', textarea_label='Notes for this question', textarea_placeholder='Write your notes here...') -%}
+<div class="app-modal" id="{{ modal_id }}" role="dialog" aria-modal="true" aria-labelledby="{{ title_id }}">
+  <div class="app-modal__dialog">
+    <h3 class="app-modal__title" id="{{ title_id }}">
+      <i class="bi bi-journal-text" aria-hidden="true"></i>
+      <span>Notes</span>
+    </h3>
+    <textarea class="app-modal__textarea" id="{{ textarea_id }}" placeholder="{{ textarea_placeholder }}" aria-label="{{ textarea_label }}"></textarea>
+    <input type="hidden" id="{{ question_id_input }}">
+    <div class="app-modal__actions">
+      <button class="ui-btn ui-btn-secondary" id="{{ cancel_id }}" aria-label="Cancel editing notes">Cancel</button>
+      <button class="ui-btn ui-btn-primary" id="{{ save_id }}" aria-label="Save notes">Save Notes</button>
+    </div>
+  </div>
+</div>
+{%- endmacro %}

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros/modals.html" import notes_modal %}
 {% block content %}
 <style>
 .back-btn { display: inline-flex; align-items: center; gap: 8px; color: var(--text-secondary); text-decoration: none; font-size: 0.85rem; font-weight: 600; margin-bottom: 20px; padding: 7px 14px; border: 1px solid var(--border-color); border-radius: 8px; transition: all 0.2s; }
@@ -57,17 +58,6 @@
 .export-notes-btn { display: inline-flex; align-items: center; gap: 7px; padding: 8px 14px; border: 1px solid var(--border-color); border-radius: 8px; background: var(--bg-secondary); color: var(--text-secondary); font-size: 0.82rem; font-weight: 700; text-decoration: none; white-space: nowrap; transition: all 0.2s; }
 .export-notes-btn:hover { border-color: var(--accent); color: var(--accent); text-decoration: none; }
 
-/* Modal focus management */
-.modal-overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.7); z-index: 9999; align-items: center; justify-content: center; }
-.modal-overlay.open { display: flex; }
-.modal-box { background: var(--bg-card); border: 1px solid var(--border-color); border-radius: 16px; padding: 28px; width: 90%; max-width: 480px; box-shadow: 0 20px 60px rgba(0,0,0,0.5); }
-.modal-box h3 { font-size: 1.1rem; font-weight: 700; margin-bottom: 16px; }
-.modal-textarea { width: 100%; padding: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 10px; color: var(--text-primary); font-size: 0.88rem; font-family: inherit; resize: vertical; min-height: 120px; outline: none; }
-.modal-textarea:focus { border-color: var(--accent); }
-.modal-actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 16px; }
-.btn-modal-cancel { padding: 9px 18px; border-radius: 8px; border: 1px solid var(--border-color); background: none; color: var(--text-secondary); font-size: 0.85rem; font-weight: 600; cursor: pointer; font-family: inherit; }
-.btn-modal-save { padding: 9px 18px; border-radius: 8px; border: none; background: var(--accent); color: white; font-size: 0.85rem; font-weight: 700; cursor: pointer; font-family: inherit; }
-.btn-modal-save:hover { background: var(--accent-hover); }
 .topic-status {
     margin-bottom: 14px;
     padding: 10px 14px;
@@ -248,17 +238,7 @@
 </div>
 
 <!-- Notes Modal -->
-<div class="modal-overlay" id="notesModal" role="dialog" aria-modal="true" aria-labelledby="notesModalTitle">
-    <div class="modal-box">
-        <h3 id="notesModalTitle"><i class="bi bi-journal-text" aria-hidden="true"></i> Notes</h3>
-        <textarea class="modal-textarea" id="notesTextarea" placeholder="Write your notes here..." aria-label="Notes for this question"></textarea>
-        <input type="hidden" id="currentQuestionId">
-        <div class="modal-actions">
-            <button class="btn-modal-cancel" id="modalCancel" aria-label="Cancel editing notes">Cancel</button>
-            <button class="btn-modal-save" id="saveNotesBtn" aria-label="Save notes">Save Notes</button>
-        </div>
-    </div>
-</div>
+{{ notes_modal(textarea_label='Notes for this question') }}
 {% endblock %}
 
 {% block scripts %}

--- a/tests/test_modal_macro.py
+++ b/tests/test_modal_macro.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "templates"
+
+
+def test_modal_macro_exists_and_defines_notes_modal():
+    template = (TEMPLATE_DIR / "macros" / "modals.html").read_text(encoding="utf-8")
+
+    assert "macro notes_modal" in template
+    assert 'class="app-modal"' in template
+    assert 'class="app-modal__dialog"' in template
+    assert 'class="app-modal__actions"' in template
+
+
+def test_base_template_defines_shared_modal_classes():
+    template = (TEMPLATE_DIR / "base.html").read_text(encoding="utf-8")
+
+    assert ".app-modal {" in template
+    assert ".app-modal.open {" in template
+    assert ".app-modal__dialog {" in template
+    assert ".app-modal__title {" in template
+    assert ".app-modal__textarea {" in template
+    assert ".app-modal__actions {" in template
+
+
+def test_topic_and_bookmarks_use_shared_notes_modal_macro():
+    topic_template = (TEMPLATE_DIR / "topic.html").read_text(encoding="utf-8")
+    bookmarks_template = (TEMPLATE_DIR / "bookmarks.html").read_text(encoding="utf-8")
+
+    assert '{% from "macros/modals.html" import notes_modal %}' in topic_template
+    assert '{% from "macros/modals.html" import notes_modal %}' in bookmarks_template
+
+    assert "{{ notes_modal(textarea_label='Notes for this question') }}" in topic_template
+    assert "{{ notes_modal(textarea_label='Notes') }}" in bookmarks_template
+
+    assert "modal-overlay" not in topic_template
+    assert "modal-ov" not in bookmarks_template


### PR DESCRIPTION
## Summary
- add shared modal styles in the base template
- add a reusable notes modal macro for repeated dialog markup
- migrate the topic and bookmarks notes dialogs onto the shared modal structure
- add a regression test to guard the macro and migrated templates

## Testing
- python3 -m pytest tests/test_modal_macro.py tests/test_template_link_security.py tests/test_search_template.py tests/test_leaderboard_template.py tests/test_progress_card_copy.py -q
- python3 -m py_compile tests/test_modal_macro.py tests/test_template_link_security.py tests/test_search_template.py tests/test_leaderboard_template.py tests/test_progress_card_copy.py
- git diff --check
