### PR TITLE
feat: add GitHub repository showcase on profile

### DIFF
--- a/app/github_showcase.py
+++ b/app/github_showcase.py
@@ -1,0 +1,123 @@
+import re
+
+import requests
+
+
+REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+DEFAULT_REPO_LIMIT = 3
+MAX_REPO_LIMIT = 6
+
+
+def normalize_repo_list(raw_value, github_username, max_repos=MAX_REPO_LIMIT):
+    if raw_value is None:
+        return ""
+    if not isinstance(raw_value, str):
+        raise ValueError("github_repo_list must be text")
+
+    github_username = (github_username or "").strip()
+    entries = []
+    seen = set()
+
+    for token in re.split(r"[\n,]+", raw_value):
+        token = token.strip()
+        if not token:
+            continue
+
+        slug = token
+        if "/" not in slug:
+            if not github_username:
+                raise ValueError("GitHub repository names must include an owner when no GitHub username is set.")
+            slug = f"{github_username}/{slug}"
+
+        if not REPO_SLUG_RE.fullmatch(slug):
+            raise ValueError("GitHub repositories must use owner/repo format with valid characters.")
+
+        slug_key = slug.lower()
+        if slug_key in seen:
+            continue
+
+        seen.add(slug_key)
+        entries.append(slug)
+
+        if len(entries) >= max_repos:
+            break
+
+    return "\n".join(entries)
+
+
+def parse_repo_list(raw_value):
+    if not raw_value:
+        return []
+    return [line.strip() for line in str(raw_value).splitlines() if line.strip()]
+
+
+def fetch_repo_metadata(repo_slug, requests_module=requests):
+    response = requests_module.get(
+        f"https://api.github.com/repos/{repo_slug}",
+        headers={"Accept": "application/vnd.github+json"},
+        timeout=5,
+    )
+    if response.status_code != 200:
+        return None
+
+    payload = response.json()
+    if payload.get("fork") or payload.get("private"):
+        return None
+
+    owner = payload.get("owner") or {}
+    return {
+        "slug": payload.get("full_name", repo_slug),
+        "name": payload.get("name", repo_slug.split("/")[-1]),
+        "url": payload.get("html_url"),
+        "description": payload.get("description") or "",
+        "language": payload.get("language") or "",
+        "stars": payload.get("stargazers_count", 0),
+        "forks": payload.get("forks_count", 0),
+        "owner": owner.get("login", repo_slug.split("/")[0]),
+    }
+
+
+def fetch_github_repo_showcase(github_username, github_repo_list="", requests_module=requests):
+    github_username = (github_username or "").strip()
+    selected_repos = parse_repo_list(github_repo_list)
+
+    if not github_username and not selected_repos:
+        return []
+
+    if selected_repos:
+        showcase = []
+        for repo_slug in selected_repos[:MAX_REPO_LIMIT]:
+            metadata = fetch_repo_metadata(repo_slug, requests_module=requests_module)
+            if metadata:
+                showcase.append(metadata)
+        return showcase
+
+    response = requests_module.get(
+        f"https://api.github.com/users/{github_username}/repos",
+        params={"sort": "updated", "per_page": DEFAULT_REPO_LIMIT, "type": "owner"},
+        headers={"Accept": "application/vnd.github+json"},
+        timeout=5,
+    )
+    if response.status_code != 200:
+        return []
+
+    showcase = []
+    for payload in response.json():
+        if payload.get("fork") or payload.get("private"):
+            continue
+        showcase.append(
+            {
+                "slug": payload.get("full_name", ""),
+                "name": payload.get("name", ""),
+                "url": payload.get("html_url"),
+                "description": payload.get("description") or "",
+                "language": payload.get("language") or "",
+                "stars": payload.get("stargazers_count", 0),
+                "forks": payload.get("forks_count", 0),
+                "owner": github_username,
+            }
+        )
+        if len(showcase) >= DEFAULT_REPO_LIMIT:
+            break
+
+    return showcase

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -5,6 +5,7 @@ from flask import Blueprint, current_app, jsonify, render_template, request, sen
 from flask_login import current_user, login_required
 
 from app.extensions import cache, db, limiter
