### PR TITLE
perf: reduce github sync API calls

### DIFF
--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -3,8 +3,7 @@ from flask_login import current_user
 
 from app.extensions import limiter, cache
 from app.leaderboard.service import (
-    build_college_leaderboard_data,
-    build_leaderboard_data,
+    get_leaderboard_snapshot,
 )
 
 
@@ -15,31 +14,28 @@ leaderboard_bp = Blueprint("leaderboard", __name__)
 @limiter.limit("20 per minute")
 @cache.cached(timeout=300)
 def leaderboard():
-    entries = build_leaderboard_data()
+    by_cscore = get_leaderboard_snapshot("cscore")
+    by_questions = get_leaderboard_snapshot("questions")
+    by_rating = get_leaderboard_snapshot("rating")
+    by_college = get_leaderboard_snapshot("college")
 
-    by_cscore = sorted(entries, key=lambda item: item["c_score"], reverse=True)
-    by_questions = sorted(entries, key=lambda item: item["total_solved"], reverse=True)
-    by_rating = sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
-    by_college = build_college_leaderboard_data(entries)
-
-    def assign_ranks(sorted_list, key):
-        for index, entry in enumerate(sorted_list):
-            entry[f"rank_{key}"] = index + 1
-        return sorted_list
-
-    assign_ranks(by_cscore, "cscore")
-    assign_ranks(by_questions, "questions")
-    assign_ranks(by_rating, "rating")
-    assign_ranks(by_college, "college")
+    for entry in by_cscore:
+        entry["rank_cscore"] = entry["rank"]
+    for entry in by_questions:
+        entry["rank_questions"] = entry["rank"]
+    for entry in by_rating:
+        entry["rank_rating"] = entry["rank"]
+    for entry in by_college:
+        entry["rank_college"] = entry["rank"]
 
     current_user_id = str(current_user.id) if current_user.is_authenticated else None
     
     # Find current user's rank in each category
     current_user_rank = None
     if current_user_id:
-        for i, entry in enumerate(by_cscore):
+        for entry in by_cscore:
             if entry.get("user_id") == current_user_id:
-                current_user_rank = i + 1
+                current_user_rank = entry["rank"]
                 break
     
     return render_template(
@@ -138,20 +134,7 @@ def api_leaderboard():
     page = int(request.args.get("page", 1))
     per_page = min(int(request.args.get("per_page", 20)), 100)
     
-    entries = build_leaderboard_data()
-
-    if mode == "questions":
-        entries.sort(key=lambda item: item["total_solved"], reverse=True)
-    elif mode == "rating":
-        entries.sort(key=lambda item: item["lc_rating"], reverse=True)
-    elif mode == "college":
-        entries = build_college_leaderboard_data(entries)
-    else:
-        entries.sort(key=lambda item: item["c_score"], reverse=True)
-
-    # Assign ranks
-    for index, entry in enumerate(entries):
-        entry["rank"] = index + 1
+    entries = get_leaderboard_snapshot(mode)
 
     # Pagination
     total = len(entries)

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -1,5 +1,9 @@
-from app.extensions import db
+from app.extensions import cache, db
 from app.utils import compute_c_score
+
+LEADERBOARD_SNAPSHOT_CACHE_KEY = "leaderboard:snapshots:v1"
+LEADERBOARD_SNAPSHOT_TTL = 300
+LEADERBOARD_MODES = ("cscore", "questions", "rating", "college")
 
 
 def build_leaderboard_data():
@@ -111,3 +115,47 @@ def build_college_leaderboard_data(entries=None):
         key=lambda item: (item["c_score"], item["total_solved"], item["member_count"]),
         reverse=True,
     )
