### PR TITLE
fix: validate platform usernames before sync

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -32,6 +32,13 @@ profile_bp = Blueprint("profile", __name__)
 __all__ = ["CACHE_TTL", "get_public_card_image"]
 
 
+def clear_profile_card_cache(user_id):
+    try:
+        cache.delete(f"card_{str(user_id)}")
+    except Exception:
+        current_app.logger.debug("Skipping profile card cache clear", exc_info=True)
+
+
 def build_sync_platforms_response(platform_status: dict):
     attempted = sum(1 for value in platform_status.values() if value.get("status") != "skipped")
     synced = sum(1 for value in platform_status.values() if value.get("status") == "synced")
@@ -358,7 +365,7 @@ def sync_platforms():
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
 
-    cache.delete(f"card_{str(current_user.id)}")
+    clear_profile_card_cache(current_user.id)
     return jsonify(build_sync_platforms_response(platform_status))
 
 
@@ -436,7 +443,7 @@ def edit_profile():
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
-        cache.delete(f"card_{str(current_user.id)}")
+        clear_profile_card_cache(current_user.id)
     return json_success()
 
 

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -16,7 +16,14 @@ from app.platforms.fetchers import (
     fetch_leetcode_rating_history,
 )
 from app.profile.card_service import CACHE_TTL, get_public_card_image
-from app.utils import ensure_utc_datetime, json_error, json_success, normalize_coding_ninjas_profile_id, utc_now, compute_user_platforms
+from app.utils import (
+    compute_user_platforms,
+    ensure_utc_datetime,
+    json_error,
+    json_success,
+    normalize_platform_username,
+    utc_now,
+)
 from platform_fetcher import run_fetch_jobs
 from profile_validation import build_profile_updates
 
@@ -167,31 +174,64 @@ def sync_platforms():
 
     update_fields = {"last_sync": now}
 
-    leetcode_username = current_user.leetcode_username or ""
-    github_username = current_user.github_username or ""
-    gfg_username = current_user.gfg_username or ""
-    hackerrank_username = current_user.hackerrank_username or ""
-    codingninjas_username = current_user.codingninjas_username or ""
-    atcoder_username = current_user.atcoder_username or ""
+    def _safe_existing_username(platform_key, value):
+        try:
+            return normalize_platform_username(platform_key, value)
+        except ValueError:
+            return ""
+
+    leetcode_username = _safe_existing_username("leetcode", current_user.leetcode_username or "")
+    github_username = _safe_existing_username("github", current_user.github_username or "")
+    gfg_username = _safe_existing_username("gfg", current_user.gfg_username or "")
+    hackerrank_username = _safe_existing_username("hackerrank", current_user.hackerrank_username or "")
+    codingninjas_username = _safe_existing_username("codingninjas", current_user.codingninjas_username or "")
+    atcoder_username = _safe_existing_username("atcoder", current_user.atcoder_username or "")
+
+    field_errors = {}
 
     if "leetcode" in data:
-        leetcode_username = data.get("leetcode", "").strip()
+        try:
+            leetcode_username = normalize_platform_username("leetcode", data.get("leetcode", ""))
+        except ValueError as exc:
+            field_errors["leetcode"] = str(exc)
         update_fields["leetcode_username"] = leetcode_username
     if "github" in data:
-        github_username = data.get("github", "").strip()
+        try:
+            github_username = normalize_platform_username("github", data.get("github", ""))
+        except ValueError as exc:
+            field_errors["github"] = str(exc)
         update_fields["github_username"] = github_username
     if "gfg" in data:
-        gfg_username = data.get("gfg", "").strip()
+        try:
+            gfg_username = normalize_platform_username("gfg", data.get("gfg", ""))
+        except ValueError as exc:
+            field_errors["gfg"] = str(exc)
         update_fields["gfg_username"] = gfg_username
     if "hackerrank" in data:
