### PR TITLE
refactor: extract shared template badge macros

### DIFF
--- a/templates/bookmarks.html
+++ b/templates/bookmarks.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "macros/modals.html" import notes_modal %}
+{% from "macros/ui_bits.html" import question_link_badge %}
 {% block content %}
 <style>
   .page-title {
@@ -126,12 +127,8 @@
         <td>
           <div class="q-name">{{ q.problem }}</div>
           <div class="q-links">
-            {% if q.url %}<a href="{{ q.url }}" target="_blank" rel="noopener noreferrer"
-              class="q-badge {% if 'leetcode' in q.url %}badge-lc{% elif 'geeksforgeeks' in q.url %}badge-gfg{% else %}badge-link{% endif %}"><i
-                class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{ q.url|platform_name }}</a>{% endif %}
-            {% if q.url2 %}<a href="{{ q.url2 }}" target="_blank" rel="noopener noreferrer"
-              class="q-badge badge-link"><i class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{
-              q.url2|platform_name }}</a>{% endif %}
+            {% if q.url %}{{ question_link_badge(q.url, q.url|platform_name, 'Solve on ' ~ (q.url|platform_name) ~ ' (opens in new tab)') }}{% endif %}
+            {% if q.url2 %}{{ question_link_badge(q.url2, q.url2|platform_name, 'Solve on ' ~ (q.url2|platform_name) ~ ' (opens in new tab)') }}{% endif %}
           </div>
         </td>
         <td>

