### PR TITLE
feat: add two-factor authentication

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -4,6 +4,7 @@ import secrets
 from bson import ObjectId
 from flask import Blueprint, abort, current_app, flash, redirect, render_template, request, session, url_for
 from flask_login import UserMixin, current_user, login_required, login_user, logout_user
+import pyotp
 
 from app.extensions import bcrypt, db, github, google, login_manager
 from app.utils import utc_now
@@ -11,6 +12,9 @@ from app.utils import utc_now
 
 auth_bp = Blueprint("auth", __name__)
 GOOGLE_OAUTH_NONCE_SESSION_KEY = "google_oauth_nonce"
+TWO_FACTOR_PENDING_USER_SESSION_KEY = "two_factor_pending_user_id"
+TWO_FACTOR_PENDING_SECRET_SESSION_KEY = "two_factor_pending_secret"
+TWO_FACTOR_PENDING_BACKUP_CODES_SESSION_KEY = "two_factor_pending_backup_codes"
 COMMON_WEAK_PASSWORDS = {
     "12345678",
     "123456789",
@@ -21,6 +25,72 @@ COMMON_WEAK_PASSWORDS = {
     "letmein",
     "welcome1",
 }
+
+
+def normalize_two_factor_code(code):
+    return re.sub(r"[\s-]+", "", (code or "")).upper()
+
+
+def generate_backup_codes(count=8):
+    return [f"{secrets.token_hex(2).upper()}-{secrets.token_hex(2).upper()}" for _ in range(count)]
+
+
+def hash_backup_codes(codes):
+    return [
+        bcrypt.generate_password_hash(normalize_two_factor_code(code)).decode("utf-8")
+        for code in codes
+    ]
+
+
+def verify_totp_code(secret, code):
+    normalized = normalize_two_factor_code(code)
+    if not normalized or not secret:
+        return False
+    return bool(pyotp.TOTP(secret).verify(normalized, valid_window=1))
+
+
+def consume_backup_code(user_doc, code):
+    normalized = normalize_two_factor_code(code)
+    if not normalized:
+        return False
+
+    hashed_codes = list(user_doc.get("two_factor_backup_codes") or [])
+    remaining_codes = []
+    matched = False
+
+    for hashed in hashed_codes:
+        if not matched and bcrypt.check_password_hash(hashed, normalized):
+            matched = True
+            continue
+        remaining_codes.append(hashed)
+
+    if matched:
+        db.user.update_one(
+            {"_id": user_doc["_id"]},
+            {"$set": {"two_factor_backup_codes": remaining_codes}},
+        )
+        user_doc["two_factor_backup_codes"] = remaining_codes
+        return True
+
+    return False
+
+
+def verify_two_factor_challenge(user_doc, code):
+    secret = user_doc.get("two_factor_secret")
+    if verify_totp_code(secret, code):
+        return True, False
+    if consume_backup_code(user_doc, code):
+        return True, True
+    return False, False
+
+
+def clear_pending_two_factor_setup():
+    session.pop(TWO_FACTOR_PENDING_SECRET_SESSION_KEY, None)
+    session.pop(TWO_FACTOR_PENDING_BACKUP_CODES_SESSION_KEY, None)
+
+
+def clear_pending_login_verification():
+    session.pop(TWO_FACTOR_PENDING_USER_SESSION_KEY, None)
 
 
 def resolve_oauth_user(provider_field, provider_id, name, email=None):
@@ -128,6 +198,10 @@ def login():
         password = request.form.get("password")
         user_doc = db.user.find_one({"email": email})
         if user_doc and user_doc.get("password") and bcrypt.check_password_hash(user_doc["password"], password):
+            if user_doc.get("two_factor_enabled") and user_doc.get("two_factor_secret"):
+                session[TWO_FACTOR_PENDING_USER_SESSION_KEY] = str(user_doc["_id"])
+                flash("Enter your authenticator code to finish signing in.", "info")
+                return redirect(url_for("auth.verify_two_factor_login"))
             login_user(UserWrapper(user_doc))
             flash(f"Welcome back, {user_doc.get('name', 'User')}! 👋", "success")
             return redirect(url_for("tracker.index"))
@@ -180,8 +254,45 @@ def register():
 
 @auth_bp.route("/logout")
 def logout():
+    clear_pending_login_verification()
     logout_user()
     return redirect(url_for("auth.login"))
+
+
+@auth_bp.route("/login/verify-2fa", methods=["GET", "POST"])
+def verify_two_factor_login():
+    if current_user.is_authenticated:
+        return redirect(url_for("tracker.index"))
+
+    pending_user_id = session.get(TWO_FACTOR_PENDING_USER_SESSION_KEY)
+    if not pending_user_id:
+        return redirect(url_for("auth.login"))
+
+    try:
+        user_doc = db.user.find_one({"_id": ObjectId(pending_user_id)})
+    except Exception:
+        user_doc = None
+
+    if not user_doc or not user_doc.get("two_factor_enabled"):
+        clear_pending_login_verification()
+        flash("Two-factor session expired. Please sign in again.", "warning")
+        return redirect(url_for("auth.login"))
+
+    if request.method == "POST":
+        code = request.form.get("code", "")
+        is_valid, used_backup_code = verify_two_factor_challenge(user_doc, code)
+        if is_valid:
+            clear_pending_login_verification()
+            login_user(UserWrapper(user_doc))
+            if used_backup_code:
+                flash("Signed in with a backup code. That code cannot be used again.", "warning")
+            else:
+                flash(f"Welcome back, {user_doc.get('name', 'User')}! 👋", "success")
+            return redirect(url_for("tracker.index"))
+
+        flash("Invalid verification code.", "danger")
+
+    return render_template("two_factor_verify.html", user_email=user_doc.get("email"))
 
 
 @auth_bp.route("/delete_account", methods=["POST"])
@@ -221,6 +332,137 @@ def delete_account_token():
     from flask import jsonify
     user_doc = db.user.find_one({"_id": current_user.id}, {"password": 1}) or {}
     return jsonify({"csrf_token": token, "is_oauth": not bool(user_doc.get("password"))})
+
+
+@auth_bp.route("/settings/two-factor", methods=["GET"])
+@login_required
+def two_factor_settings():
+    user_doc = db.user.find_one({"_id": current_user.id}) or {}
+    if not user_doc.get("password"):
+        return render_template(
+            "two_factor.html",
+            password_account=False,
+            two_factor_enabled=False,
+            setup_secret=None,
+            otpauth_uri=None,
+            backup_codes=None,
+        )
+
+    setup_secret = session.get(TWO_FACTOR_PENDING_SECRET_SESSION_KEY)
+    backup_codes = session.get(TWO_FACTOR_PENDING_BACKUP_CODES_SESSION_KEY)
+    otpauth_uri = None
+    if setup_secret:
+        otpauth_uri = pyotp.TOTP(setup_secret).provisioning_uri(
+            name=user_doc.get("email") or str(user_doc["_id"]),
+            issuer_name="450 DSA Tracker",
+        )
+
+    return render_template(
+        "two_factor.html",
+        password_account=True,
+        two_factor_enabled=bool(user_doc.get("two_factor_enabled")),
+        setup_secret=setup_secret,
+        otpauth_uri=otpauth_uri,
+        backup_codes=backup_codes,
+    )
+
+
+@auth_bp.route("/settings/two-factor/setup", methods=["POST"])
+@login_required
+def setup_two_factor():
+    user_doc = db.user.find_one({"_id": current_user.id}) or {}
+    if not user_doc.get("password"):
+        flash("Two-factor authentication is only available for password accounts.", "danger")
+        return redirect(url_for("auth.two_factor_settings"))
+
+    if user_doc.get("two_factor_enabled"):
+        flash("Two-factor authentication is already enabled.", "info")
+        return redirect(url_for("auth.two_factor_settings"))
+
+    session[TWO_FACTOR_PENDING_SECRET_SESSION_KEY] = pyotp.random_base32()
+    session[TWO_FACTOR_PENDING_BACKUP_CODES_SESSION_KEY] = generate_backup_codes()
+    flash("Scan the secret in your authenticator app, then confirm with a code.", "info")
+    return redirect(url_for("auth.two_factor_settings"))
+
+
+@auth_bp.route("/settings/two-factor/confirm", methods=["POST"])
+@login_required
+def confirm_two_factor():
+    user_doc = db.user.find_one({"_id": current_user.id}) or {}
+    secret = session.get(TWO_FACTOR_PENDING_SECRET_SESSION_KEY)
+    backup_codes = session.get(TWO_FACTOR_PENDING_BACKUP_CODES_SESSION_KEY) or []
+    password = request.form.get("password", "")
+    code = request.form.get("code", "")
+
+    if not user_doc.get("password"):
+        flash("Two-factor authentication is only available for password accounts.", "danger")
+        return redirect(url_for("auth.two_factor_settings"))
+
+    if not secret or not backup_codes:
+        flash("Start setup before confirming two-factor authentication.", "warning")
+        return redirect(url_for("auth.two_factor_settings"))
+
+    if not bcrypt.check_password_hash(user_doc["password"], password):
+        flash("Incorrect password.", "danger")
+        return redirect(url_for("auth.two_factor_settings"))
+
+    if not verify_totp_code(secret, code):
+        flash("Invalid authenticator code.", "danger")
+        return redirect(url_for("auth.two_factor_settings"))
+
+    db.user.update_one(
+        {"_id": current_user.id},
+        {
+            "$set": {
+                "two_factor_enabled": True,
+                "two_factor_secret": secret,
+                "two_factor_backup_codes": hash_backup_codes(backup_codes),
+            }
+        },
+    )
+    clear_pending_two_factor_setup()
+    current_user.reload()
+    flash("Two-factor authentication is now enabled. Save your backup codes somewhere safe.", "success")
+    return redirect(url_for("auth.two_factor_settings"))
+
+
+@auth_bp.route("/settings/two-factor/disable", methods=["POST"])
+@login_required
+def disable_two_factor():
+    user_doc = db.user.find_one({"_id": current_user.id}) or {}
+    password = request.form.get("password", "")
+    code = request.form.get("code", "")
+
+    if not user_doc.get("two_factor_enabled"):
+        flash("Two-factor authentication is not enabled.", "info")
+        return redirect(url_for("auth.two_factor_settings"))
+
+    if not bcrypt.check_password_hash(user_doc["password"], password):
+        flash("Incorrect password.", "danger")
+        return redirect(url_for("auth.two_factor_settings"))
+
+    is_valid, used_backup_code = verify_two_factor_challenge(user_doc, code)
+    if not is_valid:
+        flash("Invalid verification code.", "danger")
+        return redirect(url_for("auth.two_factor_settings"))
+
+    db.user.update_one(
+        {"_id": current_user.id},
+        {
+            "$set": {
+                "two_factor_enabled": False,
+                "two_factor_secret": None,
+                "two_factor_backup_codes": [],
+            }
+        },
+    )
+    clear_pending_two_factor_setup()
+    current_user.reload()
+    if used_backup_code:
+        flash("Two-factor authentication disabled. One backup code was consumed.", "warning")
+    else:
+        flash("Two-factor authentication disabled.", "success")
+    return redirect(url_for("auth.two_factor_settings"))
 
 
 @auth_bp.route("/login/github")

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ redis==5.0.4
 # pyjson5==1.6.2
 Flask-Caching==2.0.2
 flasgger==0.9.7.1
+pyotp==2.9.0

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -179,6 +179,11 @@ body.modal-open {
     <div class="meta-row"><i class="bi bi-mortarboard" style="color:var(--info)" aria-hidden="true"></i> Computer Science</div>
     {% endif %}
     <button class="ui-btn ui-btn-secondary ui-btn-block" onclick="openEditProfile()" style="margin-top:12px" aria-label="Edit your profile"><i class="bi bi-pencil-square" aria-hidden="true"></i> Edit Profile</button>
+    {% if user.password %}
+    <a class="ui-btn ui-btn-secondary ui-btn-block" href="{{ url_for('auth.two_factor_settings') }}" style="margin-top:8px" aria-label="Manage two-factor authentication">
+      <i class="bi bi-shield-lock" aria-hidden="true"></i> Two-Factor Auth
+    </a>
+    {% endif %}
     <button class="ui-btn ui-btn-danger ui-btn-block" onclick="openDeleteModal()" style="margin-top:8px" aria-label="Delete your account permanently"><i class="bi bi-trash3" aria-hidden="true"></i> Delete Account</button>
   </div>
 

--- a/templates/two_factor.html
+++ b/templates/two_factor.html
@@ -1,0 +1,99 @@
+{% extends "base.html" %}
+{% block head %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
+{% endblock %}
+{% block content %}
+<div class="auth-wrap">
+    <div class="auth-card" style="max-width:620px">
+        <div class="auth-logo"><i class="bi bi-shield-lock"></i></div>
+        <h2>Two-Factor Authentication</h2>
+        <p class="subtitle">Add an authenticator app step and keep backup codes for recovery.</p>
+
+        {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+            <div class="flash-inline {{ category }}">
+                <i class="bi bi-{% if category == 'danger' %}x-circle{% elif category == 'warning' %}exclamation-triangle{% else %}check-circle{% endif %}"></i>
+                {{ message }}
+            </div>
+            {% endfor %}
+        {% endif %}
+        {% endwith %}
+
+        {% if not password_account %}
+        <div class="flash-inline warning">
+            <i class="bi bi-info-circle"></i>
+            Two-factor authentication is currently available only for accounts that sign in with a password.
+        </div>
+        <div class="auth-footer">
+            <a href="{{ url_for('profile.profile') }}">Back to profile</a>
+        </div>
+        {% elif two_factor_enabled %}
+        <div class="flash-inline success">
+            <i class="bi bi-shield-check"></i>
+            Two-factor authentication is enabled for your account.
+        </div>
+        <form method="POST" action="{{ url_for('auth.disable_two_factor') }}" id="disableTwoFactorForm" novalidate>
+            <div class="form-group">
+                <label class="form-label" for="disable_password">Current Password</label>
+                <input type="password" class="form-control" id="disable_password" name="password" placeholder="••••••••" required>
+            </div>
+            <div class="form-group">
+                <label class="form-label" for="disable_code">Authenticator or Backup Code</label>
+                <input type="text" class="form-control" id="disable_code" name="code" placeholder="123456 or ABCD-EFGH" required>
+            </div>
+            <button type="submit" class="btn-primary-full">
+                <i class="bi bi-shield-x"></i> Disable 2FA
+            </button>
+        </form>
+        {% else %}
+            {% if not setup_secret %}
+            <form method="POST" action="{{ url_for('auth.setup_two_factor') }}">
+                <button type="submit" class="btn-primary-full">
+                    <i class="bi bi-shield-plus"></i> Start 2FA Setup
+                </button>
+            </form>
+            {% else %}
+            <div class="flash-inline info">
+                <i class="bi bi-phone"></i>
+                Enter this secret in your authenticator app, then confirm with a current code.
+            </div>
+            <div class="form-group">
+                <label class="form-label">Authenticator Secret</label>
+                <input type="text" class="form-control" value="{{ setup_secret }}" readonly>
+            </div>
+            <div class="form-group">
+                <label class="form-label">otpauth URI</label>
+                <textarea class="form-control" rows="3" readonly>{{ otpauth_uri }}</textarea>
+            </div>
+            <div class="form-group">
+                <label class="form-label">Backup Codes</label>
+                <div class="strength-rules" style="display:grid;grid-template-columns:1fr 1fr;gap:8px">
+                    {% for code in backup_codes %}
+                    <div class="rule met"><i class="bi bi-key-fill"></i> {{ code }}</div>
+                    {% endfor %}
+                </div>
+            </div>
+            <form method="POST" action="{{ url_for('auth.confirm_two_factor') }}" id="confirmTwoFactorForm" novalidate>
+                <div class="form-group">
+                    <label class="form-label" for="confirm_password">Current Password</label>
+                    <input type="password" class="form-control" id="confirm_password" name="password" placeholder="••••••••" required>
+                </div>
+                <div class="form-group">
+                    <label class="form-label" for="confirm_code">Authenticator Code</label>
+                    <input type="text" class="form-control" id="confirm_code" name="code" placeholder="123456" required>
+                </div>
+                <button type="submit" class="btn-primary-full">
+                    <i class="bi bi-shield-check"></i> Enable 2FA
+                </button>
+            </form>
+            {% endif %}
+        {% endif %}
+
+        <div class="auth-footer">
+            <a href="{{ url_for('profile.profile') }}">Back to profile</a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/two_factor_verify.html
+++ b/templates/two_factor_verify.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block head %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
+{% endblock %}
+{% block content %}
+<div class="auth-wrap">
+    <div class="auth-card">
+        <div class="auth-logo"><i class="bi bi-shield-lock"></i></div>
+        <h2>Verify Sign In</h2>
+        <p class="subtitle">Enter a 6-digit authenticator code or one of your backup codes for {{ user_email }}.</p>
+
+        {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+            <div class="flash-inline {{ category }}">
+                <i class="bi bi-{% if category == 'danger' %}x-circle{% elif category == 'warning' %}exclamation-triangle{% else %}check-circle{% endif %}"></i>
+                {{ message }}
+            </div>
+            {% endfor %}
+        {% endif %}
+        {% endwith %}
+
+        <form method="POST" action="{{ url_for('auth.verify_two_factor_login') }}" id="verifyTwoFactorForm" novalidate>
+            <div class="form-group">
+                <label class="form-label" for="code">Authenticator or Backup Code</label>
+                <input type="text" class="form-control" id="code" name="code" placeholder="123456 or ABCD-EFGH" required autofocus>
+            </div>
+            <button type="submit" class="btn-primary-full">
+                <i class="bi bi-shield-check"></i> Verify and Sign In
+            </button>
+        </form>
+
+        <div class="auth-footer">
+            <a href="{{ url_for('auth.login') }}">Back to login</a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -78,8 +78,13 @@ def test_create_app_preserves_routes_and_blueprints(monkeypatch):
     routes = {rule.rule for rule in flask_app.url_map.iter_rules()}
     assert "/" in routes
     assert "/login" in routes
+    assert "/login/verify-2fa" in routes
     assert "/register" in routes
     assert "/logout" in routes
+    assert "/settings/two-factor" in routes
+    assert "/settings/two-factor/setup" in routes
+    assert "/settings/two-factor/confirm" in routes
+    assert "/settings/two-factor/disable" in routes
     assert "/login/github" in routes
     assert "/login/github/authorize" in routes
     assert "/login/google" in routes

--- a/tests/test_two_factor_auth.py
+++ b/tests/test_two_factor_auth.py
@@ -1,0 +1,140 @@
+import pyotp
+
+import app.auth.routes as auth_routes
+from conftest import build_test_app
+
+
+def _create_password_user(test_db, password_hash, **extra_fields):
+    user_doc = {
+        "name": "Secure User",
+        "email": "secure@example.com",
+        "password": password_hash,
+        "progress": {},
+        "is_admin": False,
+    }
+    user_doc.update(extra_fields)
+    return test_db.user.insert_one(user_doc).inserted_id
+
+
+def test_login_redirects_two_factor_users_to_verification(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    password_hash = auth_routes.bcrypt.generate_password_hash("StrongPass1!").decode("utf-8")
+    secret = pyotp.random_base32()
+    _create_password_user(
+        test_db,
+        password_hash,
+        two_factor_enabled=True,
+        two_factor_secret=secret,
+        two_factor_backup_codes=[],
+    )
+
+    response = flask_app.test_client().post(
+        "/login",
+        data={"email": "secure@example.com", "password": "StrongPass1!"},
+    )
+
+    assert response.status_code == 302
+    assert "/login/verify-2fa" in response.headers["Location"]
+
+
+def test_two_factor_setup_confirmation_persists_secret_and_backup_codes(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    password_hash = auth_routes.bcrypt.generate_password_hash("StrongPass1!").decode("utf-8")
+    user_id = _create_password_user(test_db, password_hash)
+
+    with flask_app.test_client() as client:
+        with client.session_transaction() as session:
+            session["_user_id"] = str(user_id)
+            session["_fresh"] = True
+            session["two_factor_pending_secret"] = pyotp.random_base32()
+            session["two_factor_pending_backup_codes"] = ["ABCD-EFGH", "WXYZ-1234"]
+            secret = session["two_factor_pending_secret"]
+
+        response = client.post(
+            "/settings/two-factor/confirm",
+            data={"password": "StrongPass1!", "code": pyotp.TOTP(secret).now()},
+        )
+
+    user_doc = test_db.user.find_one({"_id": user_id})
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/settings/two-factor")
+    assert user_doc["two_factor_enabled"] is True
+    assert user_doc["two_factor_secret"] == secret
+    assert len(user_doc["two_factor_backup_codes"]) == 2
+    assert user_doc["two_factor_backup_codes"][0] != "ABCD-EFGH"
+
+
+def test_verify_two_factor_login_accepts_valid_totp_code(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    password_hash = auth_routes.bcrypt.generate_password_hash("StrongPass1!").decode("utf-8")
+    secret = pyotp.random_base32()
+    user_id = _create_password_user(
+        test_db,
+        password_hash,
+        two_factor_enabled=True,
+        two_factor_secret=secret,
+        two_factor_backup_codes=[],
+    )
+
+    with flask_app.test_client() as client:
+        with client.session_transaction() as session:
+            session["two_factor_pending_user_id"] = str(user_id)
+
+        response = client.post(
+            "/login/verify-2fa",
+            data={"code": pyotp.TOTP(secret).now()},
+        )
+
+        with client.session_transaction() as session:
+            assert session.get("_user_id") == str(user_id)
+            assert "two_factor_pending_user_id" not in session
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/")
+
+
+def test_backup_code_sign_in_consumes_code(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    password_hash = auth_routes.bcrypt.generate_password_hash("StrongPass1!").decode("utf-8")
+    backup_code = "ABCD-EFGH"
+    user_id = _create_password_user(
+        test_db,
+        password_hash,
+        two_factor_enabled=True,
+        two_factor_secret=pyotp.random_base32(),
+        two_factor_backup_codes=auth_routes.hash_backup_codes([backup_code]),
+    )
+
+    with flask_app.test_client() as client:
+        with client.session_transaction() as session:
+            session["two_factor_pending_user_id"] = str(user_id)
+
+        response = client.post("/login/verify-2fa", data={"code": backup_code})
+
+    user_doc = test_db.user.find_one({"_id": user_id})
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/")
+    assert user_doc["two_factor_backup_codes"] == []
+
+
+def test_oauth_only_users_cannot_start_two_factor_setup(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    user_id = test_db.user.insert_one(
+        {
+            "name": "OAuth User",
+            "email": "oauth@example.com",
+            "google_id": "google-1",
+            "progress": {},
+            "is_admin": False,
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        with client.session_transaction() as session:
+            session["_user_id"] = str(user_id)
+            session["_fresh"] = True
+
+        response = client.post("/settings/two-factor/setup")
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/settings/two-factor")


### PR DESCRIPTION
## Summary
- add TOTP-based two-factor authentication for password accounts, including backup recovery codes
- require 2FA verification during password login and allow enabling or disabling 2FA from a dedicated settings page
- add focused auth regression coverage for setup, verification, recovery-code consumption, and route registration

Closes #369