### PR TITLE
perf: lazy-load Chart.js on profile page

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -25,6 +25,13 @@ profile_bp = Blueprint("profile", __name__)
 __all__ = ["CACHE_TTL", "get_public_card_image"]
 
 
+def clear_profile_caches(user_id):
+    try:
+        cache.delete(f"card_{str(user_id)}")
+    except KeyError:
+        pass
+
+
 def build_sync_platforms_response(platform_status: dict):
     attempted = sum(1 for value in platform_status.values() if value.get("status") != "skipped")
     synced = sum(1 for value in platform_status.values() if value.get("status") == "synced")
@@ -318,7 +325,7 @@ def sync_platforms():
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
 
-    cache.delete(f"card_{str(current_user.id)}")
+    clear_profile_caches(current_user.id)
     return jsonify(build_sync_platforms_response(platform_status))
 
 
@@ -396,7 +403,7 @@ def edit_profile():
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
-        cache.delete(f"card_{str(current_user.id)}")
+        clear_profile_caches(current_user.id)
     return json_success()
 
 

--- a/static/js/chart_loader.js
+++ b/static/js/chart_loader.js
@@ -1,0 +1,77 @@
+(function () {
+    const sources = [
+        "https://cdn.jsdelivr.net/npm/chart.js",
+        "https://unpkg.com/chart.js@4/dist/chart.umd.js",
+    ];
+    let chartJsPromise = null;
+
+    function loadScript(src) {
+        return new Promise(function (resolve, reject) {
+            const existing = document.querySelector('script[data-chartjs-src="' + src + '"]');
+            if (existing) {
+                existing.addEventListener(
+                    "load",
+                    function () {
+                        resolve(window.Chart);
+                    },
+                    { once: true }
+                );
+                existing.addEventListener(
+                    "error",
+                    function () {
+                        reject(new Error("Failed to load Chart.js from " + src));
+                    },
+                    { once: true }
+                );
+                return;
+            }
+
+            const script = document.createElement("script");
+            script.src = src;
+            script.async = true;
+            script.dataset.chartjsSrc = src;
+            script.addEventListener(
+                "load",
+                function () {
+                    resolve(window.Chart);
+                },
+                { once: true }
+            );
+            script.addEventListener(
+                "error",
+                function () {
+                    script.remove();
+                    reject(new Error("Failed to load Chart.js from " + src));
+                },
+                { once: true }
+            );
+            document.head.appendChild(script);
+        });
+    }
+
+    window.loadChartJs = function () {
+        if (window.Chart) {
+            return Promise.resolve(window.Chart);
+        }
+
+        if (!chartJsPromise) {
+            chartJsPromise = sources
+                .reduce(function (promise, src) {
+                    return promise.catch(function () {
+                        return loadScript(src).then(function (ChartCtor) {
+                            if (!ChartCtor) {
+                                throw new Error("Chart.js loaded without constructor");
+                            }
+                            return ChartCtor;
+                        });
+                    });
+                }, Promise.reject(new Error("Chart.js not loaded yet")))
+                .catch(function (error) {
+                    chartJsPromise = null;
+                    throw error;
+                });
+        }
+
+        return chartJsPromise;
+    };
+})();

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% from "_macros.html" import modal_shell %}
 {% block head %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js" onerror="this.remove();var s=document.createElement('script');s.src='https://unpkg.com/chart.js@4/dist/chart.umd.js';document.head.appendChild(s);"></script>
+<script src="{{ url_for('static', filename='js/chart_loader.js') }}" defer></script>
 {% endblock %}
 {% block content %}
 <style>
@@ -734,41 +734,80 @@ for(let i=0;i<days;i++){
   heatmap.appendChild(el);
 }
 
-const ratingHistory = {{ rating_history | tojson }};
-const cumData = {{ cumulative_data | tojson }};
-const chartCanvas = document.getElementById('progressChart');
-const chartData = ratingHistory.length > 0 ? ratingHistory : cumData;
-if(chartData.length > 0 && chartCanvas && typeof Chart !== 'undefined'){
-  new Chart(chartCanvas,{
-    type:'line',
-    data:{labels:chartData.map(d=>d.x),datasets:[{data:chartData.map(d=>d.y),borderColor:'#f68b24',backgroundColor:'rgba(246,139,36,.15)',borderWidth:2,fill:true,tension:.4,pointRadius:ratingHistory.length>0?3:0,pointHoverRadius:5,pointBackgroundColor:'#f68b24'}]},
-    options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false},tooltip:{callbacks:{title:items=>items[0].label,label:ctx=>ratingHistory.length>0?'Rating: '+ctx.raw:'Solved: '+ctx.raw}}},scales:{x:{grid:{display:false},ticks:{color:'#888',maxTicksLimit:5,font:{size:10}}},y:{grid:{color:'rgba(255,255,255,.05)'},ticks:{color:'#888',font:{size:10}}}}}
-  });
-  markChartReady('progressChartShell');
-} else if(chartCanvas && typeof Chart !== 'undefined') {
-  // Show empty state inside canvas area
-  const ctx = chartCanvas.getContext('2d');
-  ctx.fillStyle = 'rgba(255,255,255,0.08)';
-  ctx.fillRect(0,0,chartCanvas.width,chartCanvas.height);
-  ctx.fillStyle = '#555';
-  ctx.font = '13px Inter, sans-serif';
-  ctx.textAlign = 'center';
-  ctx.fillText('Sync LeetCode to see rating chart', chartCanvas.width/2, chartCanvas.height/2 - 8);
-  markChartReady('progressChartShell');
+async function renderProfileCharts(){
+  const chartShellIds = ['progressChartShell', 'platformsChartShell', 'difficultyChartShell'];
+  const chartCanvas = document.getElementById('progressChart');
+  const platformsCanvas = document.getElementById('platformsChart');
+  const difficultyCanvas = document.getElementById('difficultyChart');
+
+  if(!chartCanvas && !platformsCanvas && !difficultyCanvas){
+    return;
+  }
+
+  if(typeof window.loadChartJs !== 'function'){
+    chartShellIds.forEach(markChartReady);
+    return;
+  }
+
+  let ChartCtor;
+  try{
+    ChartCtor = await window.loadChartJs();
+  }catch(e){
+    console.warn('Chart.js load failed:', e);
+    chartShellIds.forEach(markChartReady);
+    return;
+  }
+
+  const ratingHistory = {{ rating_history | tojson }};
+  const cumData = {{ cumulative_data | tojson }};
+  const chartData = ratingHistory.length > 0 ? ratingHistory : cumData;
+  if(chartData.length > 0 && chartCanvas){
+    new ChartCtor(chartCanvas,{
+      type:'line',
+      data:{labels:chartData.map(d=>d.x),datasets:[{data:chartData.map(d=>d.y),borderColor:'#f68b24',backgroundColor:'rgba(246,139,36,.15)',borderWidth:2,fill:true,tension:.4,pointRadius:ratingHistory.length>0?3:0,pointHoverRadius:5,pointBackgroundColor:'#f68b24'}]},
+      options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false},tooltip:{callbacks:{title:items=>items[0].label,label:ctx=>ratingHistory.length>0?'Rating: '+ctx.raw:'Solved: '+ctx.raw}}},scales:{x:{grid:{display:false},ticks:{color:'#888',maxTicksLimit:5,font:{size:10}}},y:{grid:{color:'rgba(255,255,255,.05)'},ticks:{color:'#888',font:{size:10}}}}}
+    });
+    markChartReady('progressChartShell');
+  } else if(chartCanvas) {
+    const ctx = chartCanvas.getContext('2d');
+    ctx.fillStyle = 'rgba(255,255,255,0.08)';
+    ctx.fillRect(0,0,chartCanvas.width,chartCanvas.height);
+    ctx.fillStyle = '#555';
+    ctx.font = '13px Inter, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('Sync LeetCode to see rating chart', chartCanvas.width/2, chartCanvas.height/2 - 8);
+    markChartReady('progressChartShell');
+  }
+
+  const pData = {{ platforms | tojson }};
+  if(platformsCanvas){
+    try{
+      new ChartCtor(platformsCanvas,{
+        type:'doughnut',
+        data:{labels:['LeetCode','GFG','Coding Ninjas','HackerRank','Other'],datasets:[{data:[pData['LeetCode'],pData['GFG'],pData['Coding Ninjas'],pData['HackerRank'],pData['Other']],backgroundColor:['#ffb800','#22c55e','#8b5cf6','#00bd6c','#6c757d'],borderWidth:0,cutout:'78%'}]},
+        options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}}}
+      });
+    }catch(e){
+      console.warn('Platform chart error:',e);
+    }
+    markChartReady('platformsChartShell');
+  }
+
+  if(difficultyCanvas){
+    try{
+      new ChartCtor(difficultyCanvas,{
+        type:'doughnut',
+        data:{labels:['Easy','Medium','Hard'],datasets:[{data:[{{lc_easy}},{{lc_medium}},{{lc_hard}}],backgroundColor:['#00b8a3','#ffc01e','#ff375f'],borderWidth:0,cutout:'78%'}]},
+        options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}}}
+      });
+    }catch(e){
+      console.warn('Difficulty chart error:',e);
+    }
+    markChartReady('difficultyChartShell');
+  }
 }
 
