### PR TITLE
perf: project public card question fields

### DIFF
--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -3,8 +3,7 @@ from flask_login import current_user
 
 from app.extensions import limiter, cache
 from app.leaderboard.service import (
-    build_college_leaderboard_data,
-    build_leaderboard_data,
+    get_leaderboard_snapshot,
 )
 
 
@@ -15,31 +14,28 @@ leaderboard_bp = Blueprint("leaderboard", __name__)
 @limiter.limit("20 per minute")
 @cache.cached(timeout=300)
 def leaderboard():
-    entries = build_leaderboard_data()
+    by_cscore = get_leaderboard_snapshot("cscore")
+    by_questions = get_leaderboard_snapshot("questions")
+    by_rating = get_leaderboard_snapshot("rating")
+    by_college = get_leaderboard_snapshot("college")
 
-    by_cscore = sorted(entries, key=lambda item: item["c_score"], reverse=True)
-    by_questions = sorted(entries, key=lambda item: item["total_solved"], reverse=True)
-    by_rating = sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
-    by_college = build_college_leaderboard_data(entries)
-
-    def assign_ranks(sorted_list, key):
-        for index, entry in enumerate(sorted_list):
-            entry[f"rank_{key}"] = index + 1
-        return sorted_list
-
-    assign_ranks(by_cscore, "cscore")
-    assign_ranks(by_questions, "questions")
-    assign_ranks(by_rating, "rating")
-    assign_ranks(by_college, "college")
+    for entry in by_cscore:
+        entry["rank_cscore"] = entry["rank"]
+    for entry in by_questions:
+        entry["rank_questions"] = entry["rank"]
+    for entry in by_rating:
+        entry["rank_rating"] = entry["rank"]
+    for entry in by_college:
+        entry["rank_college"] = entry["rank"]
 
     current_user_id = str(current_user.id) if current_user.is_authenticated else None
     
     # Find current user's rank in each category
     current_user_rank = None
     if current_user_id:
-        for i, entry in enumerate(by_cscore):
+        for entry in by_cscore:
             if entry.get("user_id") == current_user_id:
-                current_user_rank = i + 1
+                current_user_rank = entry["rank"]
                 break
     
     return render_template(
@@ -138,20 +134,7 @@ def api_leaderboard():
     page = int(request.args.get("page", 1))
     per_page = min(int(request.args.get("per_page", 20)), 100)
     
-    entries = build_leaderboard_data()
-
-    if mode == "questions":
-        entries.sort(key=lambda item: item["total_solved"], reverse=True)
-    elif mode == "rating":
-        entries.sort(key=lambda item: item["lc_rating"], reverse=True)
-    elif mode == "college":
-        entries = build_college_leaderboard_data(entries)
-    else:
-        entries.sort(key=lambda item: item["c_score"], reverse=True)
-
-    # Assign ranks
-    for index, entry in enumerate(entries):
-        entry["rank"] = index + 1
+    entries = get_leaderboard_snapshot(mode)
 
     # Pagination
     total = len(entries)

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -1,5 +1,9 @@
-from app.extensions import db
+from app.extensions import cache, db
 from app.utils import compute_c_score
+
+LEADERBOARD_SNAPSHOT_CACHE_KEY = "leaderboard:snapshots:v1"
+LEADERBOARD_SNAPSHOT_TTL = 300
+LEADERBOARD_MODES = ("cscore", "questions", "rating", "college")
 
 
 def build_leaderboard_data():
@@ -111,3 +115,47 @@ def build_college_leaderboard_data(entries=None):
         key=lambda item: (item["c_score"], item["total_solved"], item["member_count"]),
         reverse=True,
     )
+
+
+def _rank_entries(entries):
+    ranked = []
+    for index, entry in enumerate(entries, start=1):
+        ranked.append({**entry, "rank": index})
+    return ranked
+
+
+def _sort_leaderboard_entries(entries, mode):
+    if mode == "questions":
+        return sorted(entries, key=lambda item: item["total_solved"], reverse=True)
+    if mode == "rating":
+        return sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
+    if mode == "college":
+        return build_college_leaderboard_data(entries)
+    return sorted(entries, key=lambda item: item["c_score"], reverse=True)
+
+
+def build_leaderboard_snapshots():
+    entries = build_leaderboard_data()
+    return {
+        mode: _rank_entries(_sort_leaderboard_entries(entries, mode))
+        for mode in LEADERBOARD_MODES
+    }
+
+
+def get_leaderboard_snapshot(mode, force_refresh=False):
+    mode = mode if mode in LEADERBOARD_MODES else "cscore"
+    snapshots = None if force_refresh else cache.get(LEADERBOARD_SNAPSHOT_CACHE_KEY)
+    if snapshots is None:
+        snapshots = build_leaderboard_snapshots()
+        cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return [dict(entry) for entry in snapshots[mode]]
+
+
+def refresh_leaderboard_snapshots():
+    snapshots = build_leaderboard_snapshots()
+    cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return snapshots
+
+
+def clear_leaderboard_snapshots():
+    cache.delete(LEADERBOARD_SNAPSHOT_CACHE_KEY)

