### PR TITLE
Apply platform filtering before search result limit

### DIFF
--- a/app/search/service.py
+++ b/app/search/service.py
@@ -187,19 +187,18 @@ def search_dsa_questions(raw_query, limit=40, db_handle=None, filters=None, prog
         or difficulty_filter in DIFFICULTY_FILTERS
         or status_filter == "undone"
     )
-    fetch_limit = limit * 4 if post_fetch_filters else limit
+    fetch_limit = None if requested_platforms else (limit * 4 if post_fetch_filters else limit)
     if difficulty_filter in DIFFICULTY_FILTERS:
         projection["difficulty"] = 1
 
     if query_tokens:
         projection["score"] = {"$meta": "textScore"}
-        cursor = (
-            db_handle.question.find(mongo_query, projection)
-            .sort([("score", {"$meta": "textScore"})])
-            .limit(fetch_limit)
-        )
+        cursor = db_handle.question.find(mongo_query, projection).sort([("score", {"$meta": "textScore"})])
     else:
-        cursor = db_handle.question.find(mongo_query, projection).limit(fetch_limit)
+        cursor = db_handle.question.find(mongo_query, projection)
+
+    if fetch_limit is not None:
+        cursor = cursor.limit(fetch_limit)
 
     questions = list(cursor)
     topic_ids = list({question.get("topic") for question in questions if question.get("topic")})

--- a/tests/test_search_utils.py
+++ b/tests/test_search_utils.py
@@ -183,6 +183,42 @@ def test_search_filters_requested_platform_without_extra_collection_scan(monkeyp
     ]
 
 
+def test_search_applies_platform_filter_before_final_limit(monkeypatch):
+    lc_questions = [
+        {
+            "_id": f"lc-{index}",
+            "problem": f"Binary Tree Variant {index}",
+            "topic": "trees",
+            "url": f"https://leetcode.com/problems/binary-tree-variant-{index}/",
+            "url2": "",
+            "score": 100 - index,
+        }
+        for index in range(40)
+    ]
+    gfg_question = {
+        "_id": "gfg-1",
+        "problem": "Binary Tree Traversal",
+        "topic": "trees",
+        "url": "https://practice.geeksforgeeks.org/problems/binary-tree-traversal/",
+        "url2": "",
+        "score": 10,
+    }
+    fake_db = FakeDB(
+        questions=lc_questions + [gfg_question],
+        topics=[{"_id": "trees", "name": "Trees", "position": 4}],
+    )
+    monkeypatch.setattr(utils, "db", fake_db)
+
+    payload = utils.search_dsa_questions("gfg binary tree", limit=10)
+
+    assert payload["requested_platforms"] == ["GFG"]
+    assert [result["id"] for result in payload["results"]] == ["gfg-1"]
+    assert fake_db.question.cursor.limit_count is None
+    assert fake_db.topic.find_calls == [
+        ({"_id": {"$in": ["trees"]}}, {"name": 1, "position": 1})
+    ]
+
+
 def test_empty_query_returns_without_database_calls(monkeypatch):
     fake_db = FakeDB()
     monkeypatch.setattr(utils, "db", fake_db)


### PR DESCRIPTION
# Description

Fixes platform-specific DSA search results so requested platform matches are not dropped just because higher-ranked matches from other platforms appear before them.

Changes include:
- Preserved existing limited Mongo text search behavior when no platform filter is requested
- Avoided applying the Mongo cursor limit before platform filtering when a platform filter is requested
- Applied the final result limit after filtering by requested platform
- Added a regression test where a GFG match appears after many LeetCode matches and is still returned for `gfg binary tree`
- Updated sync platform test cache mock for latest upstream cache behavior

Fixes #214

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves code structure)

# How Has This Been Tested?

- [x] Tested in Local

Ran:

git diff --check  
python3 -m pytest

Result:

178 passed in 1.53s

## Checklist

- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs

178 passed in 1.53s