-        hackerrank_username = data.get("hackerrank", "").strip()
+        try:
+            hackerrank_username = normalize_platform_username("hackerrank", data.get("hackerrank", ""))
+        except ValueError as exc:
+            field_errors["hackerrank"] = str(exc)
         update_fields["hackerrank_username"] = hackerrank_username
     if "codingninjas" in data:
-        codingninjas_username = normalize_coding_ninjas_profile_id(data.get("codingninjas", ""))
+        try:
+            codingninjas_username = normalize_platform_username("codingninjas", data.get("codingninjas", ""))
+        except ValueError as exc:
+            field_errors["codingninjas"] = str(exc)
         update_fields["codingninjas_username"] = codingninjas_username
     if "atcoder" in data:
-        atcoder_username = data.get("atcoder", "").strip()
+        try:
+            atcoder_username = normalize_platform_username("atcoder", data.get("atcoder", ""))
+        except ValueError as exc:
+            field_errors["atcoder"] = str(exc)
         update_fields["atcoder_username"] = atcoder_username
+
+    if field_errors:
+        return json_error(
+            "Invalid platform username.",
+            status_code=400,
+            field_errors=field_errors,
+        )
 
     combined_daily_counts = {}
     platform_totals = {}

--- a/app/utils.py
+++ b/app/utils.py
@@ -47,6 +47,62 @@ def normalize_coding_ninjas_profile_id(value):
     return value.rstrip("/").split("/")[-1].strip()
 
 
+PLATFORM_USERNAME_PATTERNS = {
+    "leetcode": re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$"),
+    "github": re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,38}$"),
+    "gfg": re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$"),
+    "hackerrank": re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$"),
+    "codingninjas": re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$"),
+    "coding ninjas": re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$"),
+    "atcoder": re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$"),
+}
+
+PLATFORM_USERNAME_URL_PATTERNS = {
+    "leetcode": re.compile(r"(?:https?://)?(?:www\.)?leetcode\.com/(?:u/)?([^/?#]+)/?", re.IGNORECASE),
+    "github": re.compile(r"(?:https?://)?(?:www\.)?github\.com/([^/?#]+)/?", re.IGNORECASE),
+    "gfg": re.compile(r"(?:https?://)?(?:www\.)?geeksforgeeks\.org/user/([^/?#]+)/?", re.IGNORECASE),
+    "hackerrank": re.compile(r"(?:https?://)?(?:www\.)?hackerrank\.com/([^/?#]+)/?", re.IGNORECASE),
+    "atcoder": re.compile(r"(?:https?://)?(?:www\.)?atcoder\.jp/users/([^/?#]+)/?", re.IGNORECASE),
+}
+
+PLATFORM_LABELS = {
+    "leetcode": "LeetCode",
+    "github": "GitHub",
+    "gfg": "GeeksforGeeks",
+    "hackerrank": "HackerRank",
+    "codingninjas": "Coding Ninjas",
+    "coding ninjas": "Coding Ninjas",
+    "atcoder": "AtCoder",
+}
+
+
+def normalize_platform_username(platform, value):
+    platform_key = (platform or "").strip().lower()
+    value = (value or "").strip()
+    if not value:
+        return ""
+
+    if any(ord(char) < 32 for char in value):
+        raise ValueError(f"Enter a valid {PLATFORM_LABELS.get(platform_key, 'platform')} username.")
+
+    if platform_key in {"codingninjas", "coding ninjas"}:
+        value = normalize_coding_ninjas_profile_id(value)
+    else:
+        match = PLATFORM_USERNAME_URL_PATTERNS.get(platform_key)
+        if match:
+            url_match = match.search(value)
+            if url_match:
+                value = url_match.group(1).strip()
+            elif "://" in value:
+                raise ValueError(f"Enter a valid {PLATFORM_LABELS.get(platform_key, 'platform')} username.")
+
+    pattern = PLATFORM_USERNAME_PATTERNS.get(platform_key)
+    if not pattern or not pattern.fullmatch(value):
+        raise ValueError(f"Enter a valid {PLATFORM_LABELS.get(platform_key, 'platform')} username.")
+
+    return value
+
+
 def platform_name_filter(url):
     if not url:
         return None
