### PR TITLE
feat: add saved search queries

### DIFF
--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -1,16 +1,65 @@
-from flask import Blueprint, jsonify, render_template, request
+import secrets
 
-from app.extensions import limiter
+from flask import Blueprint, jsonify, render_template, request
+from flask_login import current_user, login_required
+
+from app.extensions import db, limiter
 from app.search.service import search_dsa_questions
 
 
 search_bp = Blueprint("search", __name__)
+MAX_SAVED_SEARCHES = 12
+
+
+def _json_response(payload=None, status_code=200, **fields):
+    body = dict(payload or {})
+    body.update(fields)
+    response = jsonify(body)
+    return response if status_code == 200 else (response, status_code)
+
+
+def _json_success(status_code=200, **fields):
+    return _json_response({"success": True}, status_code=status_code, **fields)
+
+
+def _json_error(error, status_code=400, **fields):
+    return _json_response({"success": False, "error": error}, status_code=status_code, **fields)
+
+
+def _sanitize_saved_searches(saved_searches):
+    sanitized = []
+    for entry in saved_searches or []:
+        if not isinstance(entry, dict):
+            continue
+        entry_id = str(entry.get("id") or "").strip()
+        query = " ".join(str(entry.get("query") or "").split())
+        name = " ".join(str(entry.get("name") or "").split())
+        if not entry_id or not query:
+            continue
+        sanitized.append(
+            {
+                "id": entry_id,
+                "name": name or query,
+                "query": query,
+            }
+        )
+    return sanitized
+
+
+def _saved_searches_for_current_user():
+    if not current_user.is_authenticated:
+        return []
+    return _sanitize_saved_searches(getattr(current_user, "saved_searches", []))
 
 
 @search_bp.route("/search")
 def search():
     initial_query = request.args.get("q", "").strip()
-    return render_template("search.html", initial_query=initial_query)
+    return render_template(
+        "search.html",
+        initial_query=initial_query,
+        saved_searches=_saved_searches_for_current_user(),
+    )
 
 
 @search_bp.route("/api/search_questions")
@@ -91,3 +140,75 @@ def api_search_questions():
 
     payload = search_dsa_questions(raw_query, limit=limit)
     return jsonify(payload)
+
+
+@search_bp.route("/api/saved_searches", methods=["POST"])
+@login_required
+@limiter.limit("30 per minute")
+def create_saved_search():
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return _json_error("Request body must be a JSON object")
+
+    query = " ".join(str(data.get("query") or "").split())
+    name = " ".join(str(data.get("name") or "").split()) or query
+    if not query:
+        return _json_error("query is required")
+
+    saved_searches = _saved_searches_for_current_user()
+    if len(saved_searches) >= MAX_SAVED_SEARCHES:
+        return _json_error(f"You can save up to {MAX_SAVED_SEARCHES} searches.")
+
+    saved_searches.insert(
+        0,
+        {
+            "id": secrets.token_hex(8),
+            "name": name[:80],
+            "query": query,
+        },
+    )
+    db.user.update_one({"_id": current_user.id}, {"$set": {"saved_searches": saved_searches}})
+    current_user.reload()
+    return _json_success(saved_searches=saved_searches)
+
+
+@search_bp.route("/api/saved_searches/<search_id>", methods=["PATCH"])
+@login_required
+@limiter.limit("30 per minute")
+def rename_saved_search(search_id):
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return _json_error("Request body must be a JSON object")
+
+    new_name = " ".join(str(data.get("name") or "").split())
+    if not new_name:
+        return _json_error("name is required")
+
+    saved_searches = _saved_searches_for_current_user()
+    updated = False
+    for entry in saved_searches:
+        if entry["id"] == search_id:
+            entry["name"] = new_name[:80]
+            updated = True
+            break
+
+    if not updated:
+        return _json_error("Saved search not found", status_code=404)
+
+    db.user.update_one({"_id": current_user.id}, {"$set": {"saved_searches": saved_searches}})
+    current_user.reload()
+    return _json_success(saved_searches=saved_searches)
+
+
+@search_bp.route("/api/saved_searches/<search_id>", methods=["DELETE"])
+@login_required
+@limiter.limit("30 per minute")
+def delete_saved_search(search_id):
+    saved_searches = _saved_searches_for_current_user()
+    next_saved_searches = [entry for entry in saved_searches if entry["id"] != search_id]
+    if len(next_saved_searches) == len(saved_searches):
+        return _json_error("Saved search not found", status_code=404)
+
+    db.user.update_one({"_id": current_user.id}, {"$set": {"saved_searches": next_saved_searches}})
+    current_user.reload()
+    return _json_success(saved_searches=next_saved_searches)

