### PR TITLE
fix: require explicit secret key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Flask
-SECRET_KEY=change-me-to-a-random-string
+# REQUIRED - generate your own with:
+# python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=replace-this-with-a-real-secret
 
 # MongoDB (Future/Alternative Database)
 MONGO_URI=mongodb://localhost:27017/dsa_tracker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,9 @@ copy .env.example .env  # Windows
 
 Edit `.env` with your values:
 ```env
-SECRET_KEY=any-random-string
+# REQUIRED - generate your own first:
+# python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=replace-this-with-a-real-secret
 
 # MongoDB connection string (see MongoDB Setup below)
 MONGO_URI=mongodb+srv://<user>:<password>@cluster.mongodb.net/dsa_tracker
@@ -91,6 +93,8 @@ CLOUDINARY_CLOUD_NAME=your-cloud-name
 CLOUDINARY_API_KEY=your-api-key
 CLOUDINARY_API_SECRET=your-api-secret
 ```
+
+Do not leave `SECRET_KEY` at a placeholder value. The app will now stop at startup if the secret is missing or still using a known insecure default, and any leaked or committed secret should be rotated immediately.
 
 **4. Run the app**
 ```bash

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ copy .env.example .env  # Windows
 
 Edit `.env` and fill in your values:
 ```env
-SECRET_KEY=your-random-secret-key
+# REQUIRED - generate your own first:
+# python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=replace-this-with-a-real-secret
 
 # MongoDB — use Atlas (free) or local
 MONGO_URI=mongodb+srv://<user>:<password>@cluster.mongodb.net/dsa_tracker
@@ -82,6 +84,8 @@ CLOUDINARY_CLOUD_NAME=your-cloud-name
 CLOUDINARY_API_KEY=your-api-key
 CLOUDINARY_API_SECRET=your-api-secret
 ```
+
+The app now refuses to start if `SECRET_KEY` is missing or still set to an insecure placeholder. If a secret was ever committed or shared, rotate it before running the app again.
 
 **3. Run**
 ```bash
@@ -201,7 +205,7 @@ pytest
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `SECRET_KEY` | Yes | Flask session secret |
+| `SECRET_KEY` | Yes | Flask session secret. Must be a real generated secret, not a placeholder. |
 | `MONGO_URI` | Yes | MongoDB connection string |
 | `GITHUB_CLIENT_ID` | No | GitHub OAuth app client ID |
 | `GITHUB_CLIENT_SECRET` | No | GitHub OAuth app client secret |

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -42,6 +42,7 @@ def create_app(config_class=None):
     app = Flask(__name__, template_folder="../templates", static_folder="../static")
     config_class = config_class or resolve_config_class()
     app.config.from_object(config_class)
+    # Non-test environments must provide a real SECRET_KEY before the app boots.
     config_class.apply_environment_overrides(app)
     _configure_rate_limit_storage(app, config_class)
     app.config["SESSION_COOKIE_SECURE"] = env_flag(

--- a/app/config.py
+++ b/app/config.py
@@ -29,7 +29,7 @@ def current_environment_name():
 
 
 class BaseConfig:
-    SECRET_KEY = "supersecretkey"
+    SECRET_KEY = None
     MONGO_URI = "mongodb://localhost:27017/450_dsa"
     MONGO_SERVER_SELECTION_TIMEOUT_MS = 5000
     MONGO_CONNECT_TIMEOUT_MS = 5000
@@ -45,10 +45,31 @@ class BaseConfig:
         "uiversion": 3,
     }
     RATELIMIT_STORAGE_URI = "memory://"
+    INSECURE_SECRET_KEYS = {
+        None,
+        "",
+        "supersecretkey",
+        "supersecretkey-change-me",
+        "change-me",
+        "change-me-to-a-random-string",
+        "dev",
+        "your-random-secret-key",
+        "replace-this-with-a-real-secret",
+    }
 
     @classmethod
     def apply_environment_overrides(cls, app):