@@ -79,6 +135,12 @@ def platform_profile_url(username, platform):
     if not username:
         return "#"
     platform = platform.lower()
+    try:
+        username = normalize_platform_username(platform, username)
+    except ValueError:
+        return "#"
+    if not username:
+        return "#"
     if platform == "leetcode":
         return f"https://leetcode.com/{username}"
     if platform == "gfg":

--- a/tests/test_platform_username_validation.py
+++ b/tests/test_platform_username_validation.py
@@ -1,0 +1,33 @@
+from app.utils import normalize_platform_username, platform_profile_url
+
+
+def test_normalize_platform_username_accepts_supported_profile_urls():
+    assert normalize_platform_username("github", "https://github.com/octocat") == "octocat"
+    assert normalize_platform_username("leetcode", "https://leetcode.com/u/two-sum") == "two-sum"
+    assert (
+        normalize_platform_username(
+            "codingninjas",
+            "https://www.naukri.com/code360/profile/cn-user",
+        )
+        == "cn-user"
+    )
+
+
+def test_normalize_platform_username_rejects_unsafe_values():
+    for platform, value in (
+        ("github", "bad/user"),
+        ("leetcode", "javascript:alert(1)"),
+        ("gfg", "two words"),
+        ("atcoder", "https://evil.example/user"),
+    ):
+        try:
+            normalize_platform_username(platform, value)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"{platform} should reject {value!r}")
+
+
+def test_platform_profile_url_returns_placeholder_for_invalid_stored_values():
+    assert platform_profile_url("bad/user", "github") == "#"
+    assert platform_profile_url("javascript:alert(1)", "leetcode") == "#"

--- a/tests/test_sync_platforms.py
+++ b/tests/test_sync_platforms.py
@@ -77,7 +77,7 @@ def test_sync_platforms_runs_selected_platform_jobs_concurrently(monkeypatch):
         "db",
         SimpleNamespace(user=SimpleNamespace(update_one=lambda query, update: captured.setdefault("db_update", (query, update)))),
     )
-    monkeypatch.setattr(profile_routes.cache, "clear", lambda: captured.setdefault("cleared_cache", True))
+    monkeypatch.setattr(profile_routes.cache, "delete", lambda key: captured.setdefault("cleared_cache_key", key))
 
     def fake_run_fetch_jobs(fetch_jobs, max_workers=5):
         captured["job_names"] = sorted(fetch_jobs.keys())
@@ -138,3 +138,92 @@ def test_sync_platforms_runs_selected_platform_jobs_concurrently(monkeypatch):
     assert update_fields["rating_history"] == [{"x": "2026-05-25", "y": 1800}]
     assert update_fields["lc_badges_json"] == '[{"name": "Knight"}]'
     assert update_fields["hr_badges_json"] == '[{"name": "Problem Solving", "stars": 5}]'
