### PR TITLE
perf: add conditional caching for progress cards

### DIFF
--- a/app/profile/card_service.py
+++ b/app/profile/card_service.py
@@ -1,4 +1,7 @@
+import hashlib
+import json
 import time
+from datetime import timezone
 from io import BytesIO
 
 from bson.objectid import ObjectId
@@ -6,7 +9,7 @@ from bson.objectid import ObjectId
 import card_generator
 
 from app.extensions import db
-from app.utils import compute_c_score, compute_user_platforms
+from app.utils import compute_c_score, compute_user_platforms, ensure_utc_datetime
 from streaks import compute_streak
 
 
@@ -14,14 +17,43 @@ card_cache = {}
 CACHE_TTL = 3600
 
 
-def get_public_card_image(user_id, object_id=None, db_handle=None):
-    current_time = time.time()
-    if user_id in card_cache:
-        cached_time, cached_image = card_cache[user_id]
-        if current_time - cached_time < CACHE_TTL:
-            cached_image.seek(0)
-            return cached_image
+def _build_card_etag(name, c_score, dsa_progress, current_streak, platforms):
+    payload = {
+        "name": name,
+        "c_score": c_score,
+        "dsa_progress": dsa_progress,
+        "current_streak": current_streak,
+        "platforms": platforms,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return f"progress-card-{digest}"
 
+
+def _card_last_modified(user, progress_data):
+    candidates = []
+
+    updated_at = ensure_utc_datetime(user.get("updated_at"))
+    if updated_at:
+        candidates.append(updated_at)
+
+    for progress_item in progress_data.values():
+        solved_at = ensure_utc_datetime(progress_item.get("timestamp"))
+        if solved_at and progress_item.get("done"):
+            candidates.append(solved_at)
+
+    if candidates:
+        return max(candidates)
+
+    object_id = user.get("_id")
+    if isinstance(object_id, ObjectId):
+        return object_id.generation_time.astimezone(timezone.utc)
+
+    return None
+
+
+def get_public_card_image(user_id, object_id=None, db_handle=None):
     db_handle = db_handle or db
     object_id = object_id or ObjectId(user_id)
     user = db_handle.user.find_one({"_id": object_id})
@@ -43,6 +75,15 @@ def get_public_card_image(user_id, object_id=None, db_handle=None):
     all_questions = list(db_handle.question.find())
     solved_items = {qid: progress for qid, progress in progress_data.items() if progress.get("done")}
     platforms = compute_user_platforms(solved_items, user.get("external_totals", {}), all_questions)
+    etag = _build_card_etag(name, c_score, dsa_progress, current_streak, platforms)
+    last_modified = _card_last_modified(user, progress_data)
+
+    current_time = time.time()
+    if user_id in card_cache:
+        cached_time, cached_etag, cached_image = card_cache[user_id]
+        if current_time - cached_time < CACHE_TTL and cached_etag == etag:
+            cached_image.seek(0)
+            return cached_image, etag, last_modified
 
     img_io = card_generator.generate_progress_card(
         name, c_score, dsa_progress, current_streak, platforms
@@ -50,5 +91,5 @@ def get_public_card_image(user_id, object_id=None, db_handle=None):
     if isinstance(img_io, BytesIO):
         img_io.seek(0)
 
-    card_cache[user_id] = (current_time, img_io)
-    return img_io
+    card_cache[user_id] = (current_time, etag, img_io)
+    return img_io, etag, last_modified

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -363,7 +363,7 @@ def public_card(user_id):
         return "Invalid User ID", 400
 
     try:
-        img_io = get_public_card_image(user_id, object_id, db_handle=db)
+        img_io, etag, last_modified = get_public_card_image(user_id, object_id, db_handle=db)
     except LookupError:
         return "User not found", 404
     except Exception:
@@ -372,7 +372,13 @@ def public_card(user_id):
 
     try:
         img_io.seek(0)
-        return send_file(img_io, mimetype="image/png")
+        response = send_file(img_io, mimetype="image/png")
+        response.headers["Cache-Control"] = f"public, max-age={CACHE_TTL}"
+        response.set_etag(etag)
+        if last_modified is not None:
+            response.last_modified = last_modified
+        response.make_conditional(request)
+        return response
     except Exception:
         current_app.logger.exception("Failed to generate public progress card")
         return "Unable to generate progress card", 500

--- a/tests/test_progress_card.py
+++ b/tests/test_progress_card.py
@@ -239,6 +239,49 @@ def test_public_card_caching(client, app):
         assert data1 == data2
 
 
+def test_public_card_sets_cache_headers_and_etag(client, app):
+    user_id = ObjectId()
+    now = datetime.now(timezone.utc)
+    app.mock_db.question.data = {"q1": {"_id": "q1"}}
+    app.mock_db.user.data[str(user_id)] = {
+        "_id": user_id,
+        "name": "Header User",
+        "progress": {"q1": {"done": True, "timestamp": now}},
+        "external_totals": {},
+    }
+
+    with patch("app.profile.routes.db", app.mock_db):
+        response = client.get(f"/u/{user_id}/card.png")
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "public, max-age=3600"
+    assert response.headers["ETag"].startswith('"progress-card-')
+    assert response.headers["Last-Modified"]
+
+
+def test_public_card_returns_304_for_matching_etag(client, app):
+    user_id = ObjectId()
+    now = datetime.now(timezone.utc)
+    app.mock_db.question.data = {"q1": {"_id": "q1"}}
+    app.mock_db.user.data[str(user_id)] = {
+        "_id": user_id,
+        "name": "Conditional User",
+        "progress": {"q1": {"done": True, "timestamp": now}},
+        "external_totals": {},
+    }
+
+    with patch("app.profile.routes.db", app.mock_db):
+        initial = client.get(f"/u/{user_id}/card.png")
+        response = client.get(
+            f"/u/{user_id}/card.png",
+            headers={"If-None-Match": initial.headers["ETag"]},
+        )
+
+    assert initial.status_code == 200
+    assert response.status_code == 304
+    assert response.data == b""
+
+
 def test_public_card_exception_handling(client, app):
     """Test that card generation errors do not expose raw exception text."""
     user_id = ObjectId()

--- a/tests/test_public_card_service.py
+++ b/tests/test_public_card_service.py
@@ -61,14 +61,17 @@ def test_get_public_card_image_builds_and_caches(monkeypatch):
 
     card_cache.clear()
 
-    first = get_public_card_image(str(user_id), user_id)
-    second = get_public_card_image(str(user_id), user_id)
+    first, first_etag, first_last_modified = get_public_card_image(str(user_id), user_id)
+    second, second_etag, second_last_modified = get_public_card_image(str(user_id), user_id)
 
     assert first.read() == b"fake-png"
     second.seek(0)
     assert second.read() == b"fake-png"
     assert len(generated) == 1
     assert generated[0] == ("Card User", 144, 100.0, 4, {"LeetCode": 12})
+    assert first_etag == second_etag
+    assert first_etag.startswith("progress-card-")
+    assert first_last_modified == second_last_modified
 
 
 def test_get_public_card_image_raises_for_missing_user(monkeypatch):


### PR DESCRIPTION
## Summary
- add deterministic progress-card ETags based on the rendered card payload
- return `Cache-Control`, `ETag`, and `Last-Modified` headers for public card images and respect conditional requests
- reuse cached card bytes only when the current payload still matches the cached validator, and add route/service coverage for the new behavior

Closes #321

## Testing
- `python3 -m pytest tests/test_public_card_service.py tests/test_progress_card.py -q`
- `python3 -m py_compile app/profile/card_service.py app/profile/routes.py tests/test_public_card_service.py tests/test_progress_card.py`
- `git diff --check`