-const pData = {{ platforms | tojson }};
-try{new Chart(document.getElementById('platformsChart'),{
-  type:'doughnut',
-  data:{labels:['LeetCode','GFG','Coding Ninjas','HackerRank','Other'],datasets:[{data:[pData['LeetCode'],pData['GFG'],pData['Coding Ninjas'],pData['HackerRank'],pData['Other']],backgroundColor:['#ffb800','#22c55e','#8b5cf6','#00bd6c','#6c757d'],borderWidth:0,cutout:'78%'}]},
-  options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}}}
-}); markChartReady('platformsChartShell');}catch(e){console.warn('Chart.js load failed:',e); markChartReady('platformsChartShell');}
-
-try{new Chart(document.getElementById('difficultyChart'),{
-  type:'doughnut',
-  data:{labels:['Easy','Medium','Hard'],datasets:[{data:[{{lc_easy}},{{lc_medium}},{{lc_hard}}],backgroundColor:['#00b8a3','#ffc01e','#ff375f'],borderWidth:0,cutout:'78%'}]},
-  options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}}}
-}); markChartReady('difficultyChartShell');}catch(e){console.warn('Difficulty chart error:',e); markChartReady('difficultyChartShell');}
+renderProfileCharts();
 
 function openSyncModal(){document.getElementById('syncModal').classList.add('open')}
 function closeSyncModal(){document.getElementById('syncModal').classList.remove('open')}

