### PR TITLE
perf: parallelize platform sync fetches

### DIFF
--- a/app/platforms/fetchers.py
+++ b/app/platforms/fetchers.py
@@ -1,10 +1,32 @@
 import json
 import re
+import threading
 from datetime import datetime
 
 import requests
 
 from app.utils import normalize_coding_ninjas_profile_id
+
+
+_session_local = threading.local()
+
+
+def clear_platform_http_session():
+    session = getattr(_session_local, "session", None)
+    if session is not None:
+        try:
+            session.close()
+        except Exception:
+            pass
+        delattr(_session_local, "session")
+
+
+def _get_http_session():
+    session = getattr(_session_local, "session", None)
+    if session is None:
+        session = requests.Session()
+        _session_local.session = session
+    return session
 
 
 LEETCODE_PROFILE_QUERY = """
@@ -39,7 +61,7 @@ def build_leetcode_profile_payload(username):
 
 def fetch_leetcode(username):
     try:
-        response = requests.post(
+        response = _get_http_session().post(
             "https://leetcode.com/graphql",
             json=build_leetcode_profile_payload(username),
             timeout=8,
@@ -86,7 +108,7 @@ def fetch_leetcode_rating_history(username):
             contest { title startTime }
           }
         }"""
-        response = requests.post(
+        response = _get_http_session().post(
             "https://leetcode.com/graphql",
             json={"query": query, "variables": {"username": username}},
             timeout=10,
@@ -115,7 +137,7 @@ def fetch_lc_badges(username):
             upcomingBadges { name icon }
           }
         }"""
-        response = requests.post(
+        response = _get_http_session().post(
             "https://leetcode.com/graphql",
             json={"query": query, "variables": {"username": username}},
             timeout=8,
@@ -139,7 +161,7 @@ def fetch_lc_badges(username):
 def fetch_hr_badges(username):
     """Fetch HackerRank badges and total solved count."""
     try:
-        response = requests.get(
+        response = _get_http_session().get(
             f"https://www.hackerrank.com/rest/hackers/{username}/badges",
             timeout=8,
             headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"},
@@ -161,27 +183,27 @@ def fetch_hr_badges(username):
 
 def fetch_github(username):
     try:
-        response = requests.get(f"https://github.com/users/{username}/contributions", timeout=5)
+        response = _get_http_session().get(f"https://github.com/users/{username}/contributions", timeout=5)
         matches = re.findall(r"(\d+|No)\s+contributions?\s+on\s+(\d{4}-\d{2}-\d{2})", response.text)
         result_calendar = {}
         for count_str, date_str in matches:
             count = 0 if count_str == "No" else int(count_str)
             result_calendar[date_str] = count
 
-        response_issues = requests.get(
+        response_issues = _get_http_session().get(
             f"https://api.github.com/search/issues?q=type:issue+author:{username}",
             timeout=5,
         ).json()
-        response_prs = requests.get(
+        response_prs = _get_http_session().get(
             f"https://api.github.com/search/issues?q=type:pr+author:{username}",
             timeout=5,
         ).json()
-        response_merged = requests.get(
+        response_merged = _get_http_session().get(
             f"https://api.github.com/search/issues?q=type:pr+is:merged+author:{username}",
             timeout=5,
         ).json()
         headers = {"Accept": "application/vnd.github.cloak-preview+json"}
-        response_commits = requests.get(
+        response_commits = _get_http_session().get(
             f"https://api.github.com/search/commits?q=author:{username}",
             headers=headers,
             timeout=5,
@@ -204,7 +226,7 @@ def fetch_gfg(username):
     """Fetch GFG solved count via multiple fallback methods."""
     try:
         try:
-            response = requests.get(
+            response = _get_http_session().get(
                 f"https://geeks-for-geeks-stats-api.vercel.app/?raw=Y&userName={username}",
                 timeout=6,
             )
@@ -218,7 +240,7 @@ def fetch_gfg(username):
 
         try:
             headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
-            response = requests.get(
+            response = _get_http_session().get(
                 f"https://practiceapi.geeksforgeeks.org/api/v1/user/practice/stats/?user={username}",
                 headers=headers,
                 timeout=6,
@@ -232,7 +254,7 @@ def fetch_gfg(username):
             print("GFG Error", exc)
 
         headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120"}
-        response = requests.get(f"https://www.geeksforgeeks.org/user/{username}/", timeout=8, headers=headers)
+        response = _get_http_session().get(f"https://www.geeksforgeeks.org/user/{username}/", timeout=8, headers=headers)
         for pattern in [
             r'"total_problems_solved"\s*[:=]\s*(\d+)',
             r'"totalProblemsSolved"\s*[:=]\s*(\d+)',
@@ -251,7 +273,7 @@ def fetch_gfg(username):
 
 def fetch_atcoder(handle):
     try:
-        r = requests.get(
+        r = _get_http_session().get(
             'https://kenkoooo.com/atcoder/atcoder-api/v3/user/acceptance_count',
             params={'user': handle}, timeout=8)
         if r.status_code == 200:
@@ -274,7 +296,7 @@ def fetch_coding_ninjas(username):
 
     try:
         api_url = "https://www.naukri.com/code360/api/v3/public_section/profile/user_details"
-        response = requests.get(api_url, params={"uuid": profile_id}, headers=headers, timeout=8)
+        response = _get_http_session().get(api_url, params={"uuid": profile_id}, headers=headers, timeout=8)
         if response.status_code == 200:
             data = response.json().get("data") or {}
             total = 0
@@ -304,7 +326,7 @@ def fetch_coding_ninjas(username):
     try:
         for url in urls:
             try:
-                response = requests.get(url, headers=headers, timeout=8)
+                response = _get_http_session().get(url, headers=headers, timeout=8)
                 if response.status_code != 200:
                     continue
                 for pattern in patterns:

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -18,6 +18,7 @@ from app.platforms.fetchers import (
 )
 from app.profile.card_service import CACHE_TTL, card_cache, get_public_card_image
 from app.utils import ensure_utc_datetime, json_error, json_success, normalize_coding_ninjas_profile_id, utc_now, compute_user_platforms
+from platform_fetcher import run_fetch_jobs
 from profile_validation import build_profile_updates
 
 profile_bp = Blueprint("profile", __name__)
@@ -37,6 +38,51 @@ def build_sync_platforms_response(platform_status: dict):
         return {"success": False, "error": "Sync failed for all platforms.", "platforms": platform_status}
 
     return {"success": True, "partial_success": partial_success, "platforms": platform_status}
+
+
+def build_platform_sync_jobs(
+    leetcode_username="",
+    github_username="",
+    gfg_username="",
+    codingninjas_username="",
+    hackerrank_username="",
+    atcoder_username="",
+):
+    jobs = {}
+
+    if leetcode_username:
+        def fetch_leetcode_bundle():
+            result = {"stats": fetch_leetcode(leetcode_username)}
+            try:
+                rating_history = fetch_leetcode_rating_history(leetcode_username)
+                if rating_history:
+                    result["rating_history"] = rating_history
+            except Exception:
+                pass
+            try:
+                result["badges"] = fetch_lc_badges(leetcode_username)
+            except Exception:
+                pass
+            return result
+
+        jobs["leetcode"] = fetch_leetcode_bundle
+
+    if github_username:
+        jobs["github"] = lambda: fetch_github(github_username)
+
+    if gfg_username:
+        jobs["gfg"] = lambda: fetch_gfg(gfg_username)
+
+    if codingninjas_username:
+        jobs["codingninjas"] = lambda: fetch_coding_ninjas(codingninjas_username)
+
+    if hackerrank_username:
+        jobs["hackerrank"] = lambda: fetch_hr_badges(hackerrank_username)
+
+    if atcoder_username:
+        jobs["atcoder"] = lambda: fetch_atcoder(atcoder_username)
+
+    return jobs
 
 
 @profile_bp.route("/sync_platforms", methods=["POST"])
@@ -158,113 +204,113 @@ def sync_platforms():
             payload["error"] = error
         platform_status[platform_key] = payload
 
+    platform_jobs = build_platform_sync_jobs(
+        leetcode_username=leetcode_username,
+        github_username=github_username,
+        gfg_username=gfg_username,
+        codingninjas_username=codingninjas_username,
+        hackerrank_username=hackerrank_username,
+        atcoder_username=atcoder_username,
+    )
+    platform_results, platform_errors = run_fetch_jobs(platform_jobs, max_workers=4)
+
     if leetcode_username:
-        try:
-            leetcode_data = fetch_leetcode(leetcode_username)
-            if not leetcode_data:
-                _mark("leetcode", "failed", "No data returned (username may be invalid or rate-limited).")
-            else:
-                _mark("leetcode", "synced")
-                for key, value in leetcode_data.get("calendar", {}).items():
-                    combined_daily_counts[key] = combined_daily_counts.get(key, 0) + value
-                if leetcode_data.get("total") is not None:
-                    platform_totals["LeetCode"] = leetcode_data.get("total")
-                if leetcode_data.get("difficulty"):
-                    platform_totals["LeetCode_Easy"] = leetcode_data["difficulty"].get("Easy", 0)
-                    platform_totals["LeetCode_Medium"] = leetcode_data["difficulty"].get("Medium", 0)
-                    platform_totals["LeetCode_Hard"] = leetcode_data["difficulty"].get("Hard", 0)
-                if leetcode_data.get("contest"):
-                    platform_totals["LeetCode_Contests"] = leetcode_data["contest"].get("attendedContestsCount", 0)
-                    platform_totals["LeetCode_Rating"] = int(leetcode_data["contest"].get("rating", 0))
-                    platform_totals["LeetCode_GlobalRank"] = leetcode_data["contest"].get("globalRanking", 0)
-
-                try:
-                    rating_history = fetch_leetcode_rating_history(leetcode_username)
-                    if rating_history:
-                        update_fields["rating_history"] = rating_history
-                except Exception:
-                    pass
-
-                try:
-                    lc_badges = fetch_lc_badges(leetcode_username)
-                    update_fields["lc_badges_json"] = json.dumps(lc_badges)
-                except Exception:
-                    pass
-        except Exception:
+        leetcode_bundle = platform_results.get("leetcode") or {}
+        leetcode_data = leetcode_bundle.get("stats") if isinstance(leetcode_bundle, dict) else None
+        if platform_errors.get("leetcode"):
             _mark("leetcode", "failed", "Failed to fetch LeetCode stats.")
+        elif not leetcode_data:
+            _mark("leetcode", "failed", "No data returned (username may be invalid or rate-limited).")
+        else:
+            _mark("leetcode", "synced")
+            for key, value in leetcode_data.get("calendar", {}).items():
+                combined_daily_counts[key] = combined_daily_counts.get(key, 0) + value
+            if leetcode_data.get("total") is not None:
+                platform_totals["LeetCode"] = leetcode_data.get("total")
+            if leetcode_data.get("difficulty"):
+                platform_totals["LeetCode_Easy"] = leetcode_data["difficulty"].get("Easy", 0)
+                platform_totals["LeetCode_Medium"] = leetcode_data["difficulty"].get("Medium", 0)
+                platform_totals["LeetCode_Hard"] = leetcode_data["difficulty"].get("Hard", 0)
+            if leetcode_data.get("contest"):
+                platform_totals["LeetCode_Contests"] = leetcode_data["contest"].get("attendedContestsCount", 0)
+                platform_totals["LeetCode_Rating"] = int(leetcode_data["contest"].get("rating", 0))
+                platform_totals["LeetCode_GlobalRank"] = leetcode_data["contest"].get("globalRanking", 0)
+            if leetcode_bundle.get("rating_history"):
+                update_fields["rating_history"] = leetcode_bundle["rating_history"]
+            if "badges" in leetcode_bundle:
+                update_fields["lc_badges_json"] = json.dumps(leetcode_bundle.get("badges") or [])
     else:
         _mark("leetcode", "skipped")
 
     if github_username:
-        try:
-            github_data = fetch_github(github_username)
-            if not github_data:
-                _mark("github", "failed", "No data returned (username may be invalid or rate-limited).")
-            else:
-                _mark("github", "synced")
-                for key, value in github_data.get("calendar", {}).items():
-                    combined_daily_counts[key] = combined_daily_counts.get(key, 0) + value
-                if github_data.get("stats"):
-                    platform_totals["GitHub_Issues"] = github_data["stats"]["issues"]
-                    platform_totals["GitHub_PRs"] = github_data["stats"]["prs"]
-                    platform_totals["GitHub_Merged_PRs"] = github_data["stats"]["merged_prs"]
-                    platform_totals["GitHub_Commits"] = github_data["stats"]["commits"]
-        except Exception:
+        github_data = platform_results.get("github")
+        if platform_errors.get("github"):
             _mark("github", "failed", "Failed to fetch GitHub stats.")
+        elif not github_data:
+            _mark("github", "failed", "No data returned (username may be invalid or rate-limited).")
+        else:
+            _mark("github", "synced")
+            for key, value in github_data.get("calendar", {}).items():
+                combined_daily_counts[key] = combined_daily_counts.get(key, 0) + value
+            if github_data.get("stats"):
+                platform_totals["GitHub_Issues"] = github_data["stats"]["issues"]
+                platform_totals["GitHub_PRs"] = github_data["stats"]["prs"]
+                platform_totals["GitHub_Merged_PRs"] = github_data["stats"]["merged_prs"]
+                platform_totals["GitHub_Commits"] = github_data["stats"]["commits"]
     else:
         _mark("github", "skipped")
 
     if gfg_username:
-        try:
-            gfg_data = fetch_gfg(gfg_username)
-            if not gfg_data:
-                _mark("gfg", "failed", "No data returned (username may be invalid or rate-limited).")
-            else:
-                _mark("gfg", "synced")
-                if gfg_data.get("total") is not None:
-                    platform_totals["GFG"] = int(gfg_data.get("total", 0))
-        except Exception:
+        gfg_data = platform_results.get("gfg")
+        if platform_errors.get("gfg"):
             _mark("gfg", "failed", "Failed to fetch GFG stats.")
+        elif not gfg_data:
+            _mark("gfg", "failed", "No data returned (username may be invalid or rate-limited).")
+        else:
+            _mark("gfg", "synced")
+            if gfg_data.get("total") is not None:
+                platform_totals["GFG"] = int(gfg_data.get("total", 0))
     else:
         _mark("gfg", "skipped")
 
     if codingninjas_username:
-        try:
-            codingninjas_data = fetch_coding_ninjas(codingninjas_username)
-            if not codingninjas_data:
-                _mark("codingninjas", "failed", "No data returned (username may be invalid or rate-limited).")
-            else:
-                _mark("codingninjas", "synced")
-                if codingninjas_data.get("total") is not None:
-                    platform_totals["Coding Ninjas"] = int(codingninjas_data.get("total", 0))
-        except Exception:
+        codingninjas_data = platform_results.get("codingninjas")
+        if platform_errors.get("codingninjas"):
             _mark("codingninjas", "failed", "Failed to fetch Coding Ninjas stats.")
+        elif not codingninjas_data:
+            _mark("codingninjas", "failed", "No data returned (username may be invalid or rate-limited).")
+        else:
+            _mark("codingninjas", "synced")
+            if codingninjas_data.get("total") is not None:
+                platform_totals["Coding Ninjas"] = int(codingninjas_data.get("total", 0))
     else:
         _mark("codingninjas", "skipped")
 
     if hackerrank_username:
-        try:
-            hr_badges, hr_solved = fetch_hr_badges(hackerrank_username)
+        hackerrank_data = platform_results.get("hackerrank")
+        if platform_errors.get("hackerrank"):
+            _mark("hackerrank", "failed", "Failed to fetch HackerRank stats.")
+        elif not hackerrank_data:
+            _mark("hackerrank", "failed", "No data returned (username may be invalid or rate-limited).")
+        else:
+            hr_badges, hr_solved = hackerrank_data
             update_fields["hr_badges_json"] = json.dumps(hr_badges)
             if hr_solved > 0:
                 platform_totals["HackerRank"] = hr_solved
             _mark("hackerrank", "synced")
-        except Exception:
-            _mark("hackerrank", "failed", "Failed to fetch HackerRank stats.")
     else:
         _mark("hackerrank", "skipped")
 
     if atcoder_username:
-        try:
-            atcoder_data = fetch_atcoder(atcoder_username)
-            if not atcoder_data:
-                _mark("atcoder", "failed", "No data returned (handle may be invalid or rate-limited).")
-            else:
-                _mark("atcoder", "synced")
-                if atcoder_data.get("total") is not None:
-                    platform_totals["AtCoder"] = int(atcoder_data.get("total", 0))
-        except Exception:
+        atcoder_data = platform_results.get("atcoder")
+        if platform_errors.get("atcoder"):
             _mark("atcoder", "failed", "Failed to fetch AtCoder stats.")
+        elif not atcoder_data:
+            _mark("atcoder", "failed", "No data returned (handle may be invalid or rate-limited).")
+        else:
+            _mark("atcoder", "synced")
+            if atcoder_data.get("total") is not None:
+                platform_totals["AtCoder"] = int(atcoder_data.get("total", 0))
     else:
         _mark("atcoder", "skipped")
 

--- a/tests/test_platform_fetcher.py
+++ b/tests/test_platform_fetcher.py
@@ -2,15 +2,21 @@ import time
 from unittest.mock import MagicMock, patch
 
 from platform_fetcher import run_fetch_jobs
-from app.platforms.fetchers import fetch_atcoder
+from app.platforms.fetchers import clear_platform_http_session, fetch_atcoder
+
+
+def setup_function():
+    clear_platform_http_session()
 
 
 def test_fetch_atcoder_returns_total_on_success():
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.json.return_value = {'count': 42}
+    fake_session = MagicMock()
+    fake_session.get.return_value = mock_response
 
-    with patch('app.platforms.fetchers.requests.get', return_value=mock_response):
+    with patch('app.platforms.fetchers._get_http_session', return_value=fake_session):
         result = fetch_atcoder('tourist')
 
     assert result == {'total': 42}
@@ -19,18 +25,35 @@ def test_fetch_atcoder_returns_total_on_success():
 def test_fetch_atcoder_returns_empty_on_non_200():
     mock_response = MagicMock()
     mock_response.status_code = 404
+    fake_session = MagicMock()
+    fake_session.get.return_value = mock_response
 
-    with patch('app.platforms.fetchers.requests.get', return_value=mock_response):
+    with patch('app.platforms.fetchers._get_http_session', return_value=fake_session):
         result = fetch_atcoder('unknown_user')
 
     assert result == {}
 
 
 def test_fetch_atcoder_returns_empty_on_exception():
-    with patch('app.platforms.fetchers.requests.get', side_effect=Exception('timeout')):
+    fake_session = MagicMock()
+    fake_session.get.side_effect = Exception('timeout')
+
+    with patch('app.platforms.fetchers._get_http_session', return_value=fake_session):
         result = fetch_atcoder('tourist')
 
     assert result == {}
+
+
+def test_fetchers_reuse_thread_local_http_session():
+    fake_session = MagicMock()
+    fake_session.get.return_value = MagicMock(status_code=404)
+
+    with patch('app.platforms.fetchers.requests.Session', return_value=fake_session) as mock_session:
+        fetch_atcoder('tourist')
+        fetch_atcoder('tourist')
+
+    mock_session.assert_called_once()
+    assert fake_session.get.call_count == 2
 
 
 def test_run_fetch_jobs_executes_jobs_concurrently():

--- a/tests/test_sync_platforms.py
+++ b/tests/test_sync_platforms.py
@@ -1,5 +1,7 @@
 from flask import Flask
+from types import SimpleNamespace
 
+import app.profile.routes as profile_routes
 from app.profile.routes import profile_bp
 
 
@@ -48,3 +50,91 @@ def test_sync_platforms_rejects_non_object_json_body():
         "success": False,
         "error": "Request body must be a JSON object.",
     }
+
+
+def test_sync_platforms_runs_selected_platform_jobs_concurrently(monkeypatch):
+    app = create_profile_test_app()
+    captured = {}
+
+    monkeypatch.setattr(
+        profile_routes,
+        "current_user",
+        SimpleNamespace(
+            id="user-1",
+            is_authenticated=True,
+            last_sync=None,
+            leetcode_username="",
+            github_username="",
+            gfg_username="",
+            hackerrank_username="",
+            codingninjas_username="",
+            atcoder_username="",
+            reload=lambda: None,
+        ),
+    )
+    monkeypatch.setattr(
+        profile_routes,
+        "db",
+        SimpleNamespace(user=SimpleNamespace(update_one=lambda query, update: captured.setdefault("db_update", (query, update)))),
+    )
+    monkeypatch.setattr(profile_routes.cache, "clear", lambda: captured.setdefault("cleared_cache", True))
+
+    def fake_run_fetch_jobs(fetch_jobs, max_workers=5):
+        captured["job_names"] = sorted(fetch_jobs.keys())
+        captured["max_workers"] = max_workers
+        return (
+            {
+                "leetcode": {
+                    "stats": {
+                        "calendar": {"2026-05-25": 2},
+                        "total": 101,
+                        "difficulty": {"Easy": 40, "Medium": 50, "Hard": 11},
+                        "contest": {"attendedContestsCount": 5, "rating": 1800, "globalRanking": 1234},
+                    },
+                    "rating_history": [{"x": "2026-05-25", "y": 1800}],
+                    "badges": [{"name": "Knight"}],
+                },
+                "github": {"calendar": {"2026-05-25": 3}, "stats": {"issues": 4, "prs": 5, "merged_prs": 2, "commits": 9}},
+                "gfg": {"total": 77},
+                "codingninjas": {"total": 12},
+                "hackerrank": ([{"name": "Problem Solving", "stars": 5}], 44),
+                "atcoder": {"total": 8},
+            },
+            {},
+        )
+
+    monkeypatch.setattr(profile_routes, "run_fetch_jobs", fake_run_fetch_jobs)
+
+    response = app.test_client().post(
+        "/sync_platforms",
+        json={
+            "leetcode": "lc-user",
+            "github": "gh-user",
+            "gfg": "gfg-user",
+            "codingninjas": "cn-user",
+            "hackerrank": "hr-user",
+            "atcoder": "ac-user",
+        },
+    )
+
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert captured["job_names"] == ["atcoder", "codingninjas", "gfg", "github", "hackerrank", "leetcode"]
+    assert captured["max_workers"] == 4
+    assert payload["success"] is True
+    assert payload["platforms"]["leetcode"]["status"] == "synced"
+    assert payload["platforms"]["github"]["status"] == "synced"
+    assert payload["platforms"]["hackerrank"]["status"] == "synced"
+
+    update_fields = captured["db_update"][1]["$set"]
+    assert update_fields["external_daily_counts"] == {"2026-05-25": 5}
+    assert update_fields["external_totals"]["LeetCode"] == 101
+    assert update_fields["external_totals"]["GitHub_Commits"] == 9
+    assert update_fields["external_totals"]["GFG"] == 77
+    assert update_fields["external_totals"]["Coding Ninjas"] == 12
+    assert update_fields["external_totals"]["HackerRank"] == 44
+    assert update_fields["external_totals"]["AtCoder"] == 8
+    assert update_fields["rating_history"] == [{"x": "2026-05-25", "y": 1800}]
+    assert update_fields["lc_badges_json"] == '[{"name": "Knight"}]'
+    assert update_fields["hr_badges_json"] == '[{"name": "Problem Solving", "stars": 5}]'


### PR DESCRIPTION
## Summary
- run independent platform sync fetches through the existing thread-pool helper instead of fetching each platform sequentially
- preserve the current per-platform status payload and merge logic while fan-out/fan-in happens in parallel
- add focused route coverage proving the selected platform jobs are dispatched together and still merged into the existing response/update shape

Closes #318

## Testing
- `python3 -m pytest tests/test_sync_platforms.py tests/test_sync_platforms_response.py tests/test_platform_fetcher.py -q`
- `python3 -m py_compile app/profile/routes.py tests/test_sync_platforms.py`
- `git diff --check`