### PR TITLE
perf: configure MongoDB client timeouts and pool settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,12 @@ SECRET_KEY=replace-this-with-a-real-secret
 
 # MongoDB (Future/Alternative Database)
 MONGO_URI=mongodb://localhost:27017/dsa_tracker
+MONGO_SERVER_SELECTION_TIMEOUT_MS=5000
+MONGO_CONNECT_TIMEOUT_MS=5000
+MONGO_SOCKET_TIMEOUT_MS=10000
+MONGO_MAX_POOL_SIZE=20
+MONGO_MIN_POOL_SIZE=0
+MONGO_WAIT_QUEUE_TIMEOUT_MS=5000
 
 # Rate limiting
 # Use memory:// for local development. Use a shared backend in production, for example:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,11 +28,15 @@ def _configure_rate_limit_storage(app, config_class):
 
 
 def _mongo_client_options(app):
+    max_pool_size = max(app.config["MONGO_MAX_POOL_SIZE"], 1)
+    min_pool_size = min(max(app.config["MONGO_MIN_POOL_SIZE"], 0), max_pool_size)
     return {
         "serverSelectionTimeoutMS": app.config["MONGO_SERVER_SELECTION_TIMEOUT_MS"],
         "connectTimeoutMS": app.config["MONGO_CONNECT_TIMEOUT_MS"],
-        "maxPoolSize": app.config["MONGO_MAX_POOL_SIZE"],
-        "minPoolSize": app.config["MONGO_MIN_POOL_SIZE"],
+        "socketTimeoutMS": app.config["MONGO_SOCKET_TIMEOUT_MS"],
+        "waitQueueTimeoutMS": app.config["MONGO_WAIT_QUEUE_TIMEOUT_MS"],
+        "maxPoolSize": max_pool_size,
+        "minPoolSize": min_pool_size,
     }
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -8,14 +8,17 @@ def env_flag(name, default=False):
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def env_int(name, default):
+def env_int(name, default, minimum=None):
     value = os.environ.get(name)
     if value is None:
         return default
     try:
-        return int(value.strip())
+        parsed = int(value.strip())
     except (TypeError, ValueError):
         return default
+    if minimum is not None and parsed < minimum:
+        return minimum
+    return parsed
 
 
 def current_environment_name():
@@ -33,8 +36,10 @@ class BaseConfig:
     MONGO_URI = "mongodb://localhost:27017/450_dsa"
     MONGO_SERVER_SELECTION_TIMEOUT_MS = 5000
     MONGO_CONNECT_TIMEOUT_MS = 5000
+    MONGO_SOCKET_TIMEOUT_MS = 10000
     MONGO_MAX_POOL_SIZE = 20
     MONGO_MIN_POOL_SIZE = 0
+    MONGO_WAIT_QUEUE_TIMEOUT_MS = 5000
     CACHE_TYPE = "SimpleCache"
     CACHE_DEFAULT_TIMEOUT = 300
     SESSION_COOKIE_HTTPONLY = True
