### PR TITLE
perf: cache DSA search query results

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,6 +17,7 @@ from app.web.routes import public_bp
 from app.profile import profile_bp
 from app.security import build_content_security_policy
 from app.search import search_bp
+from app.search.service import invalidate_search_question_cache
 from app.tracker import tracker_bp
 from app.utils import platform_color_filter, platform_name_filter
 
@@ -129,6 +130,7 @@ def create_app(config_class=None):
                     )
                 if questions:
                     db.question.insert_many(questions)
+                    invalidate_search_question_cache()
 
     @app.before_request
     def ensure_db_initialized():

--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -3,8 +3,7 @@ from flask_login import current_user
 
 from app.extensions import limiter, cache
 from app.leaderboard.service import (
-    build_college_leaderboard_data,
-    build_leaderboard_data,
+    get_leaderboard_snapshot,
 )
 
 
@@ -15,31 +14,28 @@ leaderboard_bp = Blueprint("leaderboard", __name__)
 @limiter.limit("20 per minute")
 @cache.cached(timeout=300)
 def leaderboard():
-    entries = build_leaderboard_data()
+    by_cscore = get_leaderboard_snapshot("cscore")
+    by_questions = get_leaderboard_snapshot("questions")
+    by_rating = get_leaderboard_snapshot("rating")
+    by_college = get_leaderboard_snapshot("college")
 
-    by_cscore = sorted(entries, key=lambda item: item["c_score"], reverse=True)
-    by_questions = sorted(entries, key=lambda item: item["total_solved"], reverse=True)
-    by_rating = sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
-    by_college = build_college_leaderboard_data(entries)
-
-    def assign_ranks(sorted_list, key):
-        for index, entry in enumerate(sorted_list):
-            entry[f"rank_{key}"] = index + 1
-        return sorted_list
-
-    assign_ranks(by_cscore, "cscore")
-    assign_ranks(by_questions, "questions")
-    assign_ranks(by_rating, "rating")
-    assign_ranks(by_college, "college")
+    for entry in by_cscore:
+        entry["rank_cscore"] = entry["rank"]
+    for entry in by_questions:
+        entry["rank_questions"] = entry["rank"]
+    for entry in by_rating:
+        entry["rank_rating"] = entry["rank"]
+    for entry in by_college:
+        entry["rank_college"] = entry["rank"]
 
     current_user_id = str(current_user.id) if current_user.is_authenticated else None
     
     # Find current user's rank in each category
     current_user_rank = None
     if current_user_id:
-        for i, entry in enumerate(by_cscore):
+        for entry in by_cscore:
             if entry.get("user_id") == current_user_id:
-                current_user_rank = i + 1
+                current_user_rank = entry["rank"]
                 break
     
     return render_template(
@@ -138,20 +134,7 @@ def api_leaderboard():
     page = int(request.args.get("page", 1))
     per_page = min(int(request.args.get("per_page", 20)), 100)
     
-    entries = build_leaderboard_data()
-
-    if mode == "questions":
-        entries.sort(key=lambda item: item["total_solved"], reverse=True)
-    elif mode == "rating":
-        entries.sort(key=lambda item: item["lc_rating"], reverse=True)
-    elif mode == "college":
-        entries = build_college_leaderboard_data(entries)
-    else:
-        entries.sort(key=lambda item: item["c_score"], reverse=True)
-
-    # Assign ranks
-    for index, entry in enumerate(entries):
-        entry["rank"] = index + 1
+    entries = get_leaderboard_snapshot(mode)
 
     # Pagination
     total = len(entries)

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -1,5 +1,9 @@
-from app.extensions import db
+from app.extensions import cache, db
 from app.utils import compute_c_score
+
+LEADERBOARD_SNAPSHOT_CACHE_KEY = "leaderboard:snapshots:v1"
+LEADERBOARD_SNAPSHOT_TTL = 300
+LEADERBOARD_MODES = ("cscore", "questions", "rating", "college")
 
 
 def build_leaderboard_data():
@@ -111,3 +115,47 @@ def build_college_leaderboard_data(entries=None):
         key=lambda item: (item["c_score"], item["total_solved"], item["member_count"]),
         reverse=True,
     )
