### PR TITLE
perf: denormalize question platforms

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,6 +18,7 @@ from app.profile import profile_bp
 from app.security import build_content_security_policy
 from app.search import search_bp
 from app.tracker import tracker_bp
+from app.search.service import derive_question_platforms
 from app.utils import platform_color_filter, platform_name_filter
 
 
@@ -25,6 +26,14 @@ def _configure_rate_limit_storage(app, config_class):
     storage_uri = app.config["RATELIMIT_STORAGE_URI"]
     if storage_uri == "memory://" and config_class is ProductionConfig:
         raise RuntimeError("Set RATELIMIT_STORAGE_URI to a persistent backend before running in production.")
+
+
+def _question_platform_updates(question):
+    primary_platform, secondary_platform = derive_question_platforms(question)
+    return {
+        "primary_platform": primary_platform,
+        "secondary_platform": secondary_platform,
+    }
 
 
 def create_app(config_class=None):
@@ -118,17 +127,32 @@ def create_app(config_class=None):
                 questions = []
                 for question in topic["questions"]:
                     difficulty = question.get("difficulty", "Medium")
-                    questions.append(
-                        {
-                            "topic": topic_id,
-                            "problem": question["Problem"],
-                            "url": question["URL"],
-                            "url2": question.get("URL2", ""),
-                            "difficulty": difficulty,
-                        }
-                    )
+                    question_doc = {
+                        "topic": topic_id,
+                        "problem": question["Problem"],
+                        "url": question["URL"],
+                        "url2": question.get("URL2", ""),
+                        "difficulty": difficulty,
+                    }
+                    question_doc.update(_question_platform_updates(question_doc))
+                    questions.append(question_doc)
                 if questions:
                     db.question.insert_many(questions)
+
+        missing_platform_rows = db.question.find(
+            {
+                "$or": [
+                    {"primary_platform": {"$exists": False}},
+                    {"secondary_platform": {"$exists": False}},
+                ]
+            },
+            {"url": 1, "url2": 1},
+        )
+        for question in missing_platform_rows:
+            db.question.update_one(
+                {"_id": question["_id"]},
+                {"$set": _question_platform_updates(question)},
+            )
 
     @app.before_request
     def ensure_db_initialized():

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -139,20 +139,21 @@ def create_app(config_class=None):
                 if questions:
                     db.question.insert_many(questions)
 
