### PR TITLE
feat: add OAuth account linking settings

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -11,6 +11,10 @@ from app.utils import utc_now
 
 auth_bp = Blueprint("auth", __name__)
 GOOGLE_OAUTH_NONCE_SESSION_KEY = "google_oauth_nonce"
+OAUTH_LINK_TARGET_USER_ID_SESSION_KEY = "oauth_link_target_user_id"
+OAUTH_SETTINGS_CSRF_SESSION_KEY = "oauth_settings_csrf_token"
+OAUTH_PROVIDER_FIELDS = {"github": "github_id", "google": "google_id"}
+OAUTH_PROVIDER_LABELS = {"github": "GitHub", "google": "Google"}
 COMMON_WEAK_PASSWORDS = {
     "12345678",
     "123456789",
@@ -21,6 +25,28 @@ COMMON_WEAK_PASSWORDS = {
     "letmein",
     "welcome1",
 }
+
+
+def link_oauth_provider(user_id, provider_field, provider_id, email=None):
+    email = (email or "").strip() or None
+    user_doc = db.user.find_one({"_id": user_id})
+    if not user_doc:
+        return None, "Unable to find the current account."
+
+    existing_provider_owner = db.user.find_one({provider_field: provider_id})
+    if existing_provider_owner and existing_provider_owner.get("_id") != user_id:
+        return None, "That provider is already linked to another account."
+
+    update_fields = {provider_field: provider_id}
+    if email and not user_doc.get("email"):
+        email_owner = db.user.find_one({"email": email})
+        if email_owner and email_owner.get("_id") != user_id:
+            return None, "That email is already linked to another account."
+        update_fields["email"] = email
+
+    db.user.update_one({"_id": user_id}, {"$set": update_fields})
+    user_doc.update(update_fields)
+    return user_doc, None
 
 
 def resolve_oauth_user(provider_field, provider_id, name, email=None):
@@ -229,6 +255,13 @@ def login_github():
     return github.authorize_redirect(redirect_uri)
 
 
+@auth_bp.route("/connect/github")
+@login_required
+def connect_github():
+    session[OAUTH_LINK_TARGET_USER_ID_SESSION_KEY] = str(current_user.id)
+    return login_github()
+
+
 @auth_bp.route("/login/github/authorize")
 def authorize_github():
     token = github.authorize_access_token()
@@ -249,6 +282,16 @@ def authorize_github():
             if email_item["primary"] and email_item["verified"]:
                 email = email_item["email"]
                 break
+
+    link_target_user_id = session.pop(OAUTH_LINK_TARGET_USER_ID_SESSION_KEY, None)
+    if current_user.is_authenticated and link_target_user_id == str(current_user.id):
+        user_doc, error = link_oauth_provider(current_user.id, "github_id", github_id, email=email)
+        if error:
+            flash(error, "danger")
+        else:
+            current_user.reload()
+            flash("GitHub is now linked to your account.", "success")
+        return redirect(url_for("profile.profile"))
 
     user_doc, action = resolve_oauth_user(
         "github_id",
@@ -273,6 +316,13 @@ def login_google():
     return google.authorize_redirect(redirect_uri, nonce=nonce)
 
 
+@auth_bp.route("/connect/google")
+@login_required
+def connect_google():
+    session[OAUTH_LINK_TARGET_USER_ID_SESSION_KEY] = str(current_user.id)
+    return login_google()
+
+
 @auth_bp.route("/login/google/authorize")
 def authorize_google():
     nonce = session.pop(GOOGLE_OAUTH_NONCE_SESSION_KEY, None)
@@ -290,6 +340,16 @@ def authorize_google():
     google_id = user_info["sub"]
     email = user_info.get("email")
 
+    link_target_user_id = session.pop(OAUTH_LINK_TARGET_USER_ID_SESSION_KEY, None)
+    if current_user.is_authenticated and link_target_user_id == str(current_user.id):
+        user_doc, error = link_oauth_provider(current_user.id, "google_id", google_id, email=email)
+        if error:
+            flash(error, "danger")
+        else:
+            current_user.reload()
+            flash("Google is now linked to your account.", "success")
+        return redirect(url_for("profile.profile"))
+
     user_doc, action = resolve_oauth_user(
         "google_id",
         google_id,
@@ -303,3 +363,40 @@ def authorize_google():
 
     login_user(UserWrapper(user_doc))
     return redirect(url_for("tracker.index"))
+
+
+@auth_bp.route("/unlink/<provider>", methods=["POST"])
+@login_required
+def unlink_oauth_provider(provider):
+    provider_field = OAUTH_PROVIDER_FIELDS.get(provider)
+    provider_label = OAUTH_PROVIDER_LABELS.get(provider, "Provider")
+    if not provider_field:
+        abort(404)
+
+    token = request.form.get("csrf_token", "")
+    expected = session.pop(OAUTH_SETTINGS_CSRF_SESSION_KEY, None)
+    if not token or not expected or token != expected:
+        abort(403)
+
+    user_doc = db.user.find_one({"_id": current_user.id}) or {}
+    if not user_doc.get(provider_field):
+        flash(f"{provider_label} is not linked to your account.", "warning")
+        return redirect(url_for("profile.profile"))
+
+    available_methods = sum(
+        1
+        for value in (
+            bool(user_doc.get("password")),
+            bool(user_doc.get("github_id")),
+            bool(user_doc.get("google_id")),
+        )
+        if value
+    )
+    if available_methods <= 1:
+        flash("Connect another sign-in method before unlinking this provider.", "danger")
+        return redirect(url_for("profile.profile"))
+
+    db.user.update_one({"_id": current_user.id}, {"$unset": {provider_field: ""}})
+    current_user.reload()
+    flash(f"{provider_label} was unlinked from your account.", "success")
+    return redirect(url_for("profile.profile"))

--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -3,8 +3,7 @@ from flask_login import current_user
 
 from app.extensions import limiter, cache
 from app.leaderboard.service import (
-    build_college_leaderboard_data,
-    build_leaderboard_data,
+    get_leaderboard_snapshot,
 )
 
 
@@ -15,31 +14,28 @@ leaderboard_bp = Blueprint("leaderboard", __name__)
 @limiter.limit("20 per minute")
 @cache.cached(timeout=300)
 def leaderboard():
-    entries = build_leaderboard_data()
+    by_cscore = get_leaderboard_snapshot("cscore")
+    by_questions = get_leaderboard_snapshot("questions")
+    by_rating = get_leaderboard_snapshot("rating")
+    by_college = get_leaderboard_snapshot("college")
 
-    by_cscore = sorted(entries, key=lambda item: item["c_score"], reverse=True)
-    by_questions = sorted(entries, key=lambda item: item["total_solved"], reverse=True)
-    by_rating = sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
-    by_college = build_college_leaderboard_data(entries)
-
-    def assign_ranks(sorted_list, key):
-        for index, entry in enumerate(sorted_list):
-            entry[f"rank_{key}"] = index + 1
-        return sorted_list
-
-    assign_ranks(by_cscore, "cscore")
-    assign_ranks(by_questions, "questions")
-    assign_ranks(by_rating, "rating")
-    assign_ranks(by_college, "college")
+    for entry in by_cscore:
+        entry["rank_cscore"] = entry["rank"]
+    for entry in by_questions:
+        entry["rank_questions"] = entry["rank"]
+    for entry in by_rating:
+        entry["rank_rating"] = entry["rank"]
+    for entry in by_college:
+        entry["rank_college"] = entry["rank"]
 
     current_user_id = str(current_user.id) if current_user.is_authenticated else None
     
     # Find current user's rank in each category
     current_user_rank = None
     if current_user_id:
-        for i, entry in enumerate(by_cscore):
+        for entry in by_cscore:
             if entry.get("user_id") == current_user_id:
-                current_user_rank = i + 1
+                current_user_rank = entry["rank"]
                 break
     
     return render_template(
@@ -138,20 +134,7 @@ def api_leaderboard():
     page = int(request.args.get("page", 1))
     per_page = min(int(request.args.get("per_page", 20)), 100)
     
-    entries = build_leaderboard_data()
-
-    if mode == "questions":
-        entries.sort(key=lambda item: item["total_solved"], reverse=True)
-    elif mode == "rating":
-        entries.sort(key=lambda item: item["lc_rating"], reverse=True)
-    elif mode == "college":
-        entries = build_college_leaderboard_data(entries)
-    else:
-        entries.sort(key=lambda item: item["c_score"], reverse=True)
-
-    # Assign ranks
-    for index, entry in enumerate(entries):
-        entry["rank"] = index + 1
+    entries = get_leaderboard_snapshot(mode)
 
     # Pagination
     total = len(entries)

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -1,5 +1,9 @@
-from app.extensions import db
+from app.extensions import cache, db
 from app.utils import compute_c_score
+
+LEADERBOARD_SNAPSHOT_CACHE_KEY = "leaderboard:snapshots:v1"
+LEADERBOARD_SNAPSHOT_TTL = 300
+LEADERBOARD_MODES = ("cscore", "questions", "rating", "college")
 
 
 def build_leaderboard_data():
@@ -111,3 +115,47 @@ def build_college_leaderboard_data(entries=None):
         key=lambda item: (item["c_score"], item["total_solved"], item["member_count"]),
         reverse=True,
     )
+
+
+def _rank_entries(entries):
+    ranked = []
+    for index, entry in enumerate(entries, start=1):
+        ranked.append({**entry, "rank": index})
+    return ranked
+
+
+def _sort_leaderboard_entries(entries, mode):
+    if mode == "questions":
+        return sorted(entries, key=lambda item: item["total_solved"], reverse=True)
+    if mode == "rating":
+        return sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
+    if mode == "college":
+        return build_college_leaderboard_data(entries)
+    return sorted(entries, key=lambda item: item["c_score"], reverse=True)
+
+
+def build_leaderboard_snapshots():
+    entries = build_leaderboard_data()
+    return {
+        mode: _rank_entries(_sort_leaderboard_entries(entries, mode))
+        for mode in LEADERBOARD_MODES
+    }
+
+
+def get_leaderboard_snapshot(mode, force_refresh=False):
+    mode = mode if mode in LEADERBOARD_MODES else "cscore"
+    snapshots = None if force_refresh else cache.get(LEADERBOARD_SNAPSHOT_CACHE_KEY)
+    if snapshots is None:
+        snapshots = build_leaderboard_snapshots()
+        cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return [dict(entry) for entry in snapshots[mode]]
+
+
+def refresh_leaderboard_snapshots():
+    snapshots = build_leaderboard_snapshots()
+    cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return snapshots
+
+
+def clear_leaderboard_snapshots():
+    cache.delete(LEADERBOARD_SNAPSHOT_CACHE_KEY)

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -1,7 +1,8 @@
 import json
+import secrets
 
 import requests
-from flask import Blueprint, current_app, jsonify, render_template, request, send_file
+from flask import Blueprint, current_app, jsonify, render_template, request, send_file, session
 from flask_login import current_user, login_required
 
 from app.extensions import db
@@ -487,6 +488,8 @@ def upload_photo():
 def profile():
     topics = list(db.topic.find().sort("position", 1))
     user = current_user
+    oauth_settings_csrf_token = secrets.token_hex(32)
+    session["oauth_settings_csrf_token"] = oauth_settings_csrf_token
 
     all_questions = list(db.question.find())
     solved_items = {question_id: progress for question_id, progress in user.progress.items() if progress.get("done")}
@@ -608,4 +611,5 @@ def profile():
         rating_history=rating_history,
         lc_badges=lc_badges,
         hr_badges=hr_badges,
+        oauth_settings_csrf_token=oauth_settings_csrf_token,
     )

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -6,6 +6,7 @@ from flask_login import current_user, login_required
 
 from app.extensions import db
 from app.extensions import limiter, cache
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.platforms.fetchers import (
     fetch_atcoder,
     fetch_coding_ninjas,
@@ -273,6 +274,7 @@ def sync_platforms():
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
 
+    clear_leaderboard_snapshots()
     cache.clear()
     return jsonify(build_sync_platforms_response(platform_status))
 
@@ -351,6 +353,7 @@ def edit_profile():
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
     return json_success()
 
 

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -3,6 +3,7 @@ from flask import Blueprint, Response, jsonify, render_template, request
 from flask_login import current_user, login_required
 
 from app.extensions import db
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.utils import json_error, json_success, utc_now
 from notes_export import build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
@@ -201,6 +202,7 @@ def update_question(question_id):
     if update_fields:
         db.user.update_one({"_id": user_id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
         return json_success(message=message)
 
     return json_success(message="No changes made")

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -230,6 +230,44 @@ body.modal-open {
     </div>
   </div>
 
+  <div class="card">
+    <div class="sec-title">Sign-In Methods</div>
+    <div class="platform-row">
+      <span><i class="bi bi-shield-lock" style="color:var(--accent);margin-right:6px" aria-hidden="true"></i>Password</span>
+      <span style="display:flex;align-items:center;gap:6px">
+        {% if user.password %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><span class="link-out">Active</span>{% else %}<span class="link-out">OAuth only</span>{% endif %}
+      </span>
+    </div>
+    <div class="platform-row">
+      <span><i class="bi bi-github" style="margin-right:6px" aria-hidden="true"></i>GitHub</span>
+      <span style="display:flex;align-items:center;gap:8px">
+        {% if user.github_id %}
+          <i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>
+          <form method="post" action="{{ url_for('auth.unlink_oauth_provider', provider='github') }}" style="margin:0">
+            <input type="hidden" name="csrf_token" value="{{ oauth_settings_csrf_token }}">
+            <button type="submit" class="add-btn" style="margin:0;padding:5px 10px" aria-label="Unlink GitHub sign-in">Unlink</button>
+          </form>
+        {% else %}
+          <a class="add-btn" href="{{ url_for('auth.connect_github') }}" style="margin:0;padding:5px 10px;text-decoration:none" aria-label="Link GitHub sign-in">Link</a>
+        {% endif %}
+      </span>
+    </div>
+    <div class="platform-row">
+      <span><i class="bi bi-google" style="color:#ea4335;margin-right:6px" aria-hidden="true"></i>Google</span>
+      <span style="display:flex;align-items:center;gap:8px">
+        {% if user.google_id %}
+          <i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>
+          <form method="post" action="{{ url_for('auth.unlink_oauth_provider', provider='google') }}" style="margin:0">
+            <input type="hidden" name="csrf_token" value="{{ oauth_settings_csrf_token }}">
+            <button type="submit" class="add-btn" style="margin:0;padding:5px 10px" aria-label="Unlink Google sign-in">Unlink</button>
+          </form>
+        {% else %}
+          <a class="add-btn" href="{{ url_for('auth.connect_google') }}" style="margin:0;padding:5px 10px;text-decoration:none" aria-label="Link Google sign-in">Link</a>
+        {% endif %}
+      </span>
+    </div>
+  </div>
+
   <div class="rank-card">
     <div style="font-size:.75rem;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">Leaderboard</div>
     <div style="font-size:.78rem;color:var(--text-secondary);margin-bottom:8px">Global Rank — Based on C Score</div>

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -62,9 +62,12 @@ def test_create_app_preserves_routes_and_blueprints(monkeypatch):
     assert "/register" in routes
     assert "/logout" in routes
     assert "/login/github" in routes
+    assert "/connect/github" in routes
     assert "/login/github/authorize" in routes
     assert "/login/google" in routes
+    assert "/connect/google" in routes
     assert "/login/google/authorize" in routes
+    assert "/unlink/<provider>" in routes
     assert "/topic/<topic_id>" in routes
     assert "/topic/<topic_id>/export-notes" in routes
     assert "/update_question/<question_id>" in routes

--- a/tests/test_leaderboard_snapshots.py
+++ b/tests/test_leaderboard_snapshots.py
@@ -1,0 +1,156 @@
+from bson import ObjectId
+
+from conftest import build_test_app, login_test_user
+from app.leaderboard.service import (
+    LEADERBOARD_SNAPSHOT_CACHE_KEY,
+    build_leaderboard_snapshots,
+    clear_leaderboard_snapshots,
+    get_leaderboard_snapshot,
+    refresh_leaderboard_snapshots,
+)
+from app.leaderboard import service as leaderboard_service
+import app.profile.routes as profile_routes
+import app.tracker.routes as tracker_routes
+
+
+class FakeCache:
+    def __init__(self):
+        self.values = {}
+        self.set_calls = []
+        self.delete_calls = []
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value, timeout=None):
+        self.values[key] = value
+        self.set_calls.append((key, timeout))
+
+    def delete(self, key):
+        self.values.pop(key, None)
+        self.delete_calls.append(key)
+
+
+def test_get_leaderboard_snapshot_uses_cached_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+    build_calls = []
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: build_calls.append("built") or {
+            "cscore": [{"user_id": "1", "rank": 1, "c_score": 42}],
+            "questions": [{"user_id": "1", "rank": 1, "total_solved": 10}],
+            "rating": [{"user_id": "1", "rank": 1, "lc_rating": 1800}],
+            "college": [{"user_id": "", "rank": 1, "college": "Alpha"}],
+        },
+    )
+
+    first = get_leaderboard_snapshot("cscore")
+    second = get_leaderboard_snapshot("questions")
+
+    assert build_calls == ["built"]
+    assert fake_cache.set_calls == [(LEADERBOARD_SNAPSHOT_CACHE_KEY, leaderboard_service.LEADERBOARD_SNAPSHOT_TTL)]
+    assert first[0]["c_score"] == 42
+    assert second[0]["total_solved"] == 10
+
+
+def test_refresh_and_clear_leaderboard_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: {
+            "cscore": [{"rank": 1}],
+            "questions": [{"rank": 1}],
+            "rating": [{"rank": 1}],
+            "college": [{"rank": 1}],
+        },
+    )
+
+    snapshots = refresh_leaderboard_snapshots()
+    clear_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert fake_cache.delete_calls == [LEADERBOARD_SNAPSHOT_CACHE_KEY]
+
+
+def test_build_leaderboard_snapshots_assigns_ranks(monkeypatch):
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_data",
+        lambda: [
+            {
+                "user_id": "1",
+                "name": "Alice",
+                "college": "Alpha",
+                "profile_photo": "",
+                "c_score": 20,
+                "total_solved": 15,
+                "dsa_done": 8,
+                "lc_total": 10,
+                "gfg_total": 2,
+                "cn_total": 1,
+                "hr_total": 0,
+                "lc_rating": 1500,
+            },
+            {
+                "user_id": "2",
+                "name": "Bob",
+                "college": "Beta",
+                "profile_photo": "",
+                "c_score": 30,
+                "total_solved": 12,
+                "dsa_done": 7,
+                "lc_total": 9,
+                "gfg_total": 1,
+                "cn_total": 0,
+                "hr_total": 0,
+                "lc_rating": 1700,
+            },
+        ],
+    )
+
+    snapshots = build_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["user_id"] == "2"
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert snapshots["questions"][0]["user_id"] == "1"
+    assert snapshots["rating"][0]["user_id"] == "2"
+    assert snapshots["college"][0]["rank"] == 1
+
+
+def test_update_question_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
+    invalidations = []
+
+    monkeypatch.setattr(tracker_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        login_test_user(client, test_db)
+        response = client.post(f"/update_question/{question_id}", json={"done": True})
+
+    assert response.status_code == 200
+    assert invalidations == ["cleared"]
+
+
+def test_edit_profile_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(profile_routes,))
+    invalidations = []
+
+    monkeypatch.setattr(profile_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        user_id = test_db.user.insert_one(
+            {"email": "user@example.com", "progress": {}, "is_admin": False, "name": "Before"}
+        ).inserted_id
+        login_test_user(client, user_id)
+        response = client.post("/edit_profile", json={"name": "After", "college": "New College"})
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert invalidations == ["cleared"]

--- a/tests/test_oauth_linking.py
+++ b/tests/test_oauth_linking.py
@@ -2,6 +2,8 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from bson import ObjectId
 
+from conftest import build_test_app, login_test_user
+
 
 EXISTING_USER_ID = ObjectId()
 
@@ -317,3 +319,86 @@ def test_resolve_oauth_user_creates_new_user_without_email(monkeypatch):
     assert action == "created"
     assert user_doc["github_id"] == str(GITHUB_USER_INFO["id"])
     assert user_doc["email"] is None
+
+
+def test_github_authorize_links_provider_for_logged_in_user(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    user_id = test_db.user.insert_one(
+        {"email": "user@example.com", "password": "hashed", "progress": {}, "is_admin": False}
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        with client.session_transaction() as sess:
+            sess["oauth_link_target_user_id"] = str(user_id)
+        with patch("app.auth.routes.github", new=_make_github_mock()):
+            resp = client.get("/login/github/authorize")
+
+    linked_user = test_db.user.find_one({"_id": user_id})
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/profile")
+    assert linked_user["github_id"] == str(GITHUB_USER_INFO["id"])
+
+
+def test_github_authorize_rejects_provider_already_linked_elsewhere(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    owner_id = test_db.user.insert_one(
+        {"email": "owner@example.com", "github_id": str(GITHUB_USER_INFO["id"]), "progress": {}, "is_admin": False}
+    ).inserted_id
+    target_id = test_db.user.insert_one(
+        {"email": "target@example.com", "password": "hashed", "progress": {}, "is_admin": False}
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, target_id)
+        with client.session_transaction() as sess:
+            sess["oauth_link_target_user_id"] = str(target_id)
+        with patch("app.auth.routes.github", new=_make_github_mock()):
+            resp = client.get("/login/github/authorize")
+
+    owner_user = test_db.user.find_one({"_id": owner_id})
+    target_user = test_db.user.find_one({"_id": target_id})
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/profile")
+    assert owner_user["github_id"] == str(GITHUB_USER_INFO["id"])
+    assert "github_id" not in target_user
+
+
+def test_unlink_oauth_provider_requires_alternative_login_method(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    user_id = test_db.user.insert_one(
+        {"email": "oauth@example.com", "github_id": "github-only", "progress": {}, "is_admin": False}
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        with client.session_transaction() as sess:
+            sess["oauth_settings_csrf_token"] = "csrf-token"
+        resp = client.post("/unlink/github", data={"csrf_token": "csrf-token"})
+
+    user_doc = test_db.user.find_one({"_id": user_id})
+    assert resp.status_code == 302
+    assert user_doc["github_id"] == "github-only"
+
+
+def test_unlink_oauth_provider_succeeds_when_password_login_exists(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    user_id = test_db.user.insert_one(
+        {
+            "email": "hybrid@example.com",
+            "password": "hashed",
+            "github_id": "github-hybrid",
+            "progress": {},
+            "is_admin": False,
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        with client.session_transaction() as sess:
+            sess["oauth_settings_csrf_token"] = "csrf-token"
+        resp = client.post("/unlink/github", data={"csrf_token": "csrf-token"})
+
+    user_doc = test_db.user.find_one({"_id": user_id})
+    assert resp.status_code == 302
+    assert "github_id" not in user_doc


### PR DESCRIPTION
## Summary
- add explicit GitHub and Google connect routes for signed-in users
- add profile-side linking and unlinking controls with CSRF protection and lockout safeguards
- add auth tests covering signed-in linking and safe unlink rules

## Testing
- python3 -m pytest tests/test_oauth_linking.py tests/test_app_factory.py tests/test_google_oauth_nonce.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/450dsa-issue-282/.pycache python3 -m py_compile app/auth/routes.py app/profile/routes.py tests/test_oauth_linking.py tests/test_app_factory.py
- git diff --check