+
+
+def _rank_entries(entries):
+    ranked = []
+    for index, entry in enumerate(entries, start=1):
+        ranked.append({**entry, "rank": index})
+    return ranked
+
+
+def _sort_leaderboard_entries(entries, mode):
+    if mode == "questions":
+        return sorted(entries, key=lambda item: item["total_solved"], reverse=True)
+    if mode == "rating":
+        return sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
+    if mode == "college":
+        return build_college_leaderboard_data(entries)
+    return sorted(entries, key=lambda item: item["c_score"], reverse=True)
+
+
+def build_leaderboard_snapshots():
+    entries = build_leaderboard_data()
+    return {
+        mode: _rank_entries(_sort_leaderboard_entries(entries, mode))
+        for mode in LEADERBOARD_MODES
+    }
+
+
+def get_leaderboard_snapshot(mode, force_refresh=False):
+    mode = mode if mode in LEADERBOARD_MODES else "cscore"
+    snapshots = None if force_refresh else cache.get(LEADERBOARD_SNAPSHOT_CACHE_KEY)
+    if snapshots is None:
+        snapshots = build_leaderboard_snapshots()
+        cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return [dict(entry) for entry in snapshots[mode]]
+
+
+def refresh_leaderboard_snapshots():
+    snapshots = build_leaderboard_snapshots()
+    cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return snapshots
+
+
+def clear_leaderboard_snapshots():
+    cache.delete(LEADERBOARD_SNAPSHOT_CACHE_KEY)

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -6,6 +6,7 @@ from flask_login import current_user, login_required
 
 from app.extensions import db
 from app.extensions import limiter, cache
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.platforms.fetchers import (
     fetch_atcoder,
     fetch_coding_ninjas,
@@ -273,6 +274,7 @@ def sync_platforms():
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
 
+    clear_leaderboard_snapshots()
     cache.clear()
     return jsonify(build_sync_platforms_response(platform_status))
 
@@ -351,6 +353,7 @@ def edit_profile():
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
     return json_success()
 
 

--- a/app/search/service.py
+++ b/app/search/service.py
@@ -1,7 +1,11 @@
 import re
 from urllib.parse import quote_plus
 
-from app.extensions import db
+from app.extensions import cache, db
+
+
+SEARCH_QUERY_CACHE_TTL = 120
+SEARCH_QUERY_CACHE_VERSION_KEY = "search:questions:version"
 
 
 PLATFORM_SEARCHES = {
@@ -84,6 +88,24 @@ def question_links(question):
     return links
 
 
+def _normalize_search_cache_query(query):
+    return " ".join(tokenize_search_text(query))
+
+
+def _search_cache_version():
+    return cache.get(SEARCH_QUERY_CACHE_VERSION_KEY) or 1
+
+
+def _search_cache_key(query, requested_platforms, limit):
+    normalized_query = _normalize_search_cache_query(query)
+    normalized_platforms = ",".join(sorted(requested_platforms or ()))
+    return f"search:questions:{_search_cache_version()}:{limit}:{normalized_platforms}:{normalized_query}"
+
+
+def invalidate_search_question_cache():
+    cache.set(SEARCH_QUERY_CACHE_VERSION_KEY, _search_cache_version() + 1, timeout=0)
+
+
 def search_dsa_questions(raw_query, limit=40, db_handle=None):
     db_handle = db_handle or db
     query, requested_platforms = parse_search_query(raw_query)
@@ -94,6 +116,16 @@ def search_dsa_questions(raw_query, limit=40, db_handle=None):
             "requested_platforms": requested_platforms,
             "results": [],
             "external_searches": [],
+        }
+
+    cache_key = _search_cache_key(query, requested_platforms, limit)
+    cached_results = cache.get(cache_key)
+    if cached_results is not None:
+        return {
+            "query": query,
+            "requested_platforms": requested_platforms,
+            "results": cached_results,
+            "external_searches": build_external_searches(query, requested_platforms),
         }
 
     cursor = (
@@ -144,6 +176,7 @@ def search_dsa_questions(raw_query, limit=40, db_handle=None):
             }
         )
 