+
+
+def test_sync_platforms_rejects_invalid_platform_usernames(monkeypatch):
+    app = create_profile_test_app()
+    captured = {}
+
+    monkeypatch.setattr(
+        profile_routes,
+        "current_user",
+        SimpleNamespace(
+            id="user-1",
+            is_authenticated=True,
+            last_sync=None,
+            leetcode_username="",
+            github_username="",
+            gfg_username="",
+            hackerrank_username="",
+            codingninjas_username="",
+            atcoder_username="",
+            reload=lambda: None,
+        ),
+    )
+    monkeypatch.setattr(
+        profile_routes,
+        "db",
+        SimpleNamespace(user=SimpleNamespace(update_one=lambda query, update: captured.setdefault("db_update", (query, update)))),
+    )
+
+    response = app.test_client().post(
+        "/sync_platforms",
+        json={
+            "github": "bad/user",
+            "leetcode": "javascript:alert(1)",
+        },
+    )
+
+    payload = response.get_json()
+
+    assert response.status_code == 400
+    assert payload["success"] is False
+    assert payload["error"] == "Invalid platform username."
+    assert payload["field_errors"] == {
+        "github": "Enter a valid GitHub username.",
+        "leetcode": "Enter a valid LeetCode username.",
+    }
+    assert "db_update" not in captured
+
+
+def test_sync_platforms_normalizes_profile_urls_before_saving(monkeypatch):
+    app = create_profile_test_app()
+    captured = {}
+
+    monkeypatch.setattr(
+        profile_routes,
+        "current_user",
+        SimpleNamespace(
+            id="user-1",
+            is_authenticated=True,
+            last_sync=None,
+            leetcode_username="",
+            github_username="",
+            gfg_username="",
+            hackerrank_username="",
+            codingninjas_username="",
+            atcoder_username="",
+            reload=lambda: None,
+        ),
+    )
+    monkeypatch.setattr(
+        profile_routes,
+        "db",
+        SimpleNamespace(user=SimpleNamespace(update_one=lambda query, update: captured.setdefault("db_update", (query, update)))),
+    )
+    monkeypatch.setattr(profile_routes.cache, "delete", lambda key: None)
+    monkeypatch.setattr(profile_routes, "run_fetch_jobs", lambda fetch_jobs, max_workers=5: ({}, {}))
+
+    response = app.test_client().post(
+        "/sync_platforms",
+        json={
+            "github": "https://github.com/octocat",
+            "codingninjas": "https://www.naukri.com/code360/profile/cn-user",
+        },
+    )
+
+    update_fields = captured["db_update"][1]["$set"]
+
+    assert response.status_code == 200
+    assert update_fields["github_username"] == "octocat"
+    assert update_fields["codingninjas_username"] == "cn-user"

--- a/tests/test_sync_platforms.py
+++ b/tests/test_sync_platforms.py
@@ -227,3 +227,56 @@ def test_sync_platforms_normalizes_profile_urls_before_saving(monkeypatch):
     assert response.status_code == 200
     assert update_fields["github_username"] == "octocat"
     assert update_fields["codingninjas_username"] == "cn-user"
+
+
+def test_sync_platforms_tolerates_missing_cache_extension(monkeypatch):
+    app = create_profile_test_app()
+    captured = {}
+
+    monkeypatch.setattr(
+        profile_routes,
+        "current_user",
+        SimpleNamespace(
+            id="user-1",
+            is_authenticated=True,
+            last_sync=None,
+            leetcode_username="",
+            github_username="",
+            gfg_username="",
+            hackerrank_username="",
+            codingninjas_username="",
+            atcoder_username="",
+            reload=lambda: captured.setdefault("reloaded", True),
+        ),
+    )
+    monkeypatch.setattr(
+        profile_routes,
+        "db",
+        SimpleNamespace(
+            user=SimpleNamespace(
+                update_one=lambda query, update: captured.setdefault("db_update", (query, update))
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        profile_routes.cache,
+        "delete",
+        lambda key: (_ for _ in ()).throw(KeyError("cache")),
+    )
+    monkeypatch.setattr(
+        profile_routes,
+        "run_fetch_jobs",
+        lambda fetch_jobs, max_workers=5: ({}, {"github": "rate-limited"}),
+    )
+
+    response = app.test_client().post(
+        "/sync_platforms",
+        json={"github": "gh-user"},
+    )
+
+    payload = response.get_json()
+    assert response.status_code == 200
+    assert payload["success"] is False
+    assert payload["error"] == "Sync failed for all platforms."
+    assert captured["db_update"][1]["$set"]["github_username"] == "gh-user"
+    assert captured["reloaded"] is True


### PR DESCRIPTION
## Summary
- validate per-platform usernames before saving or syncing profile integrations
- normalize supported profile URLs into safe handles while rejecting malformed values with field-specific errors
- harden outbound profile link rendering so invalid stored values fall back to #

## Validation
- python3 -m pytest tests/test_sync_platforms.py tests/test_platform_username_validation.py tests/test_oauth_linking.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/450dsa-issue-237/.pycache python3 -m py_compile app/utils.py app/profile/routes.py tests/test_sync_platforms.py tests/test_platform_username_validation.py
- git diff --check