### PR TITLE
Validate external stats before computing C-Score

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,5 @@
 import re
+from math import isfinite
 from datetime import datetime, timezone
 
 from flask import jsonify
@@ -142,15 +143,53 @@ def platform_from_question_url(url):
     return "Other"
 
 
+def coerce_non_negative_number(value):
+    """Return a safe finite non-negative numeric value for persisted stats."""
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, (int, float)):
+        return value if isfinite(value) and value > 0 else 0
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return 0
+        try:
+            parsed = float(stripped)
+        except ValueError:
+            return 0
+        return parsed if isfinite(parsed) and parsed > 0 else 0
+    return 0
+
+
+def count_valid_external_daily_entries(external_daily_counts):
+    if not isinstance(external_daily_counts, dict):
+        return 0
+    return sum(1 for value in external_daily_counts.values() if coerce_non_negative_number(value) > 0)
+
+
+def valid_external_daily_keys(external_daily_counts):
+    if not isinstance(external_daily_counts, dict):
+        return set()
+    return {
+        day_key
+        for day_key, value in external_daily_counts.items()
+        if coerce_non_negative_number(value) > 0
+    }
+
+
 def compute_total_solved(progress, external_totals, all_questions=None):
     progress = progress or {}
     if all_questions is not None:
         solved_items = {question_id: item for question_id, item in progress.items() if item.get("done")}
         platforms = compute_user_platforms(solved_items, external_totals or {}, all_questions)
-        return sum(max(value, 0) for value in platforms.values())
+        return sum(coerce_non_negative_number(value) for value in platforms.values())
 
     dsa_done = sum(1 for progress_item in progress.values() if progress_item.get("done"))
-    external_total = sum(max(value, 0) for key, value in (external_totals or {}).items() if key in EXTERNAL_SOLVED_TOTAL_KEYS)
+    external_total = sum(
+        coerce_non_negative_number(value)
+        for key, value in (external_totals or {}).items()
+        if key in EXTERNAL_SOLVED_TOTAL_KEYS
+    )
     return max(dsa_done, external_total)
 
 
@@ -160,17 +199,25 @@ def compute_c_score(user_doc, all_questions=None):
     dsa_done = sum(1 for progress_item in progress.values() if progress_item.get("done"))
 
     ext = user_doc.get("external_totals", {})
-    lc_total = max(ext.get("LeetCode", 0), 0)
-    lc_easy = max(ext.get("LeetCode_Easy", 0), 0)
-    lc_medium = max(ext.get("LeetCode_Medium", 0), 0)
-    lc_hard = max(ext.get("LeetCode_Hard", 0), 0)
-    lc_rating = max(ext.get("LeetCode_Rating", 0), 0)
-    gfg_total = max(ext.get("GFG", 0), 0)
-    hr_total = max(ext.get("HackerRank", 0), 0)
-    cn_total = max(ext.get("Coding Ninjas", 0), 0)
-    external_total = sum(max(value, 0) for key, value in ext.items() if key in EXTERNAL_SOLVED_TOTAL_KEYS)
+    if not isinstance(ext, dict):
+        ext = {}
+    lc_total = coerce_non_negative_number(ext.get("LeetCode", 0))
+    lc_easy = coerce_non_negative_number(ext.get("LeetCode_Easy", 0))
+    lc_medium = coerce_non_negative_number(ext.get("LeetCode_Medium", 0))
+    lc_hard = coerce_non_negative_number(ext.get("LeetCode_Hard", 0))
+    lc_rating = coerce_non_negative_number(ext.get("LeetCode_Rating", 0))
+    gfg_total = coerce_non_negative_number(ext.get("GFG", 0))
+    hr_total = coerce_non_negative_number(ext.get("HackerRank", 0))
+    cn_total = coerce_non_negative_number(ext.get("Coding Ninjas", 0))
+    external_total = sum(
+        coerce_non_negative_number(value)
+        for key, value in ext.items()
+        if key in EXTERNAL_SOLVED_TOTAL_KEYS
+    )
 
     ext_daily = user_doc.get("external_daily_counts", {})