+    cache.set(cache_key, results, timeout=SEARCH_QUERY_CACHE_TTL)
     return {
         "query": query,
         "requested_platforms": requested_platforms,

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -3,6 +3,7 @@ from flask import Blueprint, Response, jsonify, render_template, request
 from flask_login import current_user, login_required
 
 from app.extensions import db
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.utils import json_error, json_success, utc_now
 from notes_export import build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
@@ -201,6 +202,7 @@ def update_question(question_id):
     if update_fields:
         db.user.update_one({"_id": user_id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
         return json_success(message=message)
 
     return json_success(message="No changes made")

--- a/tests/test_leaderboard_snapshots.py
+++ b/tests/test_leaderboard_snapshots.py
@@ -1,0 +1,156 @@
+from bson import ObjectId
+
+from conftest import build_test_app, login_test_user
+from app.leaderboard.service import (
+    LEADERBOARD_SNAPSHOT_CACHE_KEY,
+    build_leaderboard_snapshots,
+    clear_leaderboard_snapshots,
+    get_leaderboard_snapshot,
+    refresh_leaderboard_snapshots,
+)
+from app.leaderboard import service as leaderboard_service
+import app.profile.routes as profile_routes
+import app.tracker.routes as tracker_routes
+
+
+class FakeCache:
+    def __init__(self):
+        self.values = {}
+        self.set_calls = []
+        self.delete_calls = []
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value, timeout=None):
+        self.values[key] = value
+        self.set_calls.append((key, timeout))
+
+    def delete(self, key):
+        self.values.pop(key, None)
+        self.delete_calls.append(key)
+
+
+def test_get_leaderboard_snapshot_uses_cached_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+    build_calls = []
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: build_calls.append("built") or {
+            "cscore": [{"user_id": "1", "rank": 1, "c_score": 42}],
+            "questions": [{"user_id": "1", "rank": 1, "total_solved": 10}],
+            "rating": [{"user_id": "1", "rank": 1, "lc_rating": 1800}],
+            "college": [{"user_id": "", "rank": 1, "college": "Alpha"}],
+        },
+    )
+
+    first = get_leaderboard_snapshot("cscore")
+    second = get_leaderboard_snapshot("questions")
+
+    assert build_calls == ["built"]
+    assert fake_cache.set_calls == [(LEADERBOARD_SNAPSHOT_CACHE_KEY, leaderboard_service.LEADERBOARD_SNAPSHOT_TTL)]
+    assert first[0]["c_score"] == 42
+    assert second[0]["total_solved"] == 10
+
+
+def test_refresh_and_clear_leaderboard_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: {
+            "cscore": [{"rank": 1}],
+            "questions": [{"rank": 1}],
+            "rating": [{"rank": 1}],
+            "college": [{"rank": 1}],
+        },
+    )
+
+    snapshots = refresh_leaderboard_snapshots()
+    clear_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert fake_cache.delete_calls == [LEADERBOARD_SNAPSHOT_CACHE_KEY]
+
+
+def test_build_leaderboard_snapshots_assigns_ranks(monkeypatch):
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_data",
+        lambda: [
+            {
+                "user_id": "1",
+                "name": "Alice",
+                "college": "Alpha",
+                "profile_photo": "",
+                "c_score": 20,
+                "total_solved": 15,
+                "dsa_done": 8,
+                "lc_total": 10,
+                "gfg_total": 2,
+                "cn_total": 1,
+                "hr_total": 0,
+                "lc_rating": 1500,
+            },
+            {
+                "user_id": "2",
+                "name": "Bob",
+                "college": "Beta",
+                "profile_photo": "",
+                "c_score": 30,
+                "total_solved": 12,
+                "dsa_done": 7,
+                "lc_total": 9,
+                "gfg_total": 1,
+                "cn_total": 0,
+                "hr_total": 0,
+                "lc_rating": 1700,
+            },
+        ],
+    )
+
+    snapshots = build_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["user_id"] == "2"
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert snapshots["questions"][0]["user_id"] == "1"
+    assert snapshots["rating"][0]["user_id"] == "2"
+    assert snapshots["college"][0]["rank"] == 1
+
+
+def test_update_question_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
+    invalidations = []
+
+    monkeypatch.setattr(tracker_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        login_test_user(client, test_db)
+        response = client.post(f"/update_question/{question_id}", json={"done": True})
+
+    assert response.status_code == 200
+    assert invalidations == ["cleared"]
+
+
+def test_edit_profile_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(profile_routes,))
+    invalidations = []
+
+    monkeypatch.setattr(profile_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        user_id = test_db.user.insert_one(
+            {"email": "user@example.com", "progress": {}, "is_admin": False, "name": "Before"}
+        ).inserted_id
+        login_test_user(client, user_id)
+        response = client.post("/edit_profile", json={"name": "After", "college": "New College"})
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert invalidations == ["cleared"]

--- a/tests/test_search_query_cache.py
+++ b/tests/test_search_query_cache.py
@@ -1,0 +1,143 @@
+import app as app_module
+import app.search.service as search_service
+import app.tracker.routes as tracker_routes
+import app.utils as utils
+from conftest import build_test_app
+
+
+class FakeCache:
+    def __init__(self):
+        self.values = {}
+        self.set_calls = []
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value, timeout=None):
+        self.values[key] = value
+        self.set_calls.append((key, timeout))
+
+
+class FakeCursor:
+    def __init__(self, docs):
+        self.docs = docs
+        self.limit_count = None
+
+    def sort(self, args):
+        return self
+
+    def limit(self, count):
+        self.limit_count = count
+        return self
+
+    def __iter__(self):
+        return iter(self.docs[: self.limit_count])
+
+
+class FakeQuestionCollection:
+    def __init__(self, docs):
+        self.docs = docs
+        self.find_calls = []
+
+    def find(self, query, projection):
+        self.find_calls.append((query, projection))
+        return FakeCursor(self.docs)
+
+
+class FakeTopicCollection:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def find(self, query, projection):
+        requested_ids = set(query.get("_id", {}).get("$in", []))
+        return [doc for doc in self.docs if doc["_id"] in requested_ids]
+
+
+class FakeDB:
+    def __init__(self, questions=None, topics=None):
+        self.question = FakeQuestionCollection(questions or [])
+        self.topic = FakeTopicCollection(topics or [])
+
+
+def build_fake_search_db():
+    return FakeDB(
+        questions=[
+            {
+                "_id": "q1",
+                "problem": "Two Sum",
+                "topic": "arrays",
+                "url": "https://leetcode.com/problems/two-sum/",
+                "url2": "",
+                "score": 5.0,
+            },
+            {
+                "_id": "q2",
+                "problem": "Two Sum Variant",
+                "topic": "arrays",
+                "url": "https://practice.geeksforgeeks.org/problems/two-sum-variant/",
+                "url2": "",
+                "score": 4.0,
+            },
+        ],
+        topics=[{"_id": "arrays", "name": "Arrays", "position": 1}],
+    )
+
+
+def test_search_reuses_cached_results_for_normalized_query(monkeypatch):
+    fake_db = build_fake_search_db()
+    fake_cache = FakeCache()
+
+    monkeypatch.setattr(utils, "db", fake_db)
+    monkeypatch.setattr(search_service, "cache", fake_cache)
+
+    first = utils.search_dsa_questions("  Two   Sum  ", limit=10)
+    second = utils.search_dsa_questions("two sum", limit=10)
+
+    assert len(fake_db.question.find_calls) == 1
+    assert first["results"] == second["results"]
+    assert second["query"] == "two sum"
+
+
+def test_search_cache_key_includes_limit_and_platform_filters(monkeypatch):
+    fake_db = build_fake_search_db()
+    fake_cache = FakeCache()
+
+    monkeypatch.setattr(utils, "db", fake_db)
+    monkeypatch.setattr(search_service, "cache", fake_cache)
+
+    utils.search_dsa_questions("two sum", limit=10)
+    utils.search_dsa_questions("two sum", limit=20)
+    utils.search_dsa_questions("gfg two sum", limit=10)
+
+    assert len(fake_db.question.find_calls) == 3
+
+
+def test_invalidate_search_question_cache_bumps_cache_version(monkeypatch):
+    fake_db = build_fake_search_db()
+    fake_cache = FakeCache()
+
+    monkeypatch.setattr(utils, "db", fake_db)
+    monkeypatch.setattr(search_service, "cache", fake_cache)
+
+    utils.search_dsa_questions("two sum", limit=10)
+    search_service.invalidate_search_question_cache()
+    utils.search_dsa_questions("two sum", limit=10)
+
+    assert len(fake_db.question.find_calls) == 2
+    assert fake_cache.values[search_service.SEARCH_QUERY_CACHE_VERSION_KEY] == 2
+
+
+def test_initial_question_seed_invalidates_search_cache(monkeypatch):
+    invalidations = []
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+
+    monkeypatch.setattr(app_module, "invalidate_search_question_cache", lambda: invalidations.append("cleared"))
+    flask_app._db_initialized = False
+
+    with flask_app.test_client() as client:
+        response = client.get("/")
+
+    assert response.status_code == 200
+    assert invalidations
+    assert test_db.topic.count_documents({}) > 0
+    assert test_db.question.count_documents({}) > 0


### PR DESCRIPTION
Fixes #327

## Summary
- cache normalized DSA search results for a short TTL using the existing Flask cache
- include normalized query text, requested platform filters, limit, and a cache version in the cache key
- invalidate the search cache when question data is seeded so stale results are not reused after question writes
- add focused regression coverage for normalized cache reuse, key separation, invalidation, and seed-time invalidation

## Validation
- python3 -m pytest tests/test_search_query_cache.py tests/test_search_utils.py tests/test_app_factory.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/450dsa-issue-327/.pycache python3 -m py_compile app/search/service.py app/__init__.py tests/test_search_query_cache.py
- git diff --check