### PR TITLE
perf: add route timing instrumentation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,11 +2,12 @@ import json
 import os
 import secrets
 from pathlib import Path
+from time import perf_counter
 
 from app.config import resolve_config_class, env_flag, ProductionConfig
 from dotenv import load_dotenv
 from flasgger import Swagger
-from flask import Flask, session
+from flask import Flask, g, request, session
 
 from app.admin import admin_bp
 from app.auth import auth_bp
@@ -19,6 +20,18 @@ from app.security import build_content_security_policy
 from app.search import search_bp
 from app.tracker import tracker_bp
 from app.utils import platform_color_filter, platform_name_filter, platform_profile_url
+
+
+ROUTE_TIMING_ENDPOINTS = {
+    "profile.profile",
+    "profile.sync_platforms",
+    "leaderboard.leaderboard",
+    "leaderboard.api_leaderboard",
+    "search.search",
+    "search.api_search_questions",
+    "tracker.export_csv",
+    "tracker.export_notes",
+}
 
 
 def _configure_rate_limit_storage(app, config_class):
@@ -146,6 +159,11 @@ def create_app(config_class=None):
             init_db()
             app._db_initialized = True
 
+    @app.before_request
+    def start_route_timer():
+        if request.endpoint in ROUTE_TIMING_ENDPOINTS:
+            g.route_timer_start = perf_counter()
+
     app.add_template_filter(platform_name_filter, "platform_name")
     app.add_template_filter(platform_color_filter, "platform_color")
     app.add_template_filter(platform_profile_url, "platform_url")
@@ -191,6 +209,21 @@ def create_app(config_class=None):
 
     @app.after_request
     def add_security_headers(response):
+        started_at = getattr(g, "route_timer_start", None)
+        if started_at is not None and request.endpoint in ROUTE_TIMING_ENDPOINTS:
+            app.logger.info(
+                "route_timing %s",
+                json.dumps(
+                    {
+                        "endpoint": request.endpoint,
+                        "method": request.method,
+                        "route": request.url_rule.rule if request.url_rule else request.path,
+                        "status_code": response.status_code,
+                        "duration_ms": round((perf_counter() - started_at) * 1000, 2),
+                    },
+                    sort_keys=True,
+                ),
+            )
         response.headers["Content-Security-Policy"] = build_content_security_policy()
         return response
 

--- a/tests/test_route_timing.py
+++ b/tests/test_route_timing.py
@@ -1,0 +1,61 @@
+import json
+
+import app as app_module
+
+from tests.conftest import build_test_app
+
+
+def test_route_timing_targets_cover_key_profile_leaderboard_search_routes():
+    assert {
+        "profile.profile",
+        "profile.sync_platforms",
+        "leaderboard.leaderboard",
+        "leaderboard.api_leaderboard",
+        "search.search",
+        "search.api_search_questions",
+        "tracker.export_csv",
+        "tracker.export_notes",
+    } <= app_module.ROUTE_TIMING_ENDPOINTS
+
+
+def test_instrumented_search_route_logs_structured_timing(monkeypatch):
+    flask_app, _ = build_test_app(monkeypatch)
+    records = []
+
+    monkeypatch.setattr(
+        flask_app.logger,
+        "info",
+        lambda message, payload: records.append((message, payload)),
+    )
+
+    response = flask_app.test_client().get("/search?q=graphs")
+
+    assert response.status_code == 200
+    assert len(records) == 1
+
+    message, payload = records[0]
+    data = json.loads(payload)
+
+    assert message == "route_timing %s"
+    assert data["endpoint"] == "search.search"
+    assert data["method"] == "GET"
+    assert data["route"] == "/search"
+    assert data["status_code"] == 200
+    assert isinstance(data["duration_ms"], float)
+    assert data["duration_ms"] >= 0
+
+
+def test_non_instrumented_route_does_not_emit_timing_log(monkeypatch):
+    flask_app, _ = build_test_app(monkeypatch)
+    records = []
+
+    monkeypatch.setattr(
+        flask_app.logger,
+        "info",
+        lambda message, payload: records.append((message, payload)),
+    )
+
+    response = flask_app.test_client().get("/faq")
+
+    assert response.status_code == 200
+    assert records == []


### PR DESCRIPTION
## Summary
- add low-overhead timing instrumentation for key profile, leaderboard, search, sync, and export routes
- log structured route timing metadata without request payloads
- add app-factory regression coverage for instrumented and non-instrumented routes

Closes #336