--- a/templates/macros/ui_bits.html
+++ b/templates/macros/ui_bits.html
@@ -1,0 +1,30 @@
+{% macro question_link_badge(url, platform_name, aria_label='') -%}
+  {% set label = aria_label or ('Solve on ' ~ platform_name ~ ' (opens in new tab)') %}
+  <a href="{{ url }}" target="_blank" rel="noopener noreferrer"
+     class="q-badge {% if platform_name=='LeetCode' %}badge-lc{% elif platform_name=='GFG' %}badge-gfg{% elif platform_name=='HackerRank' %}badge-hr{% elif platform_name=='Coding Ninjas' %}badge-cn{% elif platform_name=='YouTube' %}badge-yt{% else %}badge-link{% endif %}"
+     aria-label="{{ label }}">
+     <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i> {{ platform_name }}
+  </a>
+{%- endmacro %}
+
+{% macro award_badge(title, label, icon_url=None, icon_class=None, icon_text=None, stars=0) -%}
+  <div class="award-badge" title="{{ title }}" role="listitem">
+    {% if icon_url %}
+      <img src="{{ icon_url }}" width="36" height="36" loading="lazy" decoding="async" style="width:36px;height:36px;object-fit:contain" onerror="this.outerHTML='<span>🏅</span>'" alt="{{ title }} badge">
+    {% elif icon_class %}
+      <i class="{{ icon_class }}" style="font-size:.9rem;color:#00bd6c" aria-hidden="true"></i>
+      {% if stars > 0 %}
+        <div class="hr-stars">
+          {% for i in range(stars) %}
+            <span class="s-on">★</span>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% elif icon_text %}
+      <span aria-hidden="true">{{ icon_text }}</span>
+    {% else %}
+      <span aria-hidden="true">🏅</span>
+    {% endif %}
+    <span class="a-lbl">{{ label }}</span>
+  </div>
+{%- endmacro %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "_macros.html" import modal_shell %}
+{% from "macros/ui_bits.html" import award_badge %}
 {% block head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/profile.css') }}">
 <script src="https://cdn.jsdelivr.net/npm/chart.js" onerror="this.remove();var s=document.createElement('script');s.src='https://unpkg.com/chart.js@4/dist/chart.umd.js';document.head.appendChild(s);"></script>
@@ -214,34 +215,30 @@
     <div class="awards-grid" id="awardsGrid" role="list" aria-label="Achievements and badges">
       {# Real LC badges #}
       {% for badge in lc_badges %}
-      <div class="award-badge" title="{{ badge.name }}" role="listitem">
-        {% if badge.icon %}
-          <img src="{{ badge.icon }}" width="36" height="36" loading="lazy" decoding="async" style="width:36px;height:36px;object-fit:contain" onerror="this.outerHTML='<span>🏅</span>'" alt="{{ badge.name }} badge">
-        {% else %}🏅{% endif %}
-        <span class="a-lbl">{{ badge.name[:10] }}</span>
-      </div>
+      {{ award_badge(
+        badge.name,
+        badge.name[:10],
+        icon_url=badge.icon
+      ) }}
       {% endfor %}
       {# Real HR badges — only earned stars shown, no empty placeholders #}
       {% for badge in hr_badges %}
       {% set earned = badge.stars|int if badge.stars else 0 %}
-      <div class="award-badge" title="{{ badge.name }} — {{ earned }} star{{ 's' if earned != 1 else '' }}" role="listitem">
-        <i class="bi bi-terminal" style="font-size:.9rem;color:#00bd6c" aria-hidden="true"></i>
-        <div class="hr-stars">
-          {% for i in range(earned) %}
-            <span class="s-on">★</span>
-          {% endfor %}
-        </div>
-        <span class="a-lbl">{{ badge.name[:10] }}</span>
-      </div>
+      {{ award_badge(
+        badge.name ~ ' — ' ~ earned ~ ' star' ~ ('s' if earned != 1 else ''),
+        badge.name[:10],
+        icon_class='bi bi-terminal',
+        stars=earned
+      ) }}
       {% endfor %}
       {# DSA milestone badges (always shown) #}
-      {% if dsa_done >= 200 %}<div class="award-badge" title="200 DSA Solved" role="listitem">🔥<span class="a-lbl">200 Solved</span></div>
-      {% elif dsa_done >= 100 %}<div class="award-badge" title="100 DSA Solved" role="listitem">💯<span class="a-lbl">100 Solved</span></div>
-      {% elif dsa_done >= 50 %}<div class="award-badge" title="50 DSA Solved" role="listitem">🏆<span class="a-lbl">50 Solved</span></div>{% endif %}
-      {% if lc_contests > 0 %}<div class="award-badge" title="LeetCode Contestant" role="listitem">⚔️<span class="a-lbl">Contestant</span></div>{% endif %}
-      {% if lc_rating > 1400 %}<div class="award-badge" title="Rating 1400+" role="listitem">⭐<span class="a-lbl">1400+ Rating</span></div>{% endif %}
-      {% if total_active_days >= 100 %}<div class="award-badge" title="100 Active Days" role="listitem">🗓️<span class="a-lbl">100 Days</span></div>
-      {% elif total_active_days >= 30 %}<div class="award-badge" title="30 Active Days" role="listitem">📅<span class="a-lbl">30 Days</span></div>{% endif %}
+      {% if dsa_done >= 200 %}{{ award_badge('200 DSA Solved', '200 Solved', icon_text='🔥') }}
+      {% elif dsa_done >= 100 %}{{ award_badge('100 DSA Solved', '100 Solved', icon_text='💯') }}
+      {% elif dsa_done >= 50 %}{{ award_badge('50 DSA Solved', '50 Solved', icon_text='🏆') }}{% endif %}
+      {% if lc_contests > 0 %}{{ award_badge('LeetCode Contestant', 'Contestant', icon_text='⚔️') }}{% endif %}
+      {% if lc_rating > 1400 %}{{ award_badge('Rating 1400+', '1400+ Rating', icon_text='⭐') }}{% endif %}
+      {% if total_active_days >= 100 %}{{ award_badge('100 Active Days', '100 Days', icon_text='🗓️') }}
+      {% elif total_active_days >= 30 %}{{ award_badge('30 Active Days', '30 Days', icon_text='📅') }}{% endif %}
       {% if lc_badges|length == 0 and hr_badges|length == 0 and dsa_done < 50 %}
       <div style="color:var(--text-muted);font-size:.8rem;padding:10px 0;width:100%">Sync LeetCode / HackerRank to see real awards! 🎯<br><button onclick="openSyncModal()" style="margin-top:6px;padding:4px 12px;border:1px solid var(--accent);border-radius:6px;background:none;color:var(--accent);font-size:.75rem;cursor:pointer;font-family:inherit" aria-label="Connect platforms to see awards">Connect Now</button></div>
       {% endif %}

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "macros/modals.html" import notes_modal %}
+{% from "macros/ui_bits.html" import question_link_badge %}
 {% block content %}
 <style>
 .topic-title { font-size: 1.6rem; font-weight: 800; margin-bottom: 6px; }
@@ -160,19 +161,11 @@
                     <div class="q-links">
                         {% if q.url %}
                             {% set p1 = q.url|platform_name %}
-                            <a href="{{ q.url }}" target="_blank" rel="noopener noreferrer"
-                               class="q-badge {% if p1=='LeetCode' %}badge-lc{% elif p1=='GFG' %}badge-gfg{% elif p1=='HackerRank' %}badge-hr{% elif p1=='Coding Ninjas' %}badge-cn{% elif p1=='YouTube' %}badge-yt{% else %}badge-link{% endif %}"
-                               aria-label="Solve on {{ p1 }} (opens in new tab)">
-                               <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i> {{ p1 }}
-                            </a>
+                            {{ question_link_badge(q.url, p1) }}
                         {% endif %}
                         {% if q.url2 %}
                             {% set p2 = q.url2|platform_name %}
-                            <a href="{{ q.url2 }}" target="_blank" rel="noopener noreferrer"
-                               class="q-badge {% if p2=='LeetCode' %}badge-lc{% elif p2=='GFG' %}badge-gfg{% elif p2=='HackerRank' %}badge-hr{% elif p2=='Coding Ninjas' %}badge-cn{% elif p2=='YouTube' %}badge-yt{% else %}badge-link{% endif %}"
-                               aria-label="Solve on {{ p2 }} (opens in new tab)">
-                               <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i> {{ p2 }}
-                            </a>
+                            {{ question_link_badge(q.url2, p2) }}
                         {% endif %}
                     </div>
                 </td>

--- a/tests/test_profile_image_loading.py
+++ b/tests/test_profile_image_loading.py
@@ -5,11 +5,12 @@ TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "templates"
 
 
 def test_profile_template_marks_primary_avatar_as_eager_and_badges_as_lazy():
-    template = (TEMPLATE_DIR / "profile.html").read_text(encoding="utf-8")
+    profile = (TEMPLATE_DIR / "profile.html").read_text(encoding="utf-8")
+    ui_bits = (TEMPLATE_DIR / "macros" / "ui_bits.html").read_text(encoding="utf-8")
 
-    assert 'src="{{ user.profile_photo }}" width="90" height="90" loading="eager" fetchpriority="high" decoding="async"' in template
-    assert 'src="{{ badge.icon }}" width="36" height="36" loading="lazy" decoding="async"' in template
-    assert 'src="{{ user.profile_photo }}" width="80" height="80" loading="lazy" decoding="async"' in template
+    assert 'src="{{ user.profile_photo }}" width="90" height="90" loading="eager" fetchpriority="high" decoding="async"' in profile
+    assert 'src="{{ icon_url }}" width="36" height="36" loading="lazy" decoding="async"' in ui_bits
+    assert 'src="{{ user.profile_photo }}" width="80" height="80" loading="lazy" decoding="async"' in profile
 
 
 def test_public_profile_template_keeps_visible_avatar_eager_with_dimensions():

--- a/tests/test_template_macros.py
+++ b/tests/test_template_macros.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "templates"
+TOPIC_TEMPLATE = TEMPLATES_DIR / "topic.html"
+BOOKMARKS_TEMPLATE = TEMPLATES_DIR / "bookmarks.html"
+PROFILE_TEMPLATE = TEMPLATES_DIR / "profile.html"
+MACROS_TEMPLATE = TEMPLATES_DIR / "macros" / "ui_bits.html"
+
+
+def test_ui_bits_macro_file_exists_with_shared_macros():
+    template = MACROS_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "{% macro question_link_badge" in template
+    assert "{% macro award_badge" in template
+
+
+def test_topic_and_bookmarks_import_question_link_badge_macro():
+    topic = TOPIC_TEMPLATE.read_text(encoding="utf-8")
+    bookmarks = BOOKMARKS_TEMPLATE.read_text(encoding="utf-8")
+
+    assert '{% from "macros/ui_bits.html" import question_link_badge %}' in topic
+    assert '{{ question_link_badge(q.url, p1) }}' in topic
+    assert '{{ question_link_badge(q.url2, p2) }}' in topic
+
+    assert '{% from "macros/ui_bits.html" import question_link_badge %}' in bookmarks
+    assert "question_link_badge(q.url, q.url|platform_name" in bookmarks
+    assert "question_link_badge(q.url2, q.url2|platform_name" in bookmarks
+
+
+def test_profile_uses_shared_award_badge_macro():
+    profile = PROFILE_TEMPLATE.read_text(encoding="utf-8")
+
+    assert '{% from "macros/ui_bits.html" import award_badge %}' in profile
+    assert "{{ award_badge(" in profile
+    assert "LeetCode Contestant" in profile
+    assert "100 Active Days" in profile


### PR DESCRIPTION
## Summary
- extract shared Jinja macros for repeated question platform badges and award badge cards
- migrate topic and bookmarks question links to the shared badge macro
- migrate profile achievement badge rendering to the shared award badge macro
- add focused template tests to keep the rendered macro usage pinned down

## Testing
- python3 -m pytest tests/test_template_macros.py tests/test_template_link_security.py tests/test_progress_card_copy.py tests/test_search_template.py -q
- python3 -m py_compile tests/test_template_macros.py
- git diff --check