+    valid_external_days = count_valid_external_daily_entries(ext_daily)
+    ext_daily_keys = valid_external_daily_keys(ext_daily)
     extra_progress_days = set()
     for progress_item in progress.values():
         timestamp = progress_item.get("timestamp")
@@ -180,9 +227,9 @@ def compute_c_score(user_doc, all_questions=None):
             day_key = timestamp[:10]
         else:
             day_key = timestamp.date().isoformat()
-        if day_key not in ext_daily:
+        if day_key not in ext_daily_keys:
             extra_progress_days.add(day_key)
-    active_days = len(ext_daily) + len(extra_progress_days)
+    active_days = valid_external_days + len(extra_progress_days)
 
     s_dsa = min(dsa_done / 450, 1.0) * 250
     s_lc_total = min(lc_total / 500, 1.0) * 200
@@ -234,10 +281,17 @@ def merge_platform_counts(in_sheet_counts, external_totals):
         if platform in platforms:
             platforms[platform] = max(int(count or 0), 0)
 
-    ext_totals = external_totals or {}
-    platforms["LeetCode"] = max(platforms["LeetCode"], ext_totals.get("LeetCode", 0), 0)
-    platforms["GFG"] = max(platforms["GFG"], ext_totals.get("GFG", 0), 0)
-    platforms["Coding Ninjas"] = max(platforms["Coding Ninjas"], ext_totals.get("Coding Ninjas", 0), 0)
-    platforms["HackerRank"] = max(platforms["HackerRank"], ext_totals.get("HackerRank", 0), 0)
-    platforms["AtCoder"] = max(platforms["AtCoder"], ext_totals.get("AtCoder", 0), 0)
+    ext_totals = external_totals if isinstance(external_totals, dict) else {}
+    platforms["LeetCode"] = max(platforms["LeetCode"], coerce_non_negative_number(ext_totals.get("LeetCode", 0)))
+    platforms["GFG"] = max(platforms["GFG"], coerce_non_negative_number(ext_totals.get("GFG", 0)))
+    platforms["Coding Ninjas"] = max(
+        platforms["Coding Ninjas"],
+        coerce_non_negative_number(ext_totals.get("Coding Ninjas", 0)),
+    )
+    platforms["HackerRank"] = max(
+        platforms["HackerRank"],
+        coerce_non_negative_number(ext_totals.get("HackerRank", 0)),
+    )
+    platforms["AtCoder"] = max(platforms["AtCoder"], coerce_non_negative_number(ext_totals.get("AtCoder", 0)))
+
     return platforms

--- a/tests/test_compute_c_score.py
+++ b/tests/test_compute_c_score.py
@@ -2,6 +2,7 @@ from app.utils import (
     compute_c_score,
     compute_in_sheet_platform_counts,
     compute_total_solved,
+    compute_user_platforms,
     merge_platform_counts,
 )
 
@@ -174,6 +175,152 @@ def test_merge_platform_counts_keeps_external_totals_as_floor():
 
     assert counts["LeetCode"] == 10
     assert counts["GFG"] == 4