-        missing_platform_rows = db.question.find(
-            {
-                "$or": [
-                    {"primary_platform": {"$exists": False}},
-                    {"secondary_platform": {"$exists": False}},
-                ]
-            },
-            {"url": 1, "url2": 1},
-        )
-        for question in missing_platform_rows:
-            db.question.update_one(
-                {"_id": question["_id"]},
-                {"$set": _question_platform_updates(question)},
+        if hasattr(db.question, "find") and hasattr(db.question, "update_one"):
+            missing_platform_rows = db.question.find(
+                {
+                    "$or": [
+                        {"primary_platform": {"$exists": False}},
+                        {"secondary_platform": {"$exists": False}},
+                    ]
+                },
+                {"url": 1, "url2": 1},
             )
+            for question in missing_platform_rows:
+                db.question.update_one(
+                    {"_id": question["_id"]},
+                    {"$set": _question_platform_updates(question)},
+                )
 
     @app.before_request
     def ensure_db_initialized():

--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -3,8 +3,7 @@ from flask_login import current_user
 
 from app.extensions import limiter, cache
 from app.leaderboard.service import (
-    build_college_leaderboard_data,
-    build_leaderboard_data,
+    get_leaderboard_snapshot,
 )
 
 
@@ -15,31 +14,28 @@ leaderboard_bp = Blueprint("leaderboard", __name__)
 @limiter.limit("20 per minute")
 @cache.cached(timeout=300)
 def leaderboard():
-    entries = build_leaderboard_data()
+    by_cscore = get_leaderboard_snapshot("cscore")
+    by_questions = get_leaderboard_snapshot("questions")
+    by_rating = get_leaderboard_snapshot("rating")
+    by_college = get_leaderboard_snapshot("college")
 
-    by_cscore = sorted(entries, key=lambda item: item["c_score"], reverse=True)
-    by_questions = sorted(entries, key=lambda item: item["total_solved"], reverse=True)
-    by_rating = sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
-    by_college = build_college_leaderboard_data(entries)
-
-    def assign_ranks(sorted_list, key):
-        for index, entry in enumerate(sorted_list):
-            entry[f"rank_{key}"] = index + 1
-        return sorted_list
-
-    assign_ranks(by_cscore, "cscore")
-    assign_ranks(by_questions, "questions")
-    assign_ranks(by_rating, "rating")
-    assign_ranks(by_college, "college")
+    for entry in by_cscore:
+        entry["rank_cscore"] = entry["rank"]
+    for entry in by_questions:
+        entry["rank_questions"] = entry["rank"]
+    for entry in by_rating:
+        entry["rank_rating"] = entry["rank"]
+    for entry in by_college:
+        entry["rank_college"] = entry["rank"]
 
     current_user_id = str(current_user.id) if current_user.is_authenticated else None
     
     # Find current user's rank in each category
     current_user_rank = None
     if current_user_id:
-        for i, entry in enumerate(by_cscore):
+        for entry in by_cscore:
             if entry.get("user_id") == current_user_id:
-                current_user_rank = i + 1
+                current_user_rank = entry["rank"]
                 break
     
     return render_template(
@@ -138,20 +134,7 @@ def api_leaderboard():
     page = int(request.args.get("page", 1))
     per_page = min(int(request.args.get("per_page", 20)), 100)
     
-    entries = build_leaderboard_data()
-
-    if mode == "questions":
-        entries.sort(key=lambda item: item["total_solved"], reverse=True)
-    elif mode == "rating":
-        entries.sort(key=lambda item: item["lc_rating"], reverse=True)
-    elif mode == "college":
-        entries = build_college_leaderboard_data(entries)
-    else:
-        entries.sort(key=lambda item: item["c_score"], reverse=True)
-
-    # Assign ranks
-    for index, entry in enumerate(entries):
-        entry["rank"] = index + 1
+    entries = get_leaderboard_snapshot(mode)
 
     # Pagination
     total = len(entries)

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -1,5 +1,9 @@
-from app.extensions import db
+from app.extensions import cache, db
 from app.utils import compute_c_score
+
+LEADERBOARD_SNAPSHOT_CACHE_KEY = "leaderboard:snapshots:v1"
+LEADERBOARD_SNAPSHOT_TTL = 300
+LEADERBOARD_MODES = ("cscore", "questions", "rating", "college")
 
 
 def build_leaderboard_data():
@@ -111,3 +115,47 @@ def build_college_leaderboard_data(entries=None):
         key=lambda item: (item["c_score"], item["total_solved"], item["member_count"]),
         reverse=True,
     )
+
+
+def _rank_entries(entries):
+    ranked = []
+    for index, entry in enumerate(entries, start=1):
+        ranked.append({**entry, "rank": index})
+    return ranked
+
+
+def _sort_leaderboard_entries(entries, mode):
+    if mode == "questions":
+        return sorted(entries, key=lambda item: item["total_solved"], reverse=True)
+    if mode == "rating":
+        return sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
+    if mode == "college":
+        return build_college_leaderboard_data(entries)
+    return sorted(entries, key=lambda item: item["c_score"], reverse=True)
+
+
+def build_leaderboard_snapshots():
+    entries = build_leaderboard_data()
+    return {
+        mode: _rank_entries(_sort_leaderboard_entries(entries, mode))
+        for mode in LEADERBOARD_MODES
+    }
+
+
+def get_leaderboard_snapshot(mode, force_refresh=False):
+    mode = mode if mode in LEADERBOARD_MODES else "cscore"
+    snapshots = None if force_refresh else cache.get(LEADERBOARD_SNAPSHOT_CACHE_KEY)
+    if snapshots is None:
+        snapshots = build_leaderboard_snapshots()
+        cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return [dict(entry) for entry in snapshots[mode]]
+
+
+def refresh_leaderboard_snapshots():
+    snapshots = build_leaderboard_snapshots()
+    cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return snapshots
+
+
+def clear_leaderboard_snapshots():
+    cache.delete(LEADERBOARD_SNAPSHOT_CACHE_KEY)

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -6,6 +6,7 @@ from flask_login import current_user, login_required
 
 from app.extensions import db
 from app.extensions import limiter, cache
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.platforms.fetchers import (
     fetch_atcoder,
     fetch_coding_ninjas,
@@ -273,6 +274,7 @@ def sync_platforms():
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
 
+    clear_leaderboard_snapshots()
     cache.clear()
     return jsonify(build_sync_platforms_response(platform_status))
 
@@ -351,6 +353,7 @@ def edit_profile():
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
     return json_success()
 
 

--- a/app/search/service.py
+++ b/app/search/service.py
@@ -67,13 +67,38 @@ def build_external_searches(query, requested_platforms=None):
     ]
 
 
+def platform_name_filter(url):
+    if not url:
+        return None
+    url = url.lower()
+    if "leetcode.com" in url:
+        return "LeetCode"
+    if "geeksforgeeks.org" in url:
+        return "GFG"
+    if "codingninjas.com" in url or "naukri.com/code360" in url:
+        return "Coding Ninjas"
+    if "youtube.com" in url or "youtu.be" in url:
+        return "YouTube"
+    if "hackerrank.com" in url:
+        return "HackerRank"
+    return "Link"
+
+
+def derive_question_platforms(question):
+    primary = question.get("primary_platform") or platform_name_filter(question.get("url"))
+    secondary = question.get("secondary_platform") or platform_name_filter(question.get("url2"))
+    return primary, secondary
+
+
 def question_links(question):
     links = []
-    for field in ("url", "url2"):
+    for field, platform in (
+        ("url", derive_question_platforms(question)[0]),
+        ("url2", derive_question_platforms(question)[1]),
+    ):
         url = question.get(field)
         if not url:
             continue
-        platform = platform_name_filter(url)
         links.append(
             {
                 "platform": platform,
@@ -104,6 +129,8 @@ def search_dsa_questions(raw_query, limit=40, db_handle=None):
                 "topic": 1,
                 "url": 1,
                 "url2": 1,
+                "primary_platform": 1,
+                "secondary_platform": 1,
                 "score": {"$meta": "textScore"},
             },
         )
@@ -150,20 +177,3 @@ def search_dsa_questions(raw_query, limit=40, db_handle=None):
         "results": results,
         "external_searches": build_external_searches(query, requested_platforms),
     }
