### PR TITLE
perf: use lightweight user loader projection

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -22,6 +22,20 @@ COMMON_WEAK_PASSWORDS = {
     "welcome1",
 }
 
+SESSION_USER_PROJECTION = {
+    "name": 1,
+    "email": 1,
+    "progress": 1,
+    "is_admin": 1,
+    "last_sync": 1,
+    "leetcode_username": 1,
+    "github_username": 1,
+    "gfg_username": 1,
+    "hackerrank_username": 1,
+    "codingninjas_username": 1,
+    "atcoder_username": 1,
+}
+
 
 def resolve_oauth_user(provider_field, provider_id, name, email=None):
     """Find, link, or create an OAuth-backed user record.
@@ -113,7 +127,7 @@ class UserWrapper(UserMixin):
 @login_manager.user_loader
 def load_user(user_id):
     try:
-        doc = db.user.find_one({"_id": ObjectId(user_id)})
+        doc = db.user.find_one({"_id": ObjectId(user_id)}, SESSION_USER_PROJECTION)
         return UserWrapper(doc) if doc else None
     except Exception:
         return None

--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -3,8 +3,7 @@ from flask_login import current_user
 
 from app.extensions import limiter, cache
 from app.leaderboard.service import (
-    build_college_leaderboard_data,
-    build_leaderboard_data,
+    get_leaderboard_snapshot,
 )
 
 
@@ -15,31 +14,28 @@ leaderboard_bp = Blueprint("leaderboard", __name__)
 @limiter.limit("20 per minute")
 @cache.cached(timeout=300)
 def leaderboard():
-    entries = build_leaderboard_data()
+    by_cscore = get_leaderboard_snapshot("cscore")
+    by_questions = get_leaderboard_snapshot("questions")
+    by_rating = get_leaderboard_snapshot("rating")
+    by_college = get_leaderboard_snapshot("college")
 
-    by_cscore = sorted(entries, key=lambda item: item["c_score"], reverse=True)
-    by_questions = sorted(entries, key=lambda item: item["total_solved"], reverse=True)
-    by_rating = sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
-    by_college = build_college_leaderboard_data(entries)
-
-    def assign_ranks(sorted_list, key):
-        for index, entry in enumerate(sorted_list):
-            entry[f"rank_{key}"] = index + 1
-        return sorted_list
-
-    assign_ranks(by_cscore, "cscore")
-    assign_ranks(by_questions, "questions")
-    assign_ranks(by_rating, "rating")
-    assign_ranks(by_college, "college")
+    for entry in by_cscore:
+        entry["rank_cscore"] = entry["rank"]
+    for entry in by_questions:
+        entry["rank_questions"] = entry["rank"]
+    for entry in by_rating:
+        entry["rank_rating"] = entry["rank"]
+    for entry in by_college:
+        entry["rank_college"] = entry["rank"]
 
     current_user_id = str(current_user.id) if current_user.is_authenticated else None
     
     # Find current user's rank in each category
     current_user_rank = None
     if current_user_id:
-        for i, entry in enumerate(by_cscore):
+        for entry in by_cscore:
             if entry.get("user_id") == current_user_id:
-                current_user_rank = i + 1
+                current_user_rank = entry["rank"]
                 break
     
     return render_template(
@@ -138,20 +134,7 @@ def api_leaderboard():
     page = int(request.args.get("page", 1))
     per_page = min(int(request.args.get("per_page", 20)), 100)
     
-    entries = build_leaderboard_data()
-
-    if mode == "questions":
-        entries.sort(key=lambda item: item["total_solved"], reverse=True)
-    elif mode == "rating":
-        entries.sort(key=lambda item: item["lc_rating"], reverse=True)
-    elif mode == "college":
-        entries = build_college_leaderboard_data(entries)
-    else:
-        entries.sort(key=lambda item: item["c_score"], reverse=True)
-
-    # Assign ranks
-    for index, entry in enumerate(entries):
-        entry["rank"] = index + 1
+    entries = get_leaderboard_snapshot(mode)
 
     # Pagination
     total = len(entries)

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -1,5 +1,9 @@
-from app.extensions import db
+from app.extensions import cache, db
 from app.utils import compute_c_score
+
+LEADERBOARD_SNAPSHOT_CACHE_KEY = "leaderboard:snapshots:v1"
+LEADERBOARD_SNAPSHOT_TTL = 300
+LEADERBOARD_MODES = ("cscore", "questions", "rating", "college")
 
 
 def build_leaderboard_data():
@@ -111,3 +115,47 @@ def build_college_leaderboard_data(entries=None):
         key=lambda item: (item["c_score"], item["total_solved"], item["member_count"]),
         reverse=True,
     )
+
+
+def _rank_entries(entries):
+    ranked = []
+    for index, entry in enumerate(entries, start=1):
+        ranked.append({**entry, "rank": index})
+    return ranked
+
+
+def _sort_leaderboard_entries(entries, mode):
+    if mode == "questions":
+        return sorted(entries, key=lambda item: item["total_solved"], reverse=True)
+    if mode == "rating":
+        return sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
+    if mode == "college":
+        return build_college_leaderboard_data(entries)
+    return sorted(entries, key=lambda item: item["c_score"], reverse=True)
+
+
+def build_leaderboard_snapshots():
+    entries = build_leaderboard_data()
+    return {
+        mode: _rank_entries(_sort_leaderboard_entries(entries, mode))
+        for mode in LEADERBOARD_MODES
+    }
+
+
+def get_leaderboard_snapshot(mode, force_refresh=False):
+    mode = mode if mode in LEADERBOARD_MODES else "cscore"
+    snapshots = None if force_refresh else cache.get(LEADERBOARD_SNAPSHOT_CACHE_KEY)
+    if snapshots is None:
+        snapshots = build_leaderboard_snapshots()
+        cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return [dict(entry) for entry in snapshots[mode]]
+
+
+def refresh_leaderboard_snapshots():
+    snapshots = build_leaderboard_snapshots()
+    cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return snapshots
+
+
+def clear_leaderboard_snapshots():
+    cache.delete(LEADERBOARD_SNAPSHOT_CACHE_KEY)

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -6,6 +6,7 @@ from flask_login import current_user, login_required
 
 from app.extensions import db
 from app.extensions import limiter, cache
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.platforms.fetchers import (
     fetch_atcoder,
     fetch_coding_ninjas,
@@ -273,6 +274,7 @@ def sync_platforms():
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
 
+    clear_leaderboard_snapshots()
     cache.clear()
     return jsonify(build_sync_platforms_response(platform_status))
 
@@ -351,6 +353,7 @@ def edit_profile():
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
     return json_success()
 
 

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -3,6 +3,7 @@ from flask import Blueprint, Response, jsonify, render_template, request
 from flask_login import current_user, login_required
 
 from app.extensions import db
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.utils import json_error, json_success, utc_now
 from notes_export import build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
@@ -201,6 +202,7 @@ def update_question(question_id):
     if update_fields:
         db.user.update_one({"_id": user_id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
         return json_success(message=message)
 
     return json_success(message="No changes made")

--- a/tests/test_auth_user_loader.py
+++ b/tests/test_auth_user_loader.py
@@ -1,0 +1,52 @@
+from bson import ObjectId
+
+import app.auth.routes as auth_routes
+
+
+class RecordingUserCollection:
+    def __init__(self, document):
+        self.document = document
+        self.calls = []
+
+    def find_one(self, query, projection=None):
+        self.calls.append((query, projection))
+        if query.get("_id") == self.document["_id"]:
+            return dict(self.document)
+        return None
+
+
+class RecordingDB:
+    def __init__(self, document):
+        self.user = RecordingUserCollection(document)
+
+
+def test_load_user_uses_lightweight_projection(monkeypatch):
+    user_id = ObjectId()
+    db = RecordingDB(
+        {
+            "_id": user_id,
+            "name": "Loader Test",
+            "email": "loader@example.com",
+            "progress": {"q1": {"done": True}},
+            "is_admin": True,
+            "leetcode_username": "leet",
+        }
+    )
+    monkeypatch.setattr(auth_routes, "db", db)
+
+    user = auth_routes.load_user(str(user_id))
+
+    assert user is not None
+    assert str(user.get_id()) == str(user_id)
+    assert user.name == "Loader Test"
+    assert user.email == "loader@example.com"
+    assert user.progress == {"q1": {"done": True}}
+    assert user.is_admin is True
+    assert user.leetcode_username == "leet"
+    assert db.user.calls == [
+        ({"_id": user_id}, auth_routes.SESSION_USER_PROJECTION),
+    ]
+
+
+def test_load_user_returns_none_for_invalid_id():
+    assert auth_routes.load_user("not-a-valid-objectid") is None

--- a/tests/test_leaderboard_snapshots.py
+++ b/tests/test_leaderboard_snapshots.py
@@ -1,0 +1,156 @@
+from bson import ObjectId
+
+from conftest import build_test_app, login_test_user
+from app.leaderboard.service import (
+    LEADERBOARD_SNAPSHOT_CACHE_KEY,
+    build_leaderboard_snapshots,
+    clear_leaderboard_snapshots,
+    get_leaderboard_snapshot,
+    refresh_leaderboard_snapshots,
+)
+from app.leaderboard import service as leaderboard_service
+import app.profile.routes as profile_routes
+import app.tracker.routes as tracker_routes
+
+
+class FakeCache:
+    def __init__(self):
+        self.values = {}
+        self.set_calls = []
+        self.delete_calls = []
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value, timeout=None):
+        self.values[key] = value
+        self.set_calls.append((key, timeout))
+
+    def delete(self, key):
+        self.values.pop(key, None)
+        self.delete_calls.append(key)
+
+
+def test_get_leaderboard_snapshot_uses_cached_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+    build_calls = []
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: build_calls.append("built") or {
+            "cscore": [{"user_id": "1", "rank": 1, "c_score": 42}],
+            "questions": [{"user_id": "1", "rank": 1, "total_solved": 10}],
+            "rating": [{"user_id": "1", "rank": 1, "lc_rating": 1800}],
+            "college": [{"user_id": "", "rank": 1, "college": "Alpha"}],
+        },
+    )
+
+    first = get_leaderboard_snapshot("cscore")
+    second = get_leaderboard_snapshot("questions")
+
+    assert build_calls == ["built"]
+    assert fake_cache.set_calls == [(LEADERBOARD_SNAPSHOT_CACHE_KEY, leaderboard_service.LEADERBOARD_SNAPSHOT_TTL)]
+    assert first[0]["c_score"] == 42
+    assert second[0]["total_solved"] == 10
+
+
+def test_refresh_and_clear_leaderboard_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: {
+            "cscore": [{"rank": 1}],
+            "questions": [{"rank": 1}],
+            "rating": [{"rank": 1}],
+            "college": [{"rank": 1}],
+        },
+    )
+
+    snapshots = refresh_leaderboard_snapshots()
+    clear_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert fake_cache.delete_calls == [LEADERBOARD_SNAPSHOT_CACHE_KEY]
+
+
+def test_build_leaderboard_snapshots_assigns_ranks(monkeypatch):
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_data",
+        lambda: [
+            {
+                "user_id": "1",
+                "name": "Alice",
+                "college": "Alpha",
+                "profile_photo": "",
+                "c_score": 20,
+                "total_solved": 15,
+                "dsa_done": 8,
+                "lc_total": 10,
+                "gfg_total": 2,
+                "cn_total": 1,
+                "hr_total": 0,
+                "lc_rating": 1500,
+            },
+            {
+                "user_id": "2",
+                "name": "Bob",
+                "college": "Beta",
+                "profile_photo": "",
+                "c_score": 30,
+                "total_solved": 12,
+                "dsa_done": 7,
+                "lc_total": 9,
+                "gfg_total": 1,
+                "cn_total": 0,
+                "hr_total": 0,
+                "lc_rating": 1700,
+            },
+        ],
+    )
+
+    snapshots = build_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["user_id"] == "2"
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert snapshots["questions"][0]["user_id"] == "1"
+    assert snapshots["rating"][0]["user_id"] == "2"
+    assert snapshots["college"][0]["rank"] == 1
+
+
+def test_update_question_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
+    invalidations = []
+
+    monkeypatch.setattr(tracker_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        login_test_user(client, test_db)
+        response = client.post(f"/update_question/{question_id}", json={"done": True})
+
+    assert response.status_code == 200
+    assert invalidations == ["cleared"]
+
+
+def test_edit_profile_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(profile_routes,))
+    invalidations = []
+
+    monkeypatch.setattr(profile_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        user_id = test_db.user.insert_one(
+            {"email": "user@example.com", "progress": {}, "is_admin": False, "name": "Before"}
+        ).inserted_id
+        login_test_user(client, user_id)
+        response = client.post("/edit_profile", json={"name": "After", "college": "New College"})
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert invalidations == ["cleared"]


### PR DESCRIPTION
## Summary
- switch the Flask-Login user loader to a lightweight session projection instead of fetching the full user document
- keep the fields needed by current_user across templates and authenticated routes in the projected payload
- add a focused regression test that verifies both the projection query and the wrapped user behavior

## Testing
- python3 -m pytest tests/test_auth_user_loader.py tests/test_registration_validation.py tests/test_google_oauth_nonce.py tests/test_oauth_linking.py -q
- python3 -m py_compile app/auth/routes.py tests/test_auth_user_loader.py
- git diff --check
