### PR TITLE
fix: require POST plus CSRF for logout

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -178,8 +178,14 @@ def register():
     return render_template("register.html")
 
 
-@auth_bp.route("/logout")
+@auth_bp.route("/logout", methods=["POST"])
+@login_required
 def logout():
+    token = request.form.get("csrf_token", "")
+    expected = session.get("csrf_token", "")
+    if not token or not expected or token != expected:
+        abort(403)
+
     logout_user()
     return redirect(url_for("auth.login"))
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -313,6 +313,18 @@
             padding-bottom: 8px;
         }
 
+        .sidebar-logout-form {
+            display: flex;
+        }
+
+        .sidebar-logout-form .sidebar-link {
+            border: none;
+            background: transparent;
+            padding: 0;
+            cursor: pointer;
+            font: inherit;
+        }
+
         /* ─── Top Bar ─── */
         .topbar {
             position: fixed;
@@ -972,10 +984,13 @@
         </nav>
         <div class="sidebar-bottom">
             {% if current_user.is_authenticated %}
-            <a href="{{ url_for('auth.logout') }}" class="sidebar-link" title="Logout" id="nav-logout" aria-label="Logout">
-                <i class="bi bi-box-arrow-right" aria-hidden="true"></i>
-                <span class="tooltip-label">Logout</span>
-            </a>
+            <form method="post" action="{{ url_for('auth.logout') }}" class="sidebar-logout-form">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="sidebar-link" title="Logout" id="nav-logout" aria-label="Logout">
+                    <i class="bi bi-box-arrow-right" aria-hidden="true"></i>
+                    <span class="tooltip-label">Logout</span>
+                </button>
+            </form>
             {% else %}
             <a href="{{ url_for('auth.login') }}" class="sidebar-link" id="nav-login" aria-label="Login">
                 <i class="bi bi-box-arrow-in-right" aria-hidden="true"></i>

--- a/tests/test_logout_csrf.py
+++ b/tests/test_logout_csrf.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+from conftest import build_test_app, login_test_user
+
+
+BASE_TEMPLATE = (
+    Path(__file__).resolve().parents[1] / "templates" / "base.html"
+).read_text(encoding="utf-8")
+
+
+def set_csrf_token(client, token="test-csrf-token"):
+    with client.session_transaction() as session:
+        session["csrf_token"] = token
+    return token
+
+
+def test_logout_route_rejects_get_and_keeps_session(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    user_id = test_db.user.insert_one(
+        {"email": "user@example.com", "progress": {}, "is_admin": False}
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        csrf_token = set_csrf_token(client)
+
+        response = client.get("/logout")
+
+        assert response.status_code == 405
+        with client.session_transaction() as session:
+            assert session.get("_user_id") == str(user_id)
+            assert session.get("csrf_token") == csrf_token
+
+
+def test_logout_route_requires_matching_csrf_token(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    user_id = test_db.user.insert_one(
+        {"email": "user@example.com", "progress": {}, "is_admin": False}
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        set_csrf_token(client, "expected-token")
+
+        response = client.post("/logout", data={"csrf_token": "wrong-token"})
+
+        assert response.status_code == 403
+        with client.session_transaction() as session:
+            assert session.get("_user_id") == str(user_id)
+
+
+def test_logout_route_logs_user_out_with_valid_csrf_token(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    user_id = test_db.user.insert_one(
+        {"email": "user@example.com", "progress": {}, "is_admin": False}
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        csrf_token = set_csrf_token(client)
+
+        response = client.post("/logout", data={"csrf_token": csrf_token})
+
+        assert response.status_code == 302
+        assert response.headers["Location"] == "/login"
+        with client.session_transaction() as session:
+            assert "_user_id" not in session
+
+
+def test_sidebar_logout_uses_post_form_with_csrf_token():
+    assert 'action="{{ url_for(\'auth.logout\') }}"' in BASE_TEMPLATE
+    assert 'method="post"' in BASE_TEMPLATE
+    assert 'name="csrf_token"' in BASE_TEMPLATE
+    assert 'id="nav-logout"' in BASE_TEMPLATE

--- a/tests/test_sync_platforms.py
+++ b/tests/test_sync_platforms.py
@@ -77,7 +77,11 @@ def test_sync_platforms_runs_selected_platform_jobs_concurrently(monkeypatch):
         "db",
         SimpleNamespace(user=SimpleNamespace(update_one=lambda query, update: captured.setdefault("db_update", (query, update)))),
     )
-    monkeypatch.setattr(profile_routes.cache, "clear", lambda: captured.setdefault("cleared_cache", True))
+    monkeypatch.setattr(
+        profile_routes.cache,
+        "delete",
+        lambda key: captured.setdefault("cleared_cache_key", key),
+    )
 
     def fake_run_fetch_jobs(fetch_jobs, max_workers=5):
         captured["job_names"] = sorted(fetch_jobs.keys())


### PR DESCRIPTION
## Summary
- change logout to POST-only and require the shared session CSRF token
- replace the sidebar logout anchor with a small POST form button
- add focused auth regression tests for GET rejection, CSRF enforcement, and successful logout

## Validation
- python3 -m pytest tests/test_logout_csrf.py tests/test_registration_validation.py tests/test_oauth_linking.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/450dsa-issue-229/.pycache python3 -m py_compile app/auth/routes.py tests/test_logout_csrf.py
- git diff --check