--- a/tests/test_profile_chart_loading.py
+++ b/tests/test_profile_chart_loading.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROFILE_TEMPLATE = REPO_ROOT / "templates" / "profile.html"
+CHART_LOADER = REPO_ROOT / "static" / "js" / "chart_loader.js"
+
+
+def test_profile_template_uses_lazy_chart_loader_helper():
+    template = PROFILE_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "cdn.jsdelivr.net/npm/chart.js" not in template
+    assert "unpkg.com/chart.js@4/dist/chart.umd.js" not in template
+    assert """<script src="{{ url_for('static', filename='js/chart_loader.js') }}" defer></script>""" in template
+    assert "ChartCtor = await window.loadChartJs();" in template
+    assert "renderProfileCharts();" in template
+
+
+def test_chart_loader_keeps_cdn_fallback_and_reuses_single_promise():
+    loader = CHART_LOADER.read_text(encoding="utf-8")
+
+    assert '"https://cdn.jsdelivr.net/npm/chart.js"' in loader
+    assert '"https://unpkg.com/chart.js@4/dist/chart.umd.js"' in loader
+    assert "window.loadChartJs = function () {" in loader
+    assert "if (!chartJsPromise)" in loader
+    assert "return Promise.resolve(window.Chart);" in loader

--- a/tests/test_sync_platforms.py
+++ b/tests/test_sync_platforms.py
@@ -138,3 +138,45 @@ def test_sync_platforms_runs_selected_platform_jobs_concurrently(monkeypatch):
     assert update_fields["rating_history"] == [{"x": "2026-05-25", "y": 1800}]
     assert update_fields["lc_badges_json"] == '[{"name": "Knight"}]'
     assert update_fields["hr_badges_json"] == '[{"name": "Problem Solving", "stars": 5}]'
+
+
+def test_sync_platforms_tolerates_missing_cache_extension(monkeypatch):
+    app = create_profile_test_app()
+    captured = {}
+
+    monkeypatch.setattr(
+        profile_routes,
+        "current_user",
+        SimpleNamespace(
+            id="user-2",
+            is_authenticated=True,
+            last_sync=None,
+            leetcode_username="",
+            github_username="",
+            gfg_username="",
+            hackerrank_username="",
+            codingninjas_username="",
+            atcoder_username="",
+            reload=lambda: captured.setdefault("reloaded", True),
+        ),
+    )
+    monkeypatch.setattr(
+        profile_routes,
+        "db",
+        SimpleNamespace(user=SimpleNamespace(update_one=lambda query, update: captured.setdefault("db_update", (query, update)))),
+    )
+    monkeypatch.setattr(
+        profile_routes,
+        "run_fetch_jobs",
+        lambda fetch_jobs, max_workers=5: (
+            {"github": {"calendar": {"2026-05-25": 1}, "stats": {"issues": 0, "prs": 0, "merged_prs": 0, "commits": 2}}},
+            {},
+        ),
+    )
+
+    response = app.test_client().post("/sync_platforms", json={"github": "gh-user"})
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert payload["success"] is True
+    assert captured["db_update"][1]["$set"]["external_totals"]["GitHub_Commits"] == 2


### PR DESCRIPTION
## Summary\n- move Chart.js CDN loading into a reusable static loader helper\n- defer loading until the profile chart canvases are about to render\n- keep the jsDelivr primary source with the unpkg fallback path\n- add regression coverage so the profile template stays lazy-loaded\n\nCloses #305