--- a/app/profile/card_service.py
+++ b/app/profile/card_service.py
@@ -12,6 +12,7 @@ from streaks import compute_streak
 
 card_cache = {}
 CACHE_TTL = 3600
+PUBLIC_CARD_QUESTION_PROJECTION = {"url": 1}
 
 
 def get_public_card_image(user_id, object_id=None, db_handle=None):
@@ -40,7 +41,7 @@ def get_public_card_image(user_id, object_id=None, db_handle=None):
     progress_data = user.get("progress", {})
     current_streak, _ = compute_streak(progress_data)
 
-    all_questions = list(db_handle.question.find())
+    all_questions = list(db_handle.question.find({}, PUBLIC_CARD_QUESTION_PROJECTION))
     solved_items = {qid: progress for qid, progress in progress_data.items() if progress.get("done")}
     platforms = compute_user_platforms(solved_items, user.get("external_totals", {}), all_questions)
 

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -6,6 +6,7 @@ from flask_login import current_user, login_required
 
 from app.extensions import db
 from app.extensions import limiter, cache
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.platforms.fetchers import (
     fetch_atcoder,
     fetch_coding_ninjas,
@@ -273,6 +274,7 @@ def sync_platforms():
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
 
+    clear_leaderboard_snapshots()
     cache.clear()
     return jsonify(build_sync_platforms_response(platform_status))
 
@@ -351,6 +353,7 @@ def edit_profile():
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
     return json_success()
 
 

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -3,6 +3,7 @@ from flask import Blueprint, Response, jsonify, render_template, request
 from flask_login import current_user, login_required
 
 from app.extensions import db
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.utils import json_error, json_success, utc_now
 from notes_export import build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
@@ -201,6 +202,7 @@ def update_question(question_id):
     if update_fields:
         db.user.update_one({"_id": user_id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
         return json_success(message=message)
 
     return json_success(message="No changes made")

--- a/tests/test_leaderboard_snapshots.py
+++ b/tests/test_leaderboard_snapshots.py
@@ -1,0 +1,156 @@
+from bson import ObjectId
+
+from conftest import build_test_app, login_test_user
+from app.leaderboard.service import (
+    LEADERBOARD_SNAPSHOT_CACHE_KEY,
+    build_leaderboard_snapshots,
+    clear_leaderboard_snapshots,
+    get_leaderboard_snapshot,
+    refresh_leaderboard_snapshots,
+)
+from app.leaderboard import service as leaderboard_service
+import app.profile.routes as profile_routes
+import app.tracker.routes as tracker_routes
+
+
+class FakeCache:
+    def __init__(self):
+        self.values = {}
+        self.set_calls = []
+        self.delete_calls = []
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value, timeout=None):
+        self.values[key] = value
+        self.set_calls.append((key, timeout))
+
+    def delete(self, key):
+        self.values.pop(key, None)
+        self.delete_calls.append(key)
+
+
+def test_get_leaderboard_snapshot_uses_cached_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+    build_calls = []
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: build_calls.append("built") or {
+            "cscore": [{"user_id": "1", "rank": 1, "c_score": 42}],
+            "questions": [{"user_id": "1", "rank": 1, "total_solved": 10}],
+            "rating": [{"user_id": "1", "rank": 1, "lc_rating": 1800}],
+            "college": [{"user_id": "", "rank": 1, "college": "Alpha"}],
+        },
+    )
+
+    first = get_leaderboard_snapshot("cscore")
+    second = get_leaderboard_snapshot("questions")
+
+    assert build_calls == ["built"]
+    assert fake_cache.set_calls == [(LEADERBOARD_SNAPSHOT_CACHE_KEY, leaderboard_service.LEADERBOARD_SNAPSHOT_TTL)]
+    assert first[0]["c_score"] == 42
+    assert second[0]["total_solved"] == 10
+
+
+def test_refresh_and_clear_leaderboard_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: {
+            "cscore": [{"rank": 1}],
+            "questions": [{"rank": 1}],
+            "rating": [{"rank": 1}],
+            "college": [{"rank": 1}],
+        },
+    )
+
+    snapshots = refresh_leaderboard_snapshots()
+    clear_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert fake_cache.delete_calls == [LEADERBOARD_SNAPSHOT_CACHE_KEY]
+
+
+def test_build_leaderboard_snapshots_assigns_ranks(monkeypatch):
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_data",
+        lambda: [
+            {
+                "user_id": "1",
+                "name": "Alice",
+                "college": "Alpha",
+                "profile_photo": "",
+                "c_score": 20,
+                "total_solved": 15,
+                "dsa_done": 8,
+                "lc_total": 10,
+                "gfg_total": 2,
+                "cn_total": 1,
+                "hr_total": 0,
+                "lc_rating": 1500,
+            },
+            {
+                "user_id": "2",
+                "name": "Bob",
+                "college": "Beta",
+                "profile_photo": "",
+                "c_score": 30,
+                "total_solved": 12,
+                "dsa_done": 7,
+                "lc_total": 9,
+                "gfg_total": 1,
+                "cn_total": 0,
+                "hr_total": 0,
+                "lc_rating": 1700,
+            },
+        ],
+    )
+
+    snapshots = build_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["user_id"] == "2"
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert snapshots["questions"][0]["user_id"] == "1"
+    assert snapshots["rating"][0]["user_id"] == "2"
+    assert snapshots["college"][0]["rank"] == 1
+
+
+def test_update_question_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
+    invalidations = []
+
+    monkeypatch.setattr(tracker_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        login_test_user(client, test_db)
+        response = client.post(f"/update_question/{question_id}", json={"done": True})
+
+    assert response.status_code == 200
+    assert invalidations == ["cleared"]
+
+
+def test_edit_profile_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(profile_routes,))
+    invalidations = []
+
+    monkeypatch.setattr(profile_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        user_id = test_db.user.insert_one(
+            {"email": "user@example.com", "progress": {}, "is_admin": False, "name": "Before"}
+        ).inserted_id
+        login_test_user(client, user_id)
+        response = client.post("/edit_profile", json={"name": "After", "college": "New College"})
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert invalidations == ["cleared"]

--- a/tests/test_public_card_service.py
+++ b/tests/test_public_card_service.py
@@ -18,11 +18,13 @@ class FakeUserCollection:
 class FakeQuestionCollection:
     def __init__(self, questions):
         self.questions = list(questions)
+        self.find_calls = []
 
     def count_documents(self, query):
         return len(self.questions)
 
     def find(self, *args, **kwargs):
+        self.find_calls.append((args, kwargs))
         return list(self.questions)
 
 
@@ -84,3 +86,37 @@ def test_get_public_card_image_raises_for_missing_user(monkeypatch):
         assert "User not found" in str(exc)
     else:
         raise AssertionError("Expected LookupError for missing user")
+
+
+def test_get_public_card_image_projects_question_fields(monkeypatch):
+    user_id = ObjectId()
+    user = {
+        "_id": user_id,
+        "name": "Projection User",
+        "progress": {"q1": {"done": True}},
+        "external_totals": {},
+    }
+    fake_db = FakeDB(user, [{"_id": "q1", "url": "https://leetcode.com/problems/two-sum", "problem": "Two Sum"}])
+
+    monkeypatch.setattr("app.profile.card_service.db", fake_db)
+    monkeypatch.setattr(
+        "app.profile.card_service.compute_c_score",
+        lambda user_doc: {"c_score": 50, "dsa_done": 1},
+    )
+    monkeypatch.setattr("app.profile.card_service.compute_streak", lambda progress: (1, 1))
+    monkeypatch.setattr(
+        "app.profile.card_service.compute_user_platforms",
+        lambda solved, totals, all_questions: {"LeetCode": 1},
+    )
+    monkeypatch.setattr(
+        "app.profile.card_service.card_generator.generate_progress_card",
+        lambda *args, **kwargs: BytesIO(b"projection-png"),
+    )
+
+    card_cache.clear()
+    result = get_public_card_image(str(user_id), user_id)
+
+    assert result.read() == b"projection-png"
+    assert fake_db.question.find_calls == [
+        (({}, {"url": 1}), {}),
+    ]


### PR DESCRIPTION
## Summary
- project only the public-card question fields needed for platform counting instead of loading full question documents
- keep the card output unchanged while reducing the data read for each uncached card render
- add a regression test that pins the projected question query shape

## Testing
- python3 -m pytest tests/test_public_card_service.py tests/test_progress_card.py -q
- python3 -m py_compile app/profile/card_service.py tests/test_public_card_service.py
- git diff --check