+from app.github_showcase import fetch_github_repo_showcase, normalize_repo_list
 from app.platforms.fetchers import (
     fetch_atcoder,
     fetch_coding_ninjas,
@@ -23,6 +24,13 @@ from profile_validation import build_profile_updates
 profile_bp = Blueprint("profile", __name__)
 
 __all__ = ["CACHE_TTL", "get_public_card_image"]
+
+
+def clear_profile_card_cache(user_id):
+    try:
+        cache.delete(f"card_{str(user_id)}")
+    except Exception:
+        current_app.logger.debug("Skipping profile card cache clear", exc_info=True)
 
 
 def build_sync_platforms_response(platform_status: dict):
@@ -318,7 +326,7 @@ def sync_platforms():
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
 
-    cache.delete(f"card_{str(current_user.id)}")
+    clear_profile_card_cache(current_user.id)
     return jsonify(build_sync_platforms_response(platform_status))
 
 
@@ -393,10 +401,19 @@ def edit_profile():
     update_fields, error = build_profile_updates(data)
     if error:
         return json_error(error, status_code=400)
+    if "github_repo_list" in data:
+        try:
+            normalized_repo_list = normalize_repo_list(
+                data.get("github_repo_list", ""),
+                data.get("github_username", current_user.github_username or ""),
+            )
+        except ValueError as exc:
+            return json_error(str(exc), status_code=400)
+        update_fields["github_repo_list"] = normalized_repo_list
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
-        cache.delete(f"card_{str(current_user.id)}")
+        clear_profile_card_cache(current_user.id)
     return json_success()
 
 
@@ -632,6 +649,15 @@ def profile():
     except (json.JSONDecodeError, ValueError):
         print("Unable to handle hackerrank badges")
 
+    github_repos = []
+    try:
+        github_repos = fetch_github_repo_showcase(
+            user.github_username,
+            user.github_repo_list or "",
+        )
+    except Exception:
+        current_app.logger.exception("Failed to load GitHub repository showcase")
+
     return render_template(
         "profile.html",
         user=user,
@@ -657,4 +683,5 @@ def profile():
         rating_history=rating_history,
         lc_badges=lc_badges,
         hr_badges=hr_badges,
+        github_repos=github_repos,
     )

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -1,7 +1,8 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, current_app, render_template
 from bson import ObjectId
 from bson.errors import InvalidId
 from app.extensions import db
+from app.github_showcase import fetch_github_repo_showcase
 from app.utils import compute_c_score
 
 public_bp = Blueprint("public", __name__)
@@ -21,12 +22,22 @@ def public_profile(user_id):
     public_user_data = {
         "username": user_doc.get("name") or user_doc.get("username", "Unknown User"),
         "avatar_url": user_doc.get("profile_photo") or user_doc.get("avatar_url", ""),
+        "github_username": user_doc.get("github_username", ""),
     }
 
     stats = compute_c_score(user_doc)
+    github_repos = []
+    try:
+        github_repos = fetch_github_repo_showcase(
+            user_doc.get("github_username", ""),
+            user_doc.get("github_repo_list", ""),
+        )
+    except Exception:
+        current_app.logger.exception("Failed to load public GitHub repository showcase")
 
     return render_template(
         "public_profile.html",
         user=public_user_data,
-        stats=stats
+        stats=stats,
+        github_repos=github_repos,
     )

--- a/profile_validation.py
+++ b/profile_validation.py
@@ -11,6 +11,7 @@ PROFILE_FIELD_LIMITS = {
     'twitter_url': 300,
     'website_url': 300,
     'resume_url': 300,
+    'github_repo_list': 600,
 }
 PROFILE_URL_FIELDS = {'linkedin_url', 'twitter_url', 'website_url', 'resume_url'}
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -18,6 +18,14 @@
 .social-row{display:flex;justify-content:center;gap:12px;margin-bottom:12px;padding:10px 0;border-top:1px solid var(--border-color);border-bottom:1px solid var(--border-color)}
 .social-icon{color:var(--text-muted);font-size:1.1rem;text-decoration:none;transition:color 0.2s}
 .social-icon:hover{color:var(--accent)}
+.repo-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}
+.repo-card{background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:12px;padding:14px;display:flex;flex-direction:column;gap:8px}
+.repo-card:hover{border-color:var(--accent)}
+.repo-head{display:flex;align-items:center;justify-content:space-between;gap:8px}
+.repo-name{font-weight:700;color:var(--text-primary);text-decoration:none}
+.repo-name:hover{color:var(--accent)}
+.repo-meta{display:flex;gap:10px;flex-wrap:wrap;font-size:.72rem;color:var(--text-muted)}
+.repo-desc{font-size:.78rem;color:var(--text-secondary);min-height:2.4em}
 .meta-row{display:flex;align-items:center;gap:6px;font-size:0.79rem;color:var(--text-secondary);margin-bottom:6px}
 .sec-title{font-size:0.75rem;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:10px}
 .platform-row{display:flex;align-items:center;justify-content:space-between;padding:7px 8px;border-radius:8px;margin-bottom:4px;font-size:0.82rem}
@@ -171,6 +179,25 @@ body.modal-open {
       {% if user.github_username %}<a href="{{ user.github_username | platform_url('github') }}" target="_blank" rel="noopener noreferrer" class="social-icon" title="GitHub" aria-label="GitHub profile (opens in new tab)"><i class="bi bi-github" aria-hidden="true"></i></a>{% endif %}
       {% if user.resume_url %}<a href="{{ user.resume_url }}" target="_blank" rel="noopener noreferrer" class="social-icon" title="Resume" aria-label="Resume (opens in new tab)"><i class="bi bi-file-earmark-person" aria-hidden="true"></i></a>{% endif %}
     </div>
+    {% if github_repos %}
+    <div class="sec-title">Pinned GitHub Repositories</div>
+    <div class="repo-grid" style="margin-bottom:12px">
+      {% for repo in github_repos %}
+      <div class="repo-card">
+        <div class="repo-head">
+          <a href="{{ repo.url }}" target="_blank" rel="noopener noreferrer" class="repo-name">{{ repo.name }}</a>
+          <i class="bi bi-github" aria-hidden="true"></i>
+        </div>
+        <div class="repo-desc">{{ repo.description or 'Public repository showcase' }}</div>
+        <div class="repo-meta">
+          {% if repo.language %}<span>{{ repo.language }}</span>{% endif %}
+          <span><i class="bi bi-star-fill" aria-hidden="true"></i> {{ repo.stars }}</span>
+          <span><i class="bi bi-diagram-3" aria-hidden="true"></i> {{ repo.forks }}</span>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
     {% if user.location or user.college %}
     <div class="meta-row">{% if user.location %}<i class="bi bi-geo-alt" style="color:var(--accent)" aria-hidden="true"></i> {{ user.location }}{% endif %}</div>
     <div class="meta-row">{% if user.college %}<i class="bi bi-mortarboard" style="color:var(--info)" aria-hidden="true"></i> {{ user.college }}{% endif %}</div>
@@ -528,6 +555,7 @@ body.modal-open {
     <div style="margin-bottom:10px"><label class="m-lbl"><i class="bi bi-linkedin" style="color:#0a66c2"></i> LinkedIn URL</label><input class="m-inp" id="ep_linkedin" placeholder="https://linkedin.com/in/username" value="{{ user.linkedin_url or '' }}"></div>
     <div style="margin-bottom:10px"><label class="m-lbl"><i class="bi bi-twitter-x"></i> Twitter / X URL</label><input class="m-inp" id="ep_twitter" placeholder="https://twitter.com/username" value="{{ user.twitter_url or '' }}"></div>
     <div style="margin-bottom:10px"><label class="m-lbl"><i class="bi bi-globe" style="color:var(--info)"></i> Website / Portfolio</label><input class="m-inp" id="ep_website" placeholder="https://yoursite.com" value="{{ user.website_url or '' }}"></div>
+    <div style="margin-bottom:10px"><label class="m-lbl"><i class="bi bi-github"></i> Featured GitHub Repositories</label><textarea class="m-inp" id="ep_github_repo_list" rows="3" placeholder="owner/repo or just repo-name, one per line">{{ user.github_repo_list or '' }}</textarea><div style="font-size:.7rem;color:var(--text-muted);margin-top:3px">Use one repository per line. If you enter only a repo name, your GitHub username will be used as the owner.</div></div>
     <div style="margin-bottom:16px"><label class="m-lbl"><i class="bi bi-file-earmark-person" style="color:var(--accent)"></i> Resume URL</label><input class="m-inp" id="ep_resume" placeholder="https://drive.google.com/... or LinkedIn resume link" value="{{ user.resume_url or '' }}"><div style="font-size:.7rem;color:var(--text-muted);margin-top:3px">Paste a Google Drive, Dropbox, or any public resume link</div></div>
     </div><!-- end scrollable body -->
     <div style="flex-shrink:0;display:flex;justify-content:flex-end;gap:10px;padding:14px 24px;border-top:1px solid var(--border-color)">
@@ -579,6 +607,7 @@ window.handleSaveProfile = function(btn){
     linkedin_url: document.getElementById('ep_linkedin').value,
     twitter_url: document.getElementById('ep_twitter').value,
     website_url: document.getElementById('ep_website').value,
+    github_repo_list: document.getElementById('ep_github_repo_list').value,
     resume_url: document.getElementById('ep_resume').value,
   };
   btn.disabled=true;

--- a/templates/public_profile.html
+++ b/templates/public_profile.html
@@ -25,6 +25,12 @@
 .stat-card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:16px;color:var(--text-primary)}
 .stat-num{font-size:2.4rem;font-weight:900;line-height:1;margin-top:4px;color:var(--text-primary)}
 .stat-lbl{font-size:0.75rem;color:var(--text-secondary);font-weight:600}
+.repo-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}
+.repo-card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:16px;display:flex;flex-direction:column;gap:8px}
+.repo-name{font-weight:700;color:var(--text-primary);text-decoration:none}
+.repo-name:hover{color:var(--accent)}
+.repo-meta{display:flex;gap:10px;flex-wrap:wrap;font-size:.72rem;color:var(--text-muted)}
+.repo-desc{font-size:.8rem;color:var(--text-secondary)}
 @media(max-width:520px){.stat-row{grid-template-columns:1fr}}
 </style>
 
@@ -106,6 +112,25 @@
         </div>
       </div>
     </div>
+
+    {% if github_repos %}
+    <div class="card">
+      <div class="sec-title">Featured GitHub Repositories</div>
+      <div class="repo-grid">
+        {% for repo in github_repos %}
+        <div class="repo-card">
+          <a href="{{ repo.url }}" target="_blank" rel="noopener noreferrer" class="repo-name">{{ repo.name }}</a>
+          <div class="repo-desc">{{ repo.description or 'Public repository showcase' }}</div>
+          <div class="repo-meta">
+            {% if repo.language %}<span>{{ repo.language }}</span>{% endif %}
+            <span><i class="bi bi-star-fill" aria-hidden="true"></i> {{ repo.stars }}</span>
+            <span><i class="bi bi-diagram-3" aria-hidden="true"></i> {{ repo.forks }}</span>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
 
     <div class="card" style="text-align:center;color:var(--text-secondary);font-size:.82rem">
       This is a public profile page.

--- a/tests/test_github_showcase.py
+++ b/tests/test_github_showcase.py
@@ -1,0 +1,123 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.github_showcase import (
+    DEFAULT_REPO_LIMIT,
+    fetch_github_repo_showcase,
+    normalize_repo_list,
+)
+
+
+def test_normalize_repo_list_uses_github_username_for_bare_names():
+    normalized = normalize_repo_list("repo-one\nrepo-two", "saurabhhhcodes")
+
+    assert normalized == "saurabhhhcodes/repo-one\nsaurabhhhcodes/repo-two"
+
+
+def test_normalize_repo_list_deduplicates_case_insensitively():
+    normalized = normalize_repo_list(
+        "OpenAI/Codex\nopenai/codex\nOpenAI/Agents",
+        "ignored-user",
+    )
+
+    assert normalized == "OpenAI/Codex\nOpenAI/Agents"
+
+
+def test_normalize_repo_list_rejects_invalid_repo_slug():
+    with pytest.raises(ValueError, match="owner/repo format"):
+        normalize_repo_list("bad slug!", "saurabhhhcodes")
+
+
+def test_fetch_github_repo_showcase_uses_selected_repositories():
+    responses = {
+        "https://api.github.com/repos/saurabhhhcodes/repo-one": SimpleNamespace(
+            status_code=200,
+            json=lambda: {
+                "full_name": "saurabhhhcodes/repo-one",
+                "name": "repo-one",
+                "html_url": "https://github.com/saurabhhhcodes/repo-one",
+                "description": "First repo",
+                "language": "Python",
+                "stargazers_count": 10,
+                "forks_count": 2,
+                "owner": {"login": "saurabhhhcodes"},
+                "fork": False,
+                "private": False,
+            },
+        ),
+        "https://api.github.com/repos/saurabhhhcodes/repo-two": SimpleNamespace(
+            status_code=200,
+            json=lambda: {
+                "full_name": "saurabhhhcodes/repo-two",
+                "name": "repo-two",
+                "html_url": "https://github.com/saurabhhhcodes/repo-two",
+                "description": "Second repo",
+                "language": "JavaScript",
+                "stargazers_count": 8,
+                "forks_count": 1,
+                "owner": {"login": "saurabhhhcodes"},
+                "fork": False,
+                "private": False,
+            },
+        ),
+    }
+
+    def fake_get(url, headers=None, timeout=None, params=None):
+        return responses[url]
+
+    fake_requests = SimpleNamespace(get=fake_get)
+
+    showcase = fetch_github_repo_showcase(
+        "saurabhhhcodes",
+        "saurabhhhcodes/repo-one\nsaurabhhhcodes/repo-two",
+        requests_module=fake_requests,
+    )
+
+    assert [repo["slug"] for repo in showcase] == [
+        "saurabhhhcodes/repo-one",
+        "saurabhhhcodes/repo-two",
+    ]
+    assert showcase[0]["stars"] == 10
+    assert showcase[1]["language"] == "JavaScript"
+
+
+def test_fetch_github_repo_showcase_falls_back_to_recent_owned_repositories():
+    payload = [
+        {
+            "full_name": "saurabhhhcodes/active-repo",
+            "name": "active-repo",
+            "html_url": "https://github.com/saurabhhhcodes/active-repo",
+            "description": "Fresh work",
+            "language": "Python",
+            "stargazers_count": 7,
+            "forks_count": 0,
+            "fork": False,
+            "private": False,
+        },
+        {
+            "full_name": "saurabhhhcodes/forked-repo",
+            "name": "forked-repo",
+            "html_url": "https://github.com/saurabhhhcodes/forked-repo",
+            "description": "Should not show",
+            "language": "Go",
+            "stargazers_count": 99,
+            "forks_count": 10,
+            "fork": True,
+            "private": False,
+        },
+    ]
+    captured = {}
+
+    def fake_get(url, headers=None, timeout=None, params=None):
+        captured["url"] = url
+        captured["params"] = params
+        return SimpleNamespace(status_code=200, json=lambda: payload)
+
+    fake_requests = SimpleNamespace(get=fake_get)
+
+    showcase = fetch_github_repo_showcase("saurabhhhcodes", requests_module=fake_requests)
+
+    assert captured["url"] == "https://api.github.com/users/saurabhhhcodes/repos"
+    assert captured["params"] == {"sort": "updated", "per_page": DEFAULT_REPO_LIMIT, "type": "owner"}
+    assert [repo["slug"] for repo in showcase] == ["saurabhhhcodes/active-repo"]

