### PR TITLE
chore: add import sorting config

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ pip install -r requirements-dev.txt
 pytest
 ```
 
+## Import Sorting
+
+Use Ruff's import-sorting rule for focused cleanup PRs:
+
+```bash
+ruff check . --select I --fix
+```
+
 ---
 
 ## Environment Variables Reference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.ruff]
+target-version = "py310"
+extend-exclude = ["venv"]
+
+[tool.ruff.lint]
+extend-select = ["I"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["app", "tests"]

--- a/tests/test_import_sorting_config.py
+++ b/tests/test_import_sorting_config.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = PROJECT_ROOT / "pyproject.toml"
+README = PROJECT_ROOT / "README.md"
+
+
+def test_pyproject_enables_ruff_import_sorting():
+    config = PYPROJECT.read_text(encoding="utf-8")
+
+    assert '[tool.ruff.lint]' in config
+    assert 'extend-select = ["I"]' in config
+    assert '[tool.ruff.lint.isort]' in config
+    assert 'known-first-party = ["app", "tests"]' in config
+
+
+def test_readme_documents_import_sorting_command():
+    readme = README.read_text(encoding="utf-8")
+
+    assert "## Import Sorting" in readme
+    assert "ruff check . --select I --fix" in readme


### PR DESCRIPTION
Summary:
- add Ruff import-sorting configuration through pyproject.toml
- document the focused import-sorting command in the README
- add a guard test to keep the config and docs in place

Testing:
- python3 -m pytest tests/test_import_sorting_config.py -q
- python3 -m pytest tests/test_search_template.py -q
- git diff --check