### PR TITLE
perf: cache platform fetch results

### DIFF
--- a/app/platforms/fetchers.py
+++ b/app/platforms/fetchers.py
@@ -1,10 +1,39 @@
 import json
 import re
+import time
+from copy import deepcopy
 from datetime import datetime
 
 import requests
 
 from app.utils import normalize_coding_ninjas_profile_id
+
+
+PLATFORM_FETCH_CACHE_TTL = 300
+_platform_fetch_cache = {}
+
+
+def clear_platform_fetch_cache():
+    _platform_fetch_cache.clear()
+
+
+def _cached_platform_fetch(platform_key, username, fetcher):
+    normalized_username = (username or "").strip()
+    if not normalized_username:
+        return fetcher()
+
+    cache_key = (platform_key, normalized_username.lower())
+    now = time.monotonic()
+    cached_entry = _platform_fetch_cache.get(cache_key)
+    if cached_entry and (now - cached_entry["cached_at"]) < PLATFORM_FETCH_CACHE_TTL:
+        return deepcopy(cached_entry["value"])
+
+    value = fetcher()
+    _platform_fetch_cache[cache_key] = {
+        "cached_at": now,
+        "value": deepcopy(value),
+    }
+    return value
 
 
 LEETCODE_PROFILE_QUERY = """
@@ -38,6 +67,10 @@ def build_leetcode_profile_payload(username):
 
 
 def fetch_leetcode(username):
+    return _cached_platform_fetch("leetcode", username, lambda: _fetch_leetcode(username))
+
+
+def _fetch_leetcode(username):
     try:
         response = requests.post(
             "https://leetcode.com/graphql",
@@ -160,6 +193,10 @@ def fetch_hr_badges(username):
 
 
 def fetch_github(username):
+    return _cached_platform_fetch("github", username, lambda: _fetch_github(username))
+
+
+def _fetch_github(username):
     try:
         response = requests.get(f"https://github.com/users/{username}/contributions", timeout=5)
         matches = re.findall(r"(\d+|No)\s+contributions?\s+on\s+(\d{4}-\d{2}-\d{2})", response.text)
@@ -201,6 +238,10 @@ def fetch_github(username):
 
 
 def fetch_gfg(username):
+    return _cached_platform_fetch("gfg", username, lambda: _fetch_gfg(username))
+
+
+def _fetch_gfg(username):
     """Fetch GFG solved count via multiple fallback methods."""
     try:
         try:
@@ -250,6 +291,10 @@ def fetch_gfg(username):
 
 
 def fetch_atcoder(handle):
+    return _cached_platform_fetch("atcoder", handle, lambda: _fetch_atcoder(handle))
+
+
+def _fetch_atcoder(handle):
     try:
         r = requests.get(
             'https://kenkoooo.com/atcoder/atcoder-api/v3/user/acceptance_count',
@@ -262,6 +307,10 @@ def fetch_atcoder(handle):
 
 
 def fetch_coding_ninjas(username):
+    return _cached_platform_fetch("codingninjas", username, lambda: _fetch_coding_ninjas(username))
+
+
+def _fetch_coding_ninjas(username):
     """Fetch Coding Ninjas/Code360 solved count from public profile pages."""
     profile_id = normalize_coding_ninjas_profile_id(username)
     if not profile_id:

--- a/tests/test_platform_fetcher.py
+++ b/tests/test_platform_fetcher.py
@@ -2,7 +2,11 @@ import time
 from unittest.mock import MagicMock, patch
 
 from platform_fetcher import run_fetch_jobs
-from app.platforms.fetchers import fetch_atcoder
+from app.platforms.fetchers import clear_platform_fetch_cache, fetch_atcoder, fetch_github
+
+
+def setup_function():
+    clear_platform_fetch_cache()
 
 
 def test_fetch_atcoder_returns_total_on_success():
@@ -31,6 +35,69 @@ def test_fetch_atcoder_returns_empty_on_exception():
         result = fetch_atcoder('tourist')
 
     assert result == {}
+
+
+def test_fetch_atcoder_caches_successful_results():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'count': 42}
+
+    with patch('app.platforms.fetchers.requests.get', return_value=mock_response) as mock_get:
+        first = fetch_atcoder('tourist')
+        second = fetch_atcoder('tourist')
+
+    assert first == {'total': 42}
+    assert second == {'total': 42}
+    assert mock_get.call_count == 1
+
+
+def test_fetch_atcoder_caches_failed_results():
+    with patch('app.platforms.fetchers.requests.get', side_effect=Exception('timeout')) as mock_get:
+        first = fetch_atcoder('tourist')
+        second = fetch_atcoder('tourist')
+
+    assert first == {}
+    assert second == {}
+    assert mock_get.call_count == 1
+
+
+def test_fetch_github_cache_is_keyed_by_username():
+    contribution_a = MagicMock()
+    contribution_a.text = "3 contributions on 2026-05-24"
+    issues_a = MagicMock()
+    issues_a.json.return_value = {"total_count": 2}
+    prs_a = MagicMock()
+    prs_a.json.return_value = {"total_count": 5}
+    merged_a = MagicMock()
+    merged_a.json.return_value = {"total_count": 1}
+    commits_a = MagicMock()
+    commits_a.json.return_value = {"total_count": 8}
+
+    contribution_b = MagicMock()
+    contribution_b.text = "1 contributions on 2026-05-24"
+    issues_b = MagicMock()
+    issues_b.json.return_value = {"total_count": 7}
+    prs_b = MagicMock()
+    prs_b.json.return_value = {"total_count": 9}
+    merged_b = MagicMock()
+    merged_b.json.return_value = {"total_count": 4}
+    commits_b = MagicMock()
+    commits_b.json.return_value = {"total_count": 11}
+
+    with patch(
+        'app.platforms.fetchers.requests.get',
+        side_effect=[
+            contribution_a, issues_a, prs_a, merged_a, commits_a,
+            contribution_b, issues_b, prs_b, merged_b, commits_b,
+        ],
+    ) as mock_get:
+        first = fetch_github('octocat')
+        second = fetch_github('octocat')
+        third = fetch_github('hubot')
+
+    assert first == second
+    assert first != third
+    assert mock_get.call_count == 10
 
 
 def test_run_fetch_jobs_executes_jobs_concurrently():


### PR DESCRIPTION
## Summary
- add a short-lived, configurable per-platform fetch cache keyed by username
- cache both successful and failed fetch payloads so repeated sync attempts stop hammering third-party profile endpoints
- add focused fetcher tests that lock in cache reuse for success, failure, and per-username separation

Closes #319

## Testing
- `python3 -m pytest tests/test_platform_fetcher.py tests/test_sync_platforms.py tests/test_sync_platforms_response.py -q`
- `python3 -m py_compile app/platforms/fetchers.py tests/test_platform_fetcher.py`
- `git diff --check`