+
+
+def test_numeric_string_external_totals_are_coerced_safely():
+    user = make_user(
+        external_totals={
+            "LeetCode": "12",
+            "LeetCode_Easy": "5",
+            "LeetCode_Medium": "4",
+            "LeetCode_Hard": "3",
+            "LeetCode_Rating": "1500",
+            "GFG": "7",
+            "HackerRank": "2.5",
+            "Coding Ninjas": "1",
+        }
+    )
+
+    result = compute_c_score(user)
+
+    assert result["lc_total"] == 12.0
+    assert result["lc_easy"] == 5.0
+    assert result["lc_medium"] == 4.0
+    assert result["lc_hard"] == 3.0
+    assert result["lc_rating"] == 1500.0
+    assert result["gfg_total"] == 7.0
+    assert result["hr_total"] == 2.5
+    assert result["cn_total"] == 1.0
+    assert result["c_score"] > 0
+
+
+def test_invalid_external_total_types_are_ignored_as_zero():
+    user = make_user(
+        external_totals={
+            "LeetCode": {},
+            "LeetCode_Easy": [],
+            "LeetCode_Medium": None,
+            "LeetCode_Hard": "not-a-number",
+            "LeetCode_Rating": True,
+            "GFG": False,
+            "HackerRank": object(),
+            "Coding Ninjas": "",
+        }
+    )
+
+    result = compute_c_score(user)
+
+    assert result["lc_total"] == 0
+    assert result["lc_easy"] == 0
+    assert result["lc_medium"] == 0
+    assert result["lc_hard"] == 0
+    assert result["lc_rating"] == 0
+    assert result["gfg_total"] == 0
+    assert result["hr_total"] == 0
+    assert result["cn_total"] == 0
+    assert result["c_score"] == 0
+
+
+def test_negative_external_values_clamp_to_zero():
+    user = make_user(
+        external_totals={
+            "LeetCode": "-12",
+            "LeetCode_Easy": -5,
+            "LeetCode_Medium": "-4.5",
+            "LeetCode_Hard": -3,
+            "LeetCode_Rating": "-1500",
+            "GFG": -7,
+        }
+    )
+
+    result = compute_c_score(user)
+
+    assert result["lc_total"] == 0
+    assert result["lc_easy"] == 0
+    assert result["lc_medium"] == 0
+    assert result["lc_hard"] == 0
+    assert result["lc_rating"] == 0
+    assert result["gfg_total"] == 0
+
+
+def test_malformed_external_daily_counts_do_not_crash_and_ignore_invalid_values():
+    progress = {
+        "q1": {"done": True, "timestamp": "2024-01-03T10:00:00"},
+        "q2": {"done": True, "timestamp": "2024-01-02T11:00:00"},
+    }
+    user = make_user(
+        progress=progress,
+        external_daily_counts={
+            "2024-01-01": "2",
+            "2024-01-02": 0,
+            "2024-01-03": -1,
+            "2024-01-04": None,
+            "2024-01-05": [],
+            "2024-01-06": "bad",
+            "2024-01-07": True,
+        },
+    )
+
+    result = compute_c_score(user)
+
+    assert result["active_days"] == 3
+
+
+def test_non_dict_external_daily_counts_do_not_crash():
+    user = make_user(external_daily_counts=["bad", "shape"])
+
+    result = compute_c_score(user)
+
+    assert result["active_days"] == 0
+
+
+def test_compute_total_solved_handles_malformed_external_totals():
+    total = compute_total_solved(
+        {},
+        {
+            "LeetCode": "12",
+            "GFG": {},
+            "HackerRank": None,
+            "Coding Ninjas": "-4",
+            "AtCoder": "3.5",
+        },
+    )
+
+    assert total == 15.5
+
+
+def test_compute_user_platforms_handles_malformed_external_totals():
+    platforms = compute_user_platforms(
+        {},
+        {
+            "LeetCode": "12",
+            "GFG": {},
+            "Coding Ninjas": "-4",
+            "HackerRank": "2.5",
+            "AtCoder": [],
+        },
+        [],
+    )
+
+    assert platforms == {
+        "LeetCode": 12.0,
+        "GFG": 0,
+        "Coding Ninjas": 0,
+        "HackerRank": 2.5,
+        "AtCoder": 0,
+        "Other": 0,
+    }
+
 
 
 # --- Return structure ---


### PR DESCRIPTION
# Description

Adds safe numeric coercion for persisted external platform stats before C-Score and total solved calculations.

Changes include:
- Added a helper to safely coerce non-negative numeric stat values
- Accepted valid numeric strings like `"12"` and `"12.5"`
- Treated invalid strings, objects, arrays, booleans, null, NaN/inf as `0`
- Clamped negative values to `0`
- Hardened `compute_c_score()`, `compute_total_solved()`, and `compute_user_platforms()`
- Safely handled malformed `external_daily_counts`
- Added tests for malformed external totals and daily counts

Fixes #234

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Tested in Local

Ran:

git diff --check  
python3 -m pytest

Result:

184 passed in 1.53s

## Checklist

- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs

184 passed in 1.53s