### PR TITLE
fix: release page skeletons on DOM ready

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,26 @@
         content="Track your 450 DSA progress, connect coding platforms, and visualize your growth.">
     <script>
         document.documentElement.classList.add('page-loading');
+
+        (function registerPageLoadingRelease() {
+            let pageLoadingReleased = false;
+            const releasePageLoading = () => {
+                if (pageLoadingReleased) {
+                    return;
+                }
+                pageLoadingReleased = true;
+                document.documentElement.classList.remove('page-loading');
+            };
+
+            window.releasePageLoading = releasePageLoading;
+
+            document.addEventListener('DOMContentLoaded', () => {
+                window.requestAnimationFrame(releasePageLoading);
+            }, { once: true });
+
+            window.addEventListener('load', releasePageLoading, { once: true });
+            window.setTimeout(releasePageLoading, 2500);
+        })();
     </script>
    
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
@@ -987,9 +1007,6 @@
             if (fc) fc.style.opacity = '0', fc.style.transition = '0.5s', setTimeout(() => fc.remove(), 500);
         }, 4000);
 
-        window.addEventListener('load', () => {
-            document.documentElement.classList.remove('page-loading');
-        });
     </script>
     {% block scripts %}{% endblock %}
 </body>

--- a/tests/test_page_loading_release.py
+++ b/tests/test_page_loading_release.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+BASE_TEMPLATE = Path(__file__).resolve().parents[1] / "templates" / "base.html"
+
+
+def test_page_loading_releases_on_dom_ready_and_fallback_timeout():
+    template = BASE_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "window.releasePageLoading = releasePageLoading;" in template
+    assert "document.addEventListener('DOMContentLoaded'" in template
+    assert "window.requestAnimationFrame(releasePageLoading);" in template
+    assert "window.addEventListener('load', releasePageLoading, { once: true });" in template
+    assert "window.setTimeout(releasePageLoading, 2500);" in template


### PR DESCRIPTION
Summary:
- stop coupling page skeleton release to window load alone
- release loading state on DOMContentLoaded, keep load as a backup, and add a timeout escape hatch
- add a guard test for the page-loading release script

Testing:
- python3 -m pytest tests/test_page_loading_release.py tests/test_search_template.py tests/test_leaderboard_template.py -q
- git diff --check