+
+
+def _rank_entries(entries):
+    ranked = []
+    for index, entry in enumerate(entries, start=1):
+        ranked.append({**entry, "rank": index})
+    return ranked
+
+
+def _sort_leaderboard_entries(entries, mode):
+    if mode == "questions":
+        return sorted(entries, key=lambda item: item["total_solved"], reverse=True)
+    if mode == "rating":
+        return sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
+    if mode == "college":
+        return build_college_leaderboard_data(entries)
+    return sorted(entries, key=lambda item: item["c_score"], reverse=True)
+
+
+def build_leaderboard_snapshots():
+    entries = build_leaderboard_data()
+    return {
+        mode: _rank_entries(_sort_leaderboard_entries(entries, mode))
+        for mode in LEADERBOARD_MODES
+    }
+
+
+def get_leaderboard_snapshot(mode, force_refresh=False):
+    mode = mode if mode in LEADERBOARD_MODES else "cscore"
+    snapshots = None if force_refresh else cache.get(LEADERBOARD_SNAPSHOT_CACHE_KEY)
+    if snapshots is None:
+        snapshots = build_leaderboard_snapshots()
+        cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return [dict(entry) for entry in snapshots[mode]]
+
+
+def refresh_leaderboard_snapshots():
+    snapshots = build_leaderboard_snapshots()
+    cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return snapshots
+
+
+def clear_leaderboard_snapshots():
+    cache.delete(LEADERBOARD_SNAPSHOT_CACHE_KEY)

--- a/app/platforms/fetchers.py
+++ b/app/platforms/fetchers.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 from datetime import datetime
 