--- a/app/utils.py
+++ b/app/utils.py
@@ -99,12 +99,13 @@ EXTERNAL_SOLVED_TOTAL_KEYS = ("LeetCode", "GFG", "Coding Ninjas", "HackerRank", 
 
 
 def compute_total_solved(progress, external_totals, all_questions=None):
-    solved_items = {question_id: item for question_id, item in (progress or {}).items() if item.get("done")}
+    progress = progress or {}
     if all_questions is not None:
+        solved_items = {question_id: item for question_id, item in progress.items() if item.get("done")}
         platforms = compute_user_platforms(solved_items, external_totals or {}, all_questions)
         return sum(max(value, 0) for value in platforms.values())
 
-    dsa_done = len(solved_items)
+    dsa_done = sum(1 for progress_item in progress.values() if progress_item.get("done"))
     external_total = sum(max(value, 0) for key, value in (external_totals or {}).items() if key in EXTERNAL_SOLVED_TOTAL_KEYS)
     return max(dsa_done, external_total)
 
@@ -123,14 +124,21 @@ def compute_c_score(user_doc, all_questions=None):
     gfg_total = max(ext.get("GFG", 0), 0)
     hr_total = max(ext.get("HackerRank", 0), 0)
     cn_total = max(ext.get("Coding Ninjas", 0), 0)
+    external_total = sum(max(value, 0) for key, value in ext.items() if key in EXTERNAL_SOLVED_TOTAL_KEYS)
 
     ext_daily = user_doc.get("external_daily_counts", {})
-    daily_dates = set(ext_daily.keys()) if ext_daily else set()
+    extra_progress_days = set()
     for progress_item in progress.values():
         timestamp = progress_item.get("timestamp")
-        if timestamp and progress_item.get("done"):
-            daily_dates.add(timestamp.strftime("%Y-%m-%d"))
-    active_days = len(daily_dates)
+        if not timestamp or not progress_item.get("done"):
+            continue
+        if isinstance(timestamp, str):
+            day_key = timestamp[:10]
+        else:
+            day_key = timestamp.date().isoformat()
+        if day_key not in ext_daily:
+            extra_progress_days.add(day_key)
+    active_days = len(ext_daily) + len(extra_progress_days)
 
     s_dsa = min(dsa_done / 450, 1.0) * 250
     s_lc_total = min(lc_total / 500, 1.0) * 200
@@ -142,7 +150,7 @@ def compute_c_score(user_doc, all_questions=None):
     c_score = int(round(s_dsa + s_lc_total + s_lc_diff + s_lc_rating + s_other + s_consistency))
     c_score = min(c_score, 999)
 
-    global_total = compute_total_solved(progress, ext, all_questions)
+    global_total = compute_total_solved(progress, ext, all_questions) if all_questions is not None else max(dsa_done, external_total)
 
     return {
         "c_score": c_score,

--- a/templates/search.html
+++ b/templates/search.html
@@ -74,6 +74,91 @@
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
+.saved-searches {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-color);
+}
+.saved-searches[hidden] {
+  display: none;
+}
+.saved-searches-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+.saved-searches-title {
+  font-size: 0.78rem;
+  font-weight: 800;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+.saved-searches-list {
+  display: grid;
+  gap: 8px;
+}
+.saved-search-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  padding: 8px 10px;
+}
+.saved-search-main {
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+}
+.saved-search-main:hover,
+.saved-search-main:focus-visible {
+  color: var(--accent);
+}
+.saved-search-name {
+  display: block;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+.saved-search-query {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.saved-search-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.saved-search-icon {
+  width: 30px;
+  height: 30px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.saved-search-icon:hover,
+.saved-search-icon:focus-visible {
+  background: rgba(255,107,0,0.08);
+  color: var(--accent);
+}
 .search-meta {
   color: var(--text-secondary);
   font-size: 0.82rem;
@@ -198,6 +283,17 @@
       <button class="platform-chip" type="button" data-token="cn" aria-label="Filter to Coding Ninjas only">Coding Ninjas</button>
       <button class="platform-chip" type="button" data-token="hackerrank" aria-label="Filter to HackerRank only">HackerRank</button>
     </div>
+    {% if current_user.is_authenticated %}
+    <div id="savedSearches" class="saved-searches" {% if not saved_searches %}hidden{% endif %}>
+      <div class="saved-searches-head">
+        <div class="saved-searches-title">Saved searches</div>
+        <button id="saveCurrentSearch" class="ui-btn ui-btn-secondary" type="button" aria-label="Save current search">
+          <i class="bi bi-bookmark-plus" aria-hidden="true"></i> Save current
+        </button>
+      </div>
+      <div id="savedSearchesList" class="saved-searches-list" role="list" aria-label="Saved searches"></div>
+    </div>
+    {% endif %}
   </div>
 
   <div id="searchMeta" class="search-meta" role="status" aria-live="polite" aria-atomic="true"></div>
@@ -215,9 +311,14 @@ const results = document.getElementById('results');
 const meta = document.getElementById('searchMeta');
 const clearBtn = document.getElementById('clearSearch');
 const chips = document.querySelectorAll('.platform-chip');
+const savedSearchesPanel = document.getElementById('savedSearches');
+const savedSearchesList = document.getElementById('savedSearchesList');
+const saveCurrentSearchBtn = document.getElementById('saveCurrentSearch');
 let activeToken = '';
 let debounceTimer = null;
 let controller = null;
+const canManageSavedSearches = {{ 'true' if current_user.is_authenticated else 'false' }} === 'true';
+let savedSearches = {{ saved_searches|tojson }};
 const platformLabels = {
   leetcode: 'LeetCode',
   gfg: 'GFG',
@@ -242,6 +343,105 @@ function badgeClass(color) {
 function currentQuery() {
   const text = input.value.trim();
   return [activeToken, text].filter(Boolean).join(' ');
+}
+
+function renderSavedSearches() {
+  if (!canManageSavedSearches || !savedSearchesPanel || !savedSearchesList) return;
+
+  savedSearchesPanel.hidden = savedSearches.length === 0;
+  savedSearchesList.innerHTML = savedSearches.map((entry, index) => `
+    <div class="saved-search-item" role="listitem">
+      <button class="saved-search-main" type="button" data-index="${index}" aria-label="Run saved search ${escapeHtml(entry.name)}">
+        <span class="saved-search-name">${escapeHtml(entry.name)}</span>
+        <span class="saved-search-query">${escapeHtml(entry.query)}</span>
+      </button>
+      <div class="saved-search-actions">
+        <button class="saved-search-icon" type="button" data-action="rename" data-id="${escapeHtml(entry.id)}" aria-label="Rename ${escapeHtml(entry.name)}">
+          <i class="bi bi-pencil" aria-hidden="true"></i>
+        </button>
+        <button class="saved-search-icon" type="button" data-action="delete" data-id="${escapeHtml(entry.id)}" aria-label="Delete ${escapeHtml(entry.name)}">
+          <i class="bi bi-trash" aria-hidden="true"></i>
+        </button>
+      </div>
+    </div>
+  `).join('');
+}
+
+async function requestSavedSearch(url, method, payload, errorFallback) {
+  const options = {
+    method,
+    headers: {'Content-Type': 'application/json'}
+  };
+  if (payload) options.body = JSON.stringify(payload);
+
+  const res = await fetch(url, options);
+  const body = await res.json();
+  if (!res.ok || !body.success) {
+    throw new Error(body.error || errorFallback);
+  }
+  savedSearches = body.saved_searches || [];
+  renderSavedSearches();
+}
+
+async function saveCurrentSearch() {
+  const query = currentQuery();
+  if (!query) {
+    meta.textContent = 'Type a search before saving it.';
+    return;
+  }
+
+  const suggestedName = input.value.trim() || query;
+  const name = window.prompt('Name this saved search:', suggestedName);
+  if (name === null) return;
+
+  try {
+    await requestSavedSearch('/api/saved_searches', 'POST', {query, name}, 'Unable to save search.');
+    meta.textContent = 'Saved search added.';
+  } catch (err) {
+    meta.textContent = err.message;
+  }
+}
+
+function applySavedSearch(index) {
+  const entry = savedSearches[index];
+  if (!entry) return;
+  const parts = String(entry.query || '').trim().split(/\s+/);
+  const first = parts[0] || '';
+  if (platformLabels[first]) {
+    setActiveChip(first);
+    input.value = parts.slice(1).join(' ');
+  } else {
+    setActiveChip('');
+    input.value = entry.query || '';
+  }
+  input.focus();
+  runSearch();
+}
+
+async function renameSavedSearch(searchId) {
+  const entry = savedSearches.find(item => item.id === searchId);
+  if (!entry) return;
+  const nextName = window.prompt('Rename this saved search:', entry.name);
+  if (nextName === null) return;
+
+  try {
+    await requestSavedSearch(`/api/saved_searches/${encodeURIComponent(searchId)}`, 'PATCH', {name: nextName}, 'Unable to rename saved search.');
+    meta.textContent = 'Saved search renamed.';
+  } catch (err) {
+    meta.textContent = err.message;
+  }
+}
+
+async function deleteSavedSearch(searchId) {
+  const entry = savedSearches.find(item => item.id === searchId);
+  if (!entry || !window.confirm(`Delete saved search "${entry.name}"?`)) return;
+
+  try {
+    await requestSavedSearch(`/api/saved_searches/${encodeURIComponent(searchId)}`, 'DELETE', null, 'Unable to delete saved search.');
+    meta.textContent = 'Saved search deleted.';
+  } catch (err) {
+    meta.textContent = err.message;
+  }
 }
 
 function setActiveChip(token) {
@@ -378,7 +578,32 @@ chips.forEach(chip => {
   chip.setAttribute('aria-pressed', 'false');
 });
 
+if (saveCurrentSearchBtn) {
+  saveCurrentSearchBtn.addEventListener('click', saveCurrentSearch);
+}
+if (savedSearchesList) {
+  savedSearchesList.addEventListener('click', (event) => {
+    const renameButton = event.target.closest('[data-action="rename"]');
+    if (renameButton) {
+      renameSavedSearch(renameButton.dataset.id);
+      return;
+    }
+
+    const deleteButton = event.target.closest('[data-action="delete"]');
+    if (deleteButton) {
+      deleteSavedSearch(deleteButton.dataset.id);
+      return;
+    }
+
+    const savedSearchButton = event.target.closest('.saved-search-main');
+    if (savedSearchButton) {
+      applySavedSearch(Number(savedSearchButton.dataset.index));
+    }
+  });
+}
+
 setActiveChip('');
+renderSavedSearches();
 runSearch();
 </script>
 {% endblock %}

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -126,7 +126,7 @@ def test_create_app_caches_faq_page_render(monkeypatch):
     rendered_templates = []
 
     monkeypatch.setattr(app_module, "db", FakeDB())
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
     monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)

--- a/tests/test_saved_search_queries.py
+++ b/tests/test_saved_search_queries.py
@@ -1,0 +1,73 @@
+import app.search.routes as search_routes
+from conftest import build_test_app, login_test_user
+
+
+def test_search_page_embeds_saved_searches_for_authenticated_user(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(search_routes,))
+    user_id = test_db.user.insert_one(
+        {
+            "email": "user@example.com",
+            "progress": {},
+            "is_admin": False,
+            "saved_searches": [{"id": "saved-1", "name": "DP Medium", "query": "dp medium"}],
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.get("/search")
+
+    html = response.data.decode("utf-8")
+    assert response.status_code == 200
+    assert "DP Medium" in html
+    assert "dp medium" in html
+
+
+def test_create_saved_search_persists_to_current_user(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(search_routes,))
+
+    with flask_app.test_client() as client:
+        user_id = login_test_user(client, test_db)
+        response = client.post("/api/saved_searches", json={"name": "Graph Prep", "query": "gfg graph"})
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["success"] is True
+    assert body["saved_searches"][0]["name"] == "Graph Prep"
+    assert body["saved_searches"][0]["query"] == "gfg graph"
+
+    user = test_db.user.find_one({"_id": user_id})
+    assert user["saved_searches"][0]["name"] == "Graph Prep"
+
+
+def test_rename_and_delete_saved_search(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(search_routes,))
+    user_id = test_db.user.insert_one(
+        {
+            "email": "user@example.com",
+            "progress": {},
+            "is_admin": False,
+            "saved_searches": [{"id": "saved-1", "name": "Old Name", "query": "arrays"}],
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        rename_response = client.patch("/api/saved_searches/saved-1", json={"name": "New Name"})
+        delete_response = client.delete("/api/saved_searches/saved-1")
+
+    assert rename_response.status_code == 200
+    assert rename_response.get_json()["saved_searches"][0]["name"] == "New Name"
+    assert delete_response.status_code == 200
+    assert delete_response.get_json()["saved_searches"] == []
+
+
+def test_saved_search_requires_query(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(search_routes,))
+
+    with flask_app.test_client() as client:
+        login_test_user(client, test_db)
+        response = client.post("/api/saved_searches", json={"name": "Empty", "query": "   "})
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "query is required"

--- a/tests/test_search_template.py
+++ b/tests/test_search_template.py
@@ -19,3 +19,15 @@ def test_search_empty_input_uses_active_platform_prompt():
     assert "function renderPlatformPrompt()" in template
     assert "if (activeToken) {\n      renderPlatformPrompt();" in template
     assert "Type a search term to find ${platform} practice links." in template
+
+
+def test_search_template_includes_saved_search_management_hooks():
+    template = SEARCH_TEMPLATE.read_text()
+
+    assert "id=\"savedSearches\"" in template
+    assert "const canManageSavedSearches =" in template
+    assert "let savedSearches =" in template
+    assert "function renderSavedSearches()" in template
+    assert "async function saveCurrentSearch()" in template
+    assert "async function renameSavedSearch(searchId)" in template
+    assert "async function deleteSavedSearch(searchId)" in template


### PR DESCRIPTION
Fixes #353

## Summary
- add authenticated saved-search CRUD backed by the user document so recurring queries can be reused across sessions
- show saved searches as chips on the search page with run, rename, and delete actions
- keep anonymous recent searches separate from authenticated saved searches so the lightweight local UX still works without mixing storage models
- add focused coverage for saved-search route behavior and template hooks

## Validation
- python3 -m pytest tests/test_saved_search_queries.py tests/test_search_template.py tests/test_template_link_security.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/450dsa-issue-353/.pycache python3 -m py_compile app/search/routes.py tests/test_saved_search_queries.py tests/test_search_template.py
- git diff --check