@@ -74,18 +79,32 @@ class BaseConfig:
         app.config["MONGO_SERVER_SELECTION_TIMEOUT_MS"] = env_int(
             "MONGO_SERVER_SELECTION_TIMEOUT_MS",
             cls.MONGO_SERVER_SELECTION_TIMEOUT_MS,
+            minimum=1,
         )
         app.config["MONGO_CONNECT_TIMEOUT_MS"] = env_int(
             "MONGO_CONNECT_TIMEOUT_MS",
             cls.MONGO_CONNECT_TIMEOUT_MS,
+            minimum=1,
+        )
+        app.config["MONGO_SOCKET_TIMEOUT_MS"] = env_int(
+            "MONGO_SOCKET_TIMEOUT_MS",
+            cls.MONGO_SOCKET_TIMEOUT_MS,
+            minimum=1,
         )
         app.config["MONGO_MAX_POOL_SIZE"] = env_int(
             "MONGO_MAX_POOL_SIZE",
             cls.MONGO_MAX_POOL_SIZE,
+            minimum=1,
         )
         app.config["MONGO_MIN_POOL_SIZE"] = env_int(
             "MONGO_MIN_POOL_SIZE",
             cls.MONGO_MIN_POOL_SIZE,
+            minimum=0,
+        )
+        app.config["MONGO_WAIT_QUEUE_TIMEOUT_MS"] = env_int(
+            "MONGO_WAIT_QUEUE_TIMEOUT_MS",
+            cls.MONGO_WAIT_QUEUE_TIMEOUT_MS,
+            minimum=1,
         )
         app.config["SESSION_COOKIE_SAMESITE"] = os.environ.get(
             "SESSION_COOKIE_SAMESITE",

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -25,6 +25,13 @@ profile_bp = Blueprint("profile", __name__)
 __all__ = ["CACHE_TTL", "get_public_card_image"]
 
 
+def invalidate_public_card_cache(user_id):
+    try:
+        cache.delete(f"card_{str(user_id)}")
+    except KeyError:
+        return
+
+
 def build_sync_platforms_response(platform_status: dict):
     attempted = sum(1 for value in platform_status.values() if value.get("status") != "skipped")
     synced = sum(1 for value in platform_status.values() if value.get("status") == "synced")
@@ -318,7 +325,7 @@ def sync_platforms():
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
 
-    cache.delete(f"card_{str(current_user.id)}")
+    invalidate_public_card_cache(current_user.id)
     return jsonify(build_sync_platforms_response(platform_status))
 
 
@@ -396,7 +403,7 @@ def edit_profile():
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
-        cache.delete(f"card_{str(current_user.id)}")
+        invalidate_public_card_cache(current_user.id)
     return json_success()
 
 

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -60,13 +60,17 @@ def test_create_app_preserves_routes_and_blueprints(monkeypatch):
     assert flask_app.config["MONGO_URI"] == "mongodb://localhost:27017/450_dsa"
     assert flask_app.config["MONGO_SERVER_SELECTION_TIMEOUT_MS"] == 5000
     assert flask_app.config["MONGO_CONNECT_TIMEOUT_MS"] == 5000
+    assert flask_app.config["MONGO_SOCKET_TIMEOUT_MS"] == 10000
     assert flask_app.config["MONGO_MAX_POOL_SIZE"] == 20
     assert flask_app.config["MONGO_MIN_POOL_SIZE"] == 0
+    assert flask_app.config["MONGO_WAIT_QUEUE_TIMEOUT_MS"] == 5000
     assert flask_app.config["RATELIMIT_STORAGE_URI"] == "memory://"
     assert mongo_init_calls == [
         {
             "serverSelectionTimeoutMS": 5000,
             "connectTimeoutMS": 5000,
+            "socketTimeoutMS": 10000,
+            "waitQueueTimeoutMS": 5000,
             "maxPoolSize": 20,
             "minPoolSize": 0,
         }
@@ -211,6 +215,72 @@ def test_create_app_uses_configured_rate_limit_storage(monkeypatch):
     assert flask_app.config["RATELIMIT_STORAGE_URI"] == "redis://localhost:6379/0"
 
 
+def test_create_app_uses_configured_mongo_timeouts_and_pool_settings(monkeypatch):
+    mongo_init_calls = []
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("MONGO_SERVER_SELECTION_TIMEOUT_MS", "2500")
+    monkeypatch.setenv("MONGO_CONNECT_TIMEOUT_MS", "1800")
+    monkeypatch.setenv("MONGO_SOCKET_TIMEOUT_MS", "9000")
+    monkeypatch.setenv("MONGO_MAX_POOL_SIZE", "40")
+    monkeypatch.setenv("MONGO_MIN_POOL_SIZE", "6")
+    monkeypatch.setenv("MONGO_WAIT_QUEUE_TIMEOUT_MS", "3200")
+    monkeypatch.setattr(app_module, "db", FakeDB())
+    monkeypatch.setattr(
+        app_module.mongo,
+        "init_app",
+        lambda flask_app, **kwargs: mongo_init_calls.append(kwargs),
+    )
+    monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.limiter, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
+
+    flask_app = app_module.create_app()
+
+    assert flask_app.config["MONGO_SERVER_SELECTION_TIMEOUT_MS"] == 2500
+    assert flask_app.config["MONGO_CONNECT_TIMEOUT_MS"] == 1800
+    assert flask_app.config["MONGO_SOCKET_TIMEOUT_MS"] == 9000
+    assert flask_app.config["MONGO_MAX_POOL_SIZE"] == 40
+    assert flask_app.config["MONGO_MIN_POOL_SIZE"] == 6
+    assert flask_app.config["MONGO_WAIT_QUEUE_TIMEOUT_MS"] == 3200
+    assert mongo_init_calls == [
+        {
+            "serverSelectionTimeoutMS": 2500,
+            "connectTimeoutMS": 1800,
+            "socketTimeoutMS": 9000,
+            "waitQueueTimeoutMS": 3200,
+            "maxPoolSize": 40,
+            "minPoolSize": 6,
+        }
+    ]
+
+
+def test_create_app_clamps_min_pool_size_to_max_pool_size(monkeypatch):
+    mongo_init_calls = []
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("MONGO_MAX_POOL_SIZE", "5")
+    monkeypatch.setenv("MONGO_MIN_POOL_SIZE", "9")
+    monkeypatch.setattr(app_module, "db", FakeDB())
+    monkeypatch.setattr(
+        app_module.mongo,
+        "init_app",
+        lambda flask_app, **kwargs: mongo_init_calls.append(kwargs),
+    )
+    monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.limiter, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
+
+    app_module.create_app()
+
+    assert mongo_init_calls[0]["maxPoolSize"] == 5
+    assert mongo_init_calls[0]["minPoolSize"] == 5
+
+
 def test_create_app_requires_persistent_rate_limit_storage_in_production(monkeypatch):
     monkeypatch.delenv("RATELIMIT_STORAGE_URI", raising=False)
     monkeypatch.setenv("FLASK_ENV", "production")
@@ -248,6 +318,8 @@ def test_create_app_uses_testing_config_class(monkeypatch):
         {
             "serverSelectionTimeoutMS": 5000,
             "connectTimeoutMS": 5000,
+            "socketTimeoutMS": 10000,
+            "waitQueueTimeoutMS": 5000,
             "maxPoolSize": 20,
             "minPoolSize": 0,
         }
@@ -292,8 +364,10 @@ def test_create_app_allows_mongo_timeout_and_pool_overrides(monkeypatch):
     monkeypatch.setenv("SECRET_KEY", "test-secret-key")
     monkeypatch.setenv("MONGO_SERVER_SELECTION_TIMEOUT_MS", "1200")
     monkeypatch.setenv("MONGO_CONNECT_TIMEOUT_MS", "2300")
+    monkeypatch.setenv("MONGO_SOCKET_TIMEOUT_MS", "6400")
     monkeypatch.setenv("MONGO_MAX_POOL_SIZE", "17")
     monkeypatch.setenv("MONGO_MIN_POOL_SIZE", "3")
+    monkeypatch.setenv("MONGO_WAIT_QUEUE_TIMEOUT_MS", "2800")
     monkeypatch.setattr(app_module, "db", FakeDB())
     monkeypatch.setattr(
         app_module.mongo,
@@ -310,12 +384,16 @@ def test_create_app_allows_mongo_timeout_and_pool_overrides(monkeypatch):
 
     assert flask_app.config["MONGO_SERVER_SELECTION_TIMEOUT_MS"] == 1200
     assert flask_app.config["MONGO_CONNECT_TIMEOUT_MS"] == 2300
+    assert flask_app.config["MONGO_SOCKET_TIMEOUT_MS"] == 6400
     assert flask_app.config["MONGO_MAX_POOL_SIZE"] == 17
     assert flask_app.config["MONGO_MIN_POOL_SIZE"] == 3
+    assert flask_app.config["MONGO_WAIT_QUEUE_TIMEOUT_MS"] == 2800
     assert mongo_init_calls == [
         {
             "serverSelectionTimeoutMS": 1200,
             "connectTimeoutMS": 2300,
+            "socketTimeoutMS": 6400,
+            "waitQueueTimeoutMS": 2800,
             "maxPoolSize": 17,
             "minPoolSize": 3,
         }

--- a/tests/test_sync_platforms.py
+++ b/tests/test_sync_platforms.py
@@ -77,7 +77,7 @@ def test_sync_platforms_runs_selected_platform_jobs_concurrently(monkeypatch):
         "db",
         SimpleNamespace(user=SimpleNamespace(update_one=lambda query, update: captured.setdefault("db_update", (query, update)))),
     )
-    monkeypatch.setattr(profile_routes.cache, "clear", lambda: captured.setdefault("cleared_cache", True))
+    monkeypatch.setattr(profile_routes.cache, "delete", lambda key: captured.setdefault("deleted_cache_key", key))
 
     def fake_run_fetch_jobs(fetch_jobs, max_workers=5):
         captured["job_names"] = sorted(fetch_jobs.keys())
@@ -138,3 +138,4 @@ def test_sync_platforms_runs_selected_platform_jobs_concurrently(monkeypatch):
     assert update_fields["rating_history"] == [{"x": "2026-05-25", "y": 1800}]
     assert update_fields["lc_badges_json"] == '[{"name": "Knight"}]'
     assert update_fields["hr_badges_json"] == '[{"name": "Problem Solving", "stars": 5}]'
+    assert captured["deleted_cache_key"] == "card_user-1"


### PR DESCRIPTION
## Summary\n- add configurable Mongo socket and wait-queue timeouts alongside the existing server selection and connect knobs\n- clamp min pool size so invalid env combinations do not break startup\n- document the Mongo tuning env vars and lock the app-factory behavior with tests\n\n## Testing\n- python3 -m pytest tests/test_app_factory.py -q\n- PYTHONPYCACHEPREFIX=/private/tmp/450dsa-issue-335-refresh/.pycache python3 -m py_compile app/__init__.py app/config.py tests/test_app_factory.py\n- git diff --check