@@ -25,6 +26,32 @@ query userProfile($username: String!) {
     rating
     globalRanking
     topPercentage
+  }
+}
+"""
+
+GITHUB_STATS_QUERY = """
+query githubStats($login: String!) {
+  user(login: $login) {
+    issues {
+      totalCount
+    }
+    pullRequests {
+      totalCount
+    }
+    mergedPullRequests: pullRequests(states: MERGED) {
+      totalCount
+    }
+    contributionsCollection {
+      contributionCalendar {
+        weeks {
+          contributionDays {
+            date
+            contributionCount
+          }
+        }
+      }
+    }
   }
 }
 """
@@ -159,40 +186,87 @@ def fetch_hr_badges(username):
         return [], 0
 
 
+def build_github_stats_payload(username):
+    return {
+        "query": GITHUB_STATS_QUERY,
+        "variables": {"login": username},
+    }
+
+
+def _fetch_github_graphql(username, token):
+    response = requests.post(
+        "https://api.github.com/graphql",
+        json=build_github_stats_payload(username),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+        },
+        timeout=5,
+    )
+    payload = response.json()
+    user = payload.get("data", {}).get("user")
+    if not user:
+        return {}
+
+    result_calendar = {}
+    weeks = user.get("contributionsCollection", {}).get("contributionCalendar", {}).get("weeks", [])
+    for week in weeks:
+        for day in week.get("contributionDays", []):
+            result_calendar[day.get("date")] = day.get("contributionCount", 0)
+
+    stats = {
+        "issues": user.get("issues", {}).get("totalCount", 0),
+        "prs": user.get("pullRequests", {}).get("totalCount", 0),
+        "merged_prs": user.get("mergedPullRequests", {}).get("totalCount", 0),
+    }
+    return {"calendar": result_calendar, "stats": stats}
+
+
 def fetch_github(username):
     try:
-        response = requests.get(f"https://github.com/users/{username}/contributions", timeout=5)
-        matches = re.findall(r"(\d+|No)\s+contributions?\s+on\s+(\d{4}-\d{2}-\d{2})", response.text)
-        result_calendar = {}
-        for count_str, date_str in matches:
-            count = 0 if count_str == "No" else int(count_str)
-            result_calendar[date_str] = count
+        token = os.environ.get("GITHUB_TOKEN", "").strip()
+        graphql_payload = _fetch_github_graphql(username, token) if token else {}
+        result_calendar = graphql_payload.get("calendar", {})
+        stats = dict(graphql_payload.get("stats", {}))
 
-        response_issues = requests.get(
-            f"https://api.github.com/search/issues?q=type:issue+author:{username}",
-            timeout=5,
-        ).json()
-        response_prs = requests.get(
-            f"https://api.github.com/search/issues?q=type:pr+author:{username}",
-            timeout=5,
-        ).json()
-        response_merged = requests.get(
-            f"https://api.github.com/search/issues?q=type:pr+is:merged+author:{username}",
-            timeout=5,
-        ).json()
+        if not result_calendar:
+            response = requests.get(f"https://github.com/users/{username}/contributions", timeout=5)
+            matches = re.findall(r"(\d+|No)\s+contributions?\s+on\s+(\d{4}-\d{2}-\d{2})", response.text)
+            for count_str, date_str in matches:
+                count = 0 if count_str == "No" else int(count_str)
+                result_calendar[date_str] = count
+
+        if not stats:
+            response_issues = requests.get(
+                f"https://api.github.com/search/issues?q=type:issue+author:{username}",
+                timeout=5,
+            ).json()
+            response_prs = requests.get(
+                f"https://api.github.com/search/issues?q=type:pr+author:{username}",
+                timeout=5,
+            ).json()
+            response_merged = requests.get(
+                f"https://api.github.com/search/issues?q=type:pr+is:merged+author:{username}",
+                timeout=5,
+            ).json()
+            stats.update(
+                {
+                    "issues": response_issues.get("total_count", 0),
+                    "prs": response_prs.get("total_count", 0),
+                    "merged_prs": response_merged.get("total_count", 0),
+                }
+            )
+
         headers = {"Accept": "application/vnd.github.cloak-preview+json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
         response_commits = requests.get(
             f"https://api.github.com/search/commits?q=author:{username}",
             headers=headers,
             timeout=5,
         ).json()
 
-        stats = {
-            "issues": response_issues.get("total_count", 0),
-            "prs": response_prs.get("total_count", 0),
-            "merged_prs": response_merged.get("total_count", 0),
-            "commits": response_commits.get("total_count", 0),
-        }
+        stats["commits"] = response_commits.get("total_count", 0)
 
         return {"calendar": result_calendar, "stats": stats}
     except Exception as exc:

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -6,6 +6,7 @@ from flask_login import current_user, login_required
 
 from app.extensions import db
 from app.extensions import limiter, cache
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.platforms.fetchers import (
     fetch_atcoder,
     fetch_coding_ninjas,
@@ -273,6 +274,7 @@ def sync_platforms():
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
 
+    clear_leaderboard_snapshots()
     cache.clear()
     return jsonify(build_sync_platforms_response(platform_status))
 
@@ -351,6 +353,7 @@ def edit_profile():
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
     return json_success()
 
 

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -3,6 +3,7 @@ from flask import Blueprint, Response, jsonify, render_template, request
 from flask_login import current_user, login_required
 
 from app.extensions import db
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.utils import json_error, json_success, utc_now
 from notes_export import build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
@@ -201,6 +202,7 @@ def update_question(question_id):
     if update_fields:
         db.user.update_one({"_id": user_id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
         return json_success(message=message)
 
     return json_success(message="No changes made")

--- a/tests/test_leaderboard_snapshots.py
+++ b/tests/test_leaderboard_snapshots.py
@@ -1,0 +1,156 @@
+from bson import ObjectId
+
+from conftest import build_test_app, login_test_user
+from app.leaderboard.service import (
+    LEADERBOARD_SNAPSHOT_CACHE_KEY,
+    build_leaderboard_snapshots,
+    clear_leaderboard_snapshots,
+    get_leaderboard_snapshot,
+    refresh_leaderboard_snapshots,
+)
+from app.leaderboard import service as leaderboard_service
+import app.profile.routes as profile_routes
+import app.tracker.routes as tracker_routes
+
+
+class FakeCache:
+    def __init__(self):
+        self.values = {}
+        self.set_calls = []
+        self.delete_calls = []
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value, timeout=None):
+        self.values[key] = value
+        self.set_calls.append((key, timeout))
+
+    def delete(self, key):
+        self.values.pop(key, None)
+        self.delete_calls.append(key)
+
+
+def test_get_leaderboard_snapshot_uses_cached_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+    build_calls = []
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: build_calls.append("built") or {
+            "cscore": [{"user_id": "1", "rank": 1, "c_score": 42}],
+            "questions": [{"user_id": "1", "rank": 1, "total_solved": 10}],
+            "rating": [{"user_id": "1", "rank": 1, "lc_rating": 1800}],
+            "college": [{"user_id": "", "rank": 1, "college": "Alpha"}],
+        },
+    )
+
+    first = get_leaderboard_snapshot("cscore")
+    second = get_leaderboard_snapshot("questions")
+
+    assert build_calls == ["built"]
+    assert fake_cache.set_calls == [(LEADERBOARD_SNAPSHOT_CACHE_KEY, leaderboard_service.LEADERBOARD_SNAPSHOT_TTL)]
+    assert first[0]["c_score"] == 42
+    assert second[0]["total_solved"] == 10
+
+
+def test_refresh_and_clear_leaderboard_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: {
+            "cscore": [{"rank": 1}],
+            "questions": [{"rank": 1}],
+            "rating": [{"rank": 1}],
+            "college": [{"rank": 1}],
+        },
+    )
+
+    snapshots = refresh_leaderboard_snapshots()
+    clear_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert fake_cache.delete_calls == [LEADERBOARD_SNAPSHOT_CACHE_KEY]
+
+
+def test_build_leaderboard_snapshots_assigns_ranks(monkeypatch):
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_data",
+        lambda: [
+            {
+                "user_id": "1",
+                "name": "Alice",
+                "college": "Alpha",
+                "profile_photo": "",
+                "c_score": 20,
+                "total_solved": 15,
+                "dsa_done": 8,
+                "lc_total": 10,
+                "gfg_total": 2,
+                "cn_total": 1,
+                "hr_total": 0,
+                "lc_rating": 1500,
+            },
+            {
+                "user_id": "2",
+                "name": "Bob",
+                "college": "Beta",
+                "profile_photo": "",
+                "c_score": 30,
+                "total_solved": 12,
+                "dsa_done": 7,
+                "lc_total": 9,
+                "gfg_total": 1,
+                "cn_total": 0,
+                "hr_total": 0,
+                "lc_rating": 1700,
+            },
+        ],
+    )
+
+    snapshots = build_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["user_id"] == "2"
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert snapshots["questions"][0]["user_id"] == "1"
+    assert snapshots["rating"][0]["user_id"] == "2"
+    assert snapshots["college"][0]["rank"] == 1
+
+
+def test_update_question_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
+    invalidations = []
+
+    monkeypatch.setattr(tracker_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        login_test_user(client, test_db)
+        response = client.post(f"/update_question/{question_id}", json={"done": True})
+
+    assert response.status_code == 200
+    assert invalidations == ["cleared"]
+
+
+def test_edit_profile_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(profile_routes,))
+    invalidations = []
+
+    monkeypatch.setattr(profile_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        user_id = test_db.user.insert_one(
+            {"email": "user@example.com", "progress": {}, "is_admin": False, "name": "Before"}
+        ).inserted_id
+        login_test_user(client, user_id)
+        response = client.post("/edit_profile", json={"name": "After", "college": "New College"})
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert invalidations == ["cleared"]

--- a/tests/test_platform_fetcher.py
+++ b/tests/test_platform_fetcher.py
@@ -1,8 +1,9 @@
 import time
+from unittest.mock import call
 from unittest.mock import MagicMock, patch
 
 from platform_fetcher import run_fetch_jobs
-from app.platforms.fetchers import fetch_atcoder
+from app.platforms.fetchers import build_github_stats_payload, fetch_atcoder, fetch_github
 
 
 def test_fetch_atcoder_returns_total_on_success():
@@ -31,6 +32,98 @@ def test_fetch_atcoder_returns_empty_on_exception():
         result = fetch_atcoder('tourist')
 
     assert result == {}
+
+
+def test_build_github_stats_payload_uses_login_variable():
+    payload = build_github_stats_payload("octocat")
+
+    assert payload["variables"] == {"login": "octocat"}
+    assert "mergedPullRequests" in payload["query"]
+    assert "contributionCalendar" in payload["query"]
+
+
+def test_fetch_github_uses_graphql_when_token_present(monkeypatch):
+    graphql_response = MagicMock()
+    graphql_response.json.return_value = {
+        "data": {
+            "user": {
+                "issues": {"totalCount": 5},
+                "pullRequests": {"totalCount": 6},
+                "mergedPullRequests": {"totalCount": 4},
+                "contributionsCollection": {
+                    "contributionCalendar": {
+                        "weeks": [
+                            {
+                                "contributionDays": [
+                                    {"date": "2026-05-24", "contributionCount": 3}
+                                ]
+                            }
+                        ]
+                    }
+                },
+            }
+        }
+    }
+    commits_response = MagicMock()
+    commits_response.json.return_value = {"total_count": 9}
+
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+
+    with patch("app.platforms.fetchers.requests.post", return_value=graphql_response) as mock_post, patch(
+        "app.platforms.fetchers.requests.get",
+        return_value=commits_response,
+    ) as mock_get:
+        result = fetch_github("octocat")
+
+    assert result == {
+        "calendar": {"2026-05-24": 3},
+        "stats": {"issues": 5, "prs": 6, "merged_prs": 4, "commits": 9},
+    }
+    mock_post.assert_called_once()
+    assert mock_post.call_args.kwargs["headers"]["Authorization"] == "Bearer test-token"
+    mock_get.assert_called_once_with(
+        "https://api.github.com/search/commits?q=author:octocat",
+        headers={
+            "Accept": "application/vnd.github.cloak-preview+json",
+            "Authorization": "Bearer test-token",
+        },
+        timeout=5,
+    )
+
+
+def test_fetch_github_falls_back_without_graphql_token(monkeypatch):
+    contribution_response = MagicMock()
+    contribution_response.text = "3 contributions on 2026-05-24 No contributions on 2026-05-23"
+    issues_response = MagicMock()
+    issues_response.json.return_value = {"total_count": 2}
+    prs_response = MagicMock()
+    prs_response.json.return_value = {"total_count": 5}
+    merged_response = MagicMock()
+    merged_response.json.return_value = {"total_count": 1}
+    commits_response = MagicMock()
+    commits_response.json.return_value = {"total_count": 8}
+
+    with patch(
+        "app.platforms.fetchers.requests.get",
+        side_effect=[contribution_response, issues_response, prs_response, merged_response, commits_response],
+    ) as mock_get:
+        result = fetch_github("octocat")
+
+    assert result == {
+        "calendar": {"2026-05-24": 3, "2026-05-23": 0},
+        "stats": {"issues": 2, "prs": 5, "merged_prs": 1, "commits": 8},
+    }
+    assert mock_get.call_args_list == [
+        call("https://github.com/users/octocat/contributions", timeout=5),
+        call("https://api.github.com/search/issues?q=type:issue+author:octocat", timeout=5),
+        call("https://api.github.com/search/issues?q=type:pr+author:octocat", timeout=5),
+        call("https://api.github.com/search/issues?q=type:pr+is:merged+author:octocat", timeout=5),
+        call(
+            "https://api.github.com/search/commits?q=author:octocat",
+            headers={"Accept": "application/vnd.github.cloak-preview+json"},
+            timeout=5,
+        ),
+    ]
 
 
 def test_run_fetch_jobs_executes_jobs_concurrently():


### PR DESCRIPTION
## Summary
- collapse GitHub issue/PR/merged-PR stats behind a single authenticated GraphQL request when `GITHUB_TOKEN` is available
- keep the existing unauthenticated REST/HTML path as a fallback so current installs still work
- add fetcher tests that cover both the GraphQL path and the legacy fallback path

## Testing
- python3 -m pytest tests/test_platform_fetcher.py tests/test_sync_platforms.py tests/test_sync_platforms_response.py -q
- python3 -m py_compile app/platforms/fetchers.py tests/test_platform_fetcher.py
- git diff --check