-        app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", cls.SECRET_KEY)
+        secret_key = os.environ.get("SECRET_KEY")
+        if secret_key is None:
+            secret_key = cls.SECRET_KEY
+        if isinstance(secret_key, str):
+            secret_key = secret_key.strip()
+        if not app.config.get("TESTING") and secret_key in cls.INSECURE_SECRET_KEYS:
+            raise RuntimeError(
+                "SECRET_KEY is not set or is using an insecure default. "
+                "Generate one with: python -c \"import secrets; print(secrets.token_hex(32))\""
+            )
+        app.config["SECRET_KEY"] = secret_key
         app.config["MONGO_URI"] = os.environ.get("MONGO_URI", cls.MONGO_URI)
         app.config["MONGO_SERVER_SELECTION_TIMEOUT_MS"] = env_int(
             "MONGO_SERVER_SELECTION_TIMEOUT_MS",
@@ -82,6 +103,7 @@ class DevelopmentConfig(BaseConfig):
 
 class TestingConfig(BaseConfig):
     TESTING = True
+    SECRET_KEY = "test-only-secret-not-for-production"
     SESSION_COOKIE_SECURE = False
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       - FLASK_APP=app.py
       - FLASK_ENV=production
       - MONGO_URI=mongodb://mongo:27017/dsa_tracker
-      # It's recommended to move these to a separate .env file in production
-      - SECRET_KEY=${SECRET_KEY:-supersecretkey-change-me}
+      # Provide a real SECRET_KEY via your shell or .env file before startup.
+      - SECRET_KEY=${SECRET_KEY:?SECRET_KEY must be set}
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def pytest_collection_modifyitems(config, items):
 
 def build_test_app(monkeypatch, *, extra_db_targets=(), oauth_clients=None):
     test_db = mongomock.MongoClient().db
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
 
     for target in (app_module, auth_routes, *extra_db_targets):
         monkeypatch.setattr(target, "db", test_db)

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -10,6 +10,7 @@ import app.auth.routes as auth_routes
 
 def create_test_app(monkeypatch):
     test_db = mongomock.MongoClient().db
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
 
     monkeypatch.setattr(app_module, "db", test_db)
     monkeypatch.setattr(admin_routes, "db", test_db)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -38,6 +38,7 @@ def test_create_app_preserves_routes_and_blueprints(monkeypatch):
     registered_clients = []
     mongo_init_calls = []
 
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
     monkeypatch.setenv("MONGO_URI", "mongodb://localhost:27017/450_dsa")
     monkeypatch.setattr(app_module, "db", FakeDB())
     monkeypatch.setattr(
@@ -125,8 +126,9 @@ def test_create_app_preserves_routes_and_blueprints(monkeypatch):
 def test_create_app_caches_faq_page_render(monkeypatch):
     rendered_templates = []
 
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
     monkeypatch.setattr(app_module, "db", FakeDB())
-    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
     monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
@@ -153,6 +155,7 @@ def test_create_app_caches_faq_page_render(monkeypatch):
 
 
 def test_create_app_sets_secure_session_cookie_defaults(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
     monkeypatch.delenv("FLASK_ENV", raising=False)
     monkeypatch.delenv("APP_ENV", raising=False)
     monkeypatch.delenv("ENV", raising=False)
@@ -175,6 +178,7 @@ def test_create_app_sets_secure_session_cookie_defaults(monkeypatch):
 
 def test_create_app_allows_insecure_session_cookie_in_development(monkeypatch):
     monkeypatch.setenv("FLASK_ENV", "development")
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
     monkeypatch.delenv("SESSION_COOKIE_SECURE", raising=False)
     monkeypatch.setattr(app_module, "db", FakeDB())
     monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
@@ -192,6 +196,7 @@ def test_create_app_allows_insecure_session_cookie_in_development(monkeypatch):
 
 
 def test_create_app_uses_configured_rate_limit_storage(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
     monkeypatch.setenv("RATELIMIT_STORAGE_URI", "redis://localhost:6379/0")
     monkeypatch.setattr(app_module, "db", FakeDB())
     monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
@@ -209,6 +214,7 @@ def test_create_app_uses_configured_rate_limit_storage(monkeypatch):
 def test_create_app_requires_persistent_rate_limit_storage_in_production(monkeypatch):
     monkeypatch.delenv("RATELIMIT_STORAGE_URI", raising=False)
     monkeypatch.setenv("FLASK_ENV", "production")
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
     monkeypatch.setattr(app_module, "db", FakeDB())
 
     try:
@@ -221,6 +227,7 @@ def test_create_app_requires_persistent_rate_limit_storage_in_production(monkeyp
 
 def test_create_app_uses_testing_config_class(monkeypatch):
     mongo_init_calls = []
+    monkeypatch.delenv("SECRET_KEY", raising=False)
     monkeypatch.setattr(app_module, "db", FakeDB())
     monkeypatch.setattr(
         app_module.mongo,
@@ -248,6 +255,7 @@ def test_create_app_uses_testing_config_class(monkeypatch):
 
 
 def test_create_app_uses_production_config_class(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
     monkeypatch.setenv("RATELIMIT_STORAGE_URI", "redis://localhost:6379/0")
     monkeypatch.setattr(app_module, "db", FakeDB())
     monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
@@ -264,6 +272,7 @@ def test_create_app_uses_production_config_class(monkeypatch):
 
 
 def test_create_app_uses_development_config_class(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
     monkeypatch.setattr(app_module, "db", FakeDB())
     monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
     monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
@@ -280,6 +289,7 @@ def test_create_app_uses_development_config_class(monkeypatch):
 def test_create_app_allows_mongo_timeout_and_pool_overrides(monkeypatch):
     mongo_init_calls = []
 
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
     monkeypatch.setenv("MONGO_SERVER_SELECTION_TIMEOUT_MS", "1200")
     monkeypatch.setenv("MONGO_CONNECT_TIMEOUT_MS", "2300")
     monkeypatch.setenv("MONGO_MAX_POOL_SIZE", "17")
@@ -310,3 +320,37 @@ def test_create_app_allows_mongo_timeout_and_pool_overrides(monkeypatch):
             "minPoolSize": 3,
         }
     ]
+
+
+def test_create_app_requires_secret_key_outside_testing(monkeypatch):
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    monkeypatch.delenv("FLASK_ENV", raising=False)
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.delenv("ENV", raising=False)
+    monkeypatch.delenv("FLASK_DEBUG", raising=False)
+    monkeypatch.setattr(app_module, "load_dotenv", lambda: None)
+    monkeypatch.setattr(app_module, "db", FakeDB())
+
+    try:
+        app_module.create_app()
+    except RuntimeError as exc:
+        assert "SECRET_KEY" in str(exc)
+    else:
+        raise AssertionError("startup should require SECRET_KEY outside testing")
+
+
+def test_create_app_rejects_insecure_secret_key_defaults(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "supersecretkey")
+    monkeypatch.delenv("FLASK_ENV", raising=False)
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.delenv("ENV", raising=False)
+    monkeypatch.delenv("FLASK_DEBUG", raising=False)
+    monkeypatch.setattr(app_module, "load_dotenv", lambda: None)
+    monkeypatch.setattr(app_module, "db", FakeDB())
+
+    try:
+        app_module.create_app()
+    except RuntimeError as exc:
+        assert "SECRET_KEY" in str(exc)
+    else:
+        raise AssertionError("startup should reject insecure SECRET_KEY defaults")

--- a/tests/test_oauth_linking.py
+++ b/tests/test_oauth_linking.py
@@ -104,6 +104,7 @@ def make_app(monkeypatch, db_override):
     import app.auth.routes as auth_routes
     import app.extensions as ext
 
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
     monkeypatch.setattr(app_module, "db", db_override)
     monkeypatch.setattr(auth_routes, "db", db_override)
     monkeypatch.setattr(ext, "db", db_override)

--- a/tests/test_progress_card.py
+++ b/tests/test_progress_card.py
@@ -72,7 +72,8 @@ def app(mock_db):
     # Patch db globally before importing app
     with patch('app.extensions.db', mock_db), \
          patch('app.db', mock_db), \
-         patch('app.mongo'):
+         patch('app.mongo'), \
+         patch.dict('os.environ', {'SECRET_KEY': 'test-secret-key'}, clear=False):
         from app import create_app
         app = create_app()
         app.config['TESTING'] = True


### PR DESCRIPTION
## Summary
- remove the hardcoded Flask SECRET_KEY fallback and block insecure placeholder values at startup
- update docker and env setup docs so contributors must provide a real generated secret
- cover the new startup guard and patch tests that boot the app without explicit env setup

## Testing
- python3 -m pytest tests/test_app_factory.py tests/test_admin_routes.py tests/test_oauth_linking.py tests/test_progress_card.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/450dsa-issue-530/.pycache python3 -m py_compile app/config.py app/__init__.py tests/conftest.py tests/test_app_factory.py tests/test_admin_routes.py tests/test_oauth_linking.py tests/test_progress_card.py
- git diff --check