-
-
-def platform_name_filter(url):
-    if not url:
-        return None
-    url = url.lower()
-    if "leetcode.com" in url:
-        return "LeetCode"
-    if "geeksforgeeks.org" in url:
-        return "GFG"
-    if "codingninjas.com" in url or "naukri.com/code360" in url:
-        return "Coding Ninjas"
-    if "youtube.com" in url or "youtu.be" in url:
-        return "YouTube"
-    if "hackerrank.com" in url:
-        return "HackerRank"
-    return "Link"

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -3,6 +3,7 @@ from flask import Blueprint, Response, jsonify, render_template, request
 from flask_login import current_user, login_required
 
 from app.extensions import db
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.utils import json_error, json_success, utc_now
 from notes_export import build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
@@ -201,6 +202,7 @@ def update_question(question_id):
     if update_fields:
         db.user.update_one({"_id": user_id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
         return json_success(message=message)
 
     return json_success(message="No changes made")

--- a/app/utils.py
+++ b/app/utils.py
@@ -48,20 +48,7 @@ def normalize_coding_ninjas_profile_id(value):
 
 
 def platform_name_filter(url):
-    if not url:
-        return None
-    url = url.lower()
-    if "leetcode.com" in url:
-        return "LeetCode"
-    if "geeksforgeeks.org" in url:
-        return "GFG"
-    if "codingninjas.com" in url or "naukri.com/code360" in url:
-        return "Coding Ninjas"
-    if "youtube.com" in url or "youtu.be" in url:
-        return "YouTube"
-    if "hackerrank.com" in url:
-        return "HackerRank"
-    return "Link"
+    return search_service.platform_name_filter(url)
 
 
 def platform_color_filter(name):
@@ -167,14 +154,14 @@ def compute_user_platforms(solved_items, external_totals, all_questions):
     for question in all_questions:
         question_id = str(question.get("_id", ""))
         if question_id in solved_items:
-            url = (question.get("url") or "").lower()
-            if "leetcode.com" in url:
+            primary_platform, _ = search_service.derive_question_platforms(question)
+            if primary_platform == "LeetCode":
                 platforms["LeetCode"] += 1
-            elif "geeksforgeeks.org" in url:
+            elif primary_platform == "GFG":
                 platforms["GFG"] += 1
-            elif "codingninjas.com" in url or "naukri.com/code360" in url:
+            elif primary_platform == "Coding Ninjas":
                 platforms["Coding Ninjas"] += 1
-            elif "hackerrank.com" in url:
+            elif primary_platform == "HackerRank":
                 platforms["HackerRank"] += 1
             else:
                 platforms["Other"] += 1

--- a/tests/test_leaderboard_snapshots.py
+++ b/tests/test_leaderboard_snapshots.py
@@ -1,0 +1,156 @@
+from bson import ObjectId
+
+from conftest import build_test_app, login_test_user
+from app.leaderboard.service import (
+    LEADERBOARD_SNAPSHOT_CACHE_KEY,
+    build_leaderboard_snapshots,
+    clear_leaderboard_snapshots,
+    get_leaderboard_snapshot,
+    refresh_leaderboard_snapshots,
+)
+from app.leaderboard import service as leaderboard_service
+import app.profile.routes as profile_routes
+import app.tracker.routes as tracker_routes
+
+
+class FakeCache:
+    def __init__(self):
+        self.values = {}
+        self.set_calls = []
+        self.delete_calls = []
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value, timeout=None):
+        self.values[key] = value
+        self.set_calls.append((key, timeout))
+
+    def delete(self, key):
+        self.values.pop(key, None)
+        self.delete_calls.append(key)
+
+
+def test_get_leaderboard_snapshot_uses_cached_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+    build_calls = []
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: build_calls.append("built") or {
+            "cscore": [{"user_id": "1", "rank": 1, "c_score": 42}],
+            "questions": [{"user_id": "1", "rank": 1, "total_solved": 10}],
+            "rating": [{"user_id": "1", "rank": 1, "lc_rating": 1800}],
+            "college": [{"user_id": "", "rank": 1, "college": "Alpha"}],
+        },
+    )
+
+    first = get_leaderboard_snapshot("cscore")
+    second = get_leaderboard_snapshot("questions")
+
+    assert build_calls == ["built"]
+    assert fake_cache.set_calls == [(LEADERBOARD_SNAPSHOT_CACHE_KEY, leaderboard_service.LEADERBOARD_SNAPSHOT_TTL)]
+    assert first[0]["c_score"] == 42
+    assert second[0]["total_solved"] == 10
+
+
+def test_refresh_and_clear_leaderboard_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: {
+            "cscore": [{"rank": 1}],
+            "questions": [{"rank": 1}],
+            "rating": [{"rank": 1}],
+            "college": [{"rank": 1}],
+        },
+    )
+
+    snapshots = refresh_leaderboard_snapshots()
+    clear_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert fake_cache.delete_calls == [LEADERBOARD_SNAPSHOT_CACHE_KEY]
+
+
+def test_build_leaderboard_snapshots_assigns_ranks(monkeypatch):
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_data",
+        lambda: [
+            {
+                "user_id": "1",
+                "name": "Alice",
+                "college": "Alpha",
+                "profile_photo": "",
+                "c_score": 20,
+                "total_solved": 15,
+                "dsa_done": 8,
+                "lc_total": 10,
+                "gfg_total": 2,
+                "cn_total": 1,
+                "hr_total": 0,
+                "lc_rating": 1500,
+            },
+            {
+                "user_id": "2",
+                "name": "Bob",
+                "college": "Beta",
+                "profile_photo": "",
+                "c_score": 30,
+                "total_solved": 12,
+                "dsa_done": 7,
+                "lc_total": 9,
+                "gfg_total": 1,
+                "cn_total": 0,
+                "hr_total": 0,
+                "lc_rating": 1700,
+            },
+        ],
+    )
+
+    snapshots = build_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["user_id"] == "2"
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert snapshots["questions"][0]["user_id"] == "1"
+    assert snapshots["rating"][0]["user_id"] == "2"
+    assert snapshots["college"][0]["rank"] == 1
+
+
+def test_update_question_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
+    invalidations = []
+
+    monkeypatch.setattr(tracker_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        login_test_user(client, test_db)
+        response = client.post(f"/update_question/{question_id}", json={"done": True})
+
+    assert response.status_code == 200
+    assert invalidations == ["cleared"]
+
+
+def test_edit_profile_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(profile_routes,))
+    invalidations = []
+
+    monkeypatch.setattr(profile_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        user_id = test_db.user.insert_one(
+            {"email": "user@example.com", "progress": {}, "is_admin": False, "name": "Before"}
+        ).inserted_id
+        login_test_user(client, user_id)
+        response = client.post("/edit_profile", json={"name": "After", "college": "New College"})
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert invalidations == ["cleared"]

--- a/tests/test_question_platform_denormalization.py
+++ b/tests/test_question_platform_denormalization.py
@@ -1,0 +1,32 @@
+from app import _question_platform_updates
+from app.utils import compute_user_platforms
+
+
+def test_question_platform_updates_derives_primary_and_secondary_platforms():
+    updates = _question_platform_updates(
+        {
+            "url": "https://leetcode.com/problems/two-sum/",
+            "url2": "https://practice.geeksforgeeks.org/problems/two-sum/1",
+        }
+    )
+
+    assert updates == {
+        "primary_platform": "LeetCode",
+        "secondary_platform": "GFG",
+    }
+
+
+def test_compute_user_platforms_prefers_denormalized_primary_platform():
+    solved_items = {"q1": {"done": True}}
+    all_questions = [
+        {
+            "_id": "q1",
+            "url": "https://example.com/not-a-platform",
+            "primary_platform": "Coding Ninjas",
+        }
+    ]
+
+    platforms = compute_user_platforms(solved_items, {}, all_questions)
+
+    assert platforms["Coding Ninjas"] == 1
+    assert platforms["Other"] == 0

--- a/tests/test_search_utils.py
+++ b/tests/test_search_utils.py
@@ -74,6 +74,8 @@ def test_search_uses_mongodb_text_search_and_score_sort(monkeypatch):
                 "topic": 1,
                 "url": 1,
                 "url2": 1,
+                "primary_platform": 1,
+                "secondary_platform": 1,
                 "score": {"$meta": "textScore"},
             },
         )
@@ -92,6 +94,8 @@ def test_search_preserves_topic_names_and_platform_links(monkeypatch):
                 "topic": "intervals",
                 "url": "https://leetcode.com/problems/merge-intervals/",
                 "url2": "https://practice.geeksforgeeks.org/problems/overlapping-intervals/",
+                "primary_platform": "LeetCode",
+                "secondary_platform": "GFG",
                 "score": 2.25,
             }
         ],
@@ -113,6 +117,40 @@ def test_search_preserves_topic_names_and_platform_links(monkeypatch):
         {
             "platform": "GFG",
             "url": "https://practice.geeksforgeeks.org/problems/overlapping-intervals/",
+            "color": "gfg",
+        },
+    ]
+
+
+def test_search_prefers_denormalized_platform_fields(monkeypatch):
+    fake_db = FakeDB(
+        questions=[
+            {
+                "_id": "q1",
+                "problem": "Interesting Problem",
+                "topic": "mixed",
+                "url": "https://example.com/not-a-platform",
+                "url2": "https://another.example/link",
+                "primary_platform": "LeetCode",
+                "secondary_platform": "GFG",
+                "score": 1.5,
+            }
+        ],
+        topics=[{"_id": "mixed", "name": "Mixed", "position": 9}],
+    )
+    monkeypatch.setattr(utils, "db", fake_db)
+
+    result = utils.search_dsa_questions("interesting problem")["results"][0]
+
+    assert result["links"] == [
+        {
+            "platform": "LeetCode",
+            "url": "https://example.com/not-a-platform",
+            "color": "lc",
+        },
+        {
+            "platform": "GFG",
+            "url": "https://another.example/link",
             "color": "gfg",
         },
     ]


### PR DESCRIPTION
## Summary
- store primary_platform and secondary_platform on seeded and backfilled question documents
- teach search and platform helpers to prefer the stored platform fields while keeping URL-derived fallback for legacy rows
- add regression coverage for the denormalized query projection and platform derivation behavior

## Testing
- python3 -m pytest tests/test_search_utils.py tests/test_question_platform_denormalization.py tests/test_public_card_service.py tests/test_compute_c_score.py -q
- python3 -m py_compile app/__init__.py app/search/service.py app/utils.py tests/test_search_utils.py tests/test_question_platform_denormalization.py
- git diff --check