--- a/tests/test_profile_github_showcase_routes.py
+++ b/tests/test_profile_github_showcase_routes.py
@@ -1,0 +1,131 @@
+from types import SimpleNamespace
+
+from flask import Flask
+
+import app.profile.routes as profile_routes
+from app.profile.routes import profile_bp
+
+
+def create_profile_test_app():
+    app = Flask(__name__)
+    app.config.update(TESTING=True, LOGIN_DISABLED=True, SECRET_KEY="test-secret")
+    app.register_blueprint(profile_bp)
+    return app
+
+
+def test_edit_profile_normalizes_featured_github_repositories(monkeypatch):
+    app = create_profile_test_app()
+    captured = {}
+
+    monkeypatch.setattr(
+        profile_routes,
+        "current_user",
+        SimpleNamespace(
+            id="user-1",
+            github_username="saurabhhhcodes",
+            reload=lambda: captured.setdefault("reloaded", True),
+        ),
+    )
+    monkeypatch.setattr(profile_routes, "build_profile_updates", lambda data: ({}, None))
+    monkeypatch.setattr(
+        profile_routes,
+        "db",
+        SimpleNamespace(
+            user=SimpleNamespace(
+                update_one=lambda query, update: captured.setdefault("db_update", (query, update))
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        profile_routes.cache,
+        "delete",
+        lambda key: captured.setdefault("deleted_cache_key", key),
+    )
+
+    response = app.test_client().post(
+        "/edit_profile",
+        json={
+            "github_username": "saurabhhhcodes",
+            "github_repo_list": "repo-one\nrepo-two",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"success": True}
+    assert captured["db_update"][1]["$set"]["github_repo_list"] == (
+        "saurabhhhcodes/repo-one\nsaurabhhhcodes/repo-two"
+    )
+    assert captured["deleted_cache_key"] == "card_user-1"
+    assert captured["reloaded"] is True
+
+
+def test_edit_profile_rejects_invalid_featured_github_repository(monkeypatch):
+    app = create_profile_test_app()
+
+    monkeypatch.setattr(
+        profile_routes,
+        "current_user",
+        SimpleNamespace(
+            id="user-1",
+            github_username="saurabhhhcodes",
+            reload=lambda: None,
+        ),
+    )
+    monkeypatch.setattr(profile_routes, "build_profile_updates", lambda data: ({}, None))
+
+    response = app.test_client().post(
+        "/edit_profile",
+        json={
+            "github_username": "saurabhhhcodes",
+            "github_repo_list": "bad slug!",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "success": False,
+        "error": "GitHub repositories must use owner/repo format with valid characters.",
+    }
+
+
+def test_edit_profile_tolerates_cache_delete_failures(monkeypatch):
+    app = create_profile_test_app()
+    captured = {}
+
+    monkeypatch.setattr(
+        profile_routes,
+        "current_user",
+        SimpleNamespace(
+            id="user-1",
+            github_username="saurabhhhcodes",
+            reload=lambda: captured.setdefault("reloaded", True),
+        ),
+    )
+    monkeypatch.setattr(profile_routes, "build_profile_updates", lambda data: ({}, None))
+    monkeypatch.setattr(
+        profile_routes,
+        "db",
+        SimpleNamespace(
+            user=SimpleNamespace(
+                update_one=lambda query, update: captured.setdefault("db_update", (query, update))
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        profile_routes.cache,
+        "delete",
+        lambda key: (_ for _ in ()).throw(RuntimeError("cache unavailable")),
+    )
+
+    response = app.test_client().post(
+        "/edit_profile",
+        json={
+            "github_username": "saurabhhhcodes",
+            "github_repo_list": "repo-one",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"success": True}
+    assert captured["db_update"][1]["$set"]["github_repo_list"] == "saurabhhhcodes/repo-one"
+    assert captured["reloaded"] is True

--- a/tests/test_profile_image_loading.py
+++ b/tests/test_profile_image_loading.py
@@ -10,9 +10,12 @@ def test_profile_template_marks_primary_avatar_as_eager_and_badges_as_lazy():
     assert 'src="{{ user.profile_photo }}" width="90" height="90" loading="eager" fetchpriority="high" decoding="async"' in template
     assert 'src="{{ badge.icon }}" width="36" height="36" loading="lazy" decoding="async"' in template
     assert 'src="{{ user.profile_photo }}" width="80" height="80" loading="lazy" decoding="async"' in template
+    assert 'id="ep_github_repo_list"' in template
+    assert "Featured GitHub Repositories" in template
 
 
 def test_public_profile_template_keeps_visible_avatar_eager_with_dimensions():
     template = (TEMPLATE_DIR / "public_profile.html").read_text(encoding="utf-8")
 
     assert 'src="{{ user.avatar_url }}" width="90" height="90" loading="eager" fetchpriority="high" decoding="async"' in template
+    assert "Featured GitHub Repositories" in template

--- a/tests/test_public_profile.py
+++ b/tests/test_public_profile.py
@@ -43,6 +43,47 @@ def test_public_profile_route_is_accessible_without_login(monkeypatch):
     assert "This is a public profile page." in html
 
 
+def test_public_profile_renders_github_repository_showcase(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(public_routes,))
+    user_id = test_db.user.insert_one(
+        {
+            "name": "Public User",
+            "profile_photo": "https://example.com/avatar.png",
+            "progress": {},
+            "external_totals": {},
+            "github_username": "saurabhhhcodes",
+            "github_repo_list": "saurabhhhcodes/repo-one",
+        }
+    ).inserted_id
+
+    monkeypatch.setattr(
+        public_routes,
+        "fetch_github_repo_showcase",
+        lambda username, repo_list: [
+            {
+                "name": "repo-one",
+                "url": "https://github.com/saurabhhhcodes/repo-one",
+                "description": "Featured repository",
+                "language": "Python",
+                "stars": 42,
+                "forks": 5,
+            }
+        ],
+    )
+
+    with flask_app.test_client() as client:
+        response = client.get(f"/u/{user_id}")
+
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert "Featured GitHub Repositories" in html
+    assert "repo-one" in html
+    assert "Featured repository" in html
+    assert "Python" in html
+    assert "42" in html
+    assert "5" in html
+
+
 def test_public_profile_invalid_id_returns_400(monkeypatch):
     flask_app, _ = build_test_app(monkeypatch, extra_db_targets=(public_routes,))
 


### PR DESCRIPTION
## Summary\n- add featured GitHub repository support for profile and public profile pages\n- normalize and validate configured repository slugs before saving\n- add focused helper, route, and public-profile regression coverage\n\nCloses #367