### PR TITLE
feat: add email preference controls for users

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -122,6 +122,7 @@ def create_app(config_class=None):
         db.topic.create_index("position")
         db.question.create_index("topic")
         db.question.create_index([("problem", "text")], name="problem_text")
+        db.email_preferences.create_index("user_id", unique=True)
     except Exception:
         pass
 

--- a/app/notifications/email_preferences.py
+++ b/app/notifications/email_preferences.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+from bson import ObjectId
+from app.extensions import db
+
+
+def init_email_preferences(user_id):
+    """Create default email preferences for a new user."""
+    existing = db.email_preferences.find_one({"user_id": ObjectId(user_id)})
+    if existing:
+        return existing
+
+    prefs = {
+        "user_id": ObjectId(user_id),
+        "product_updates": True,
+        "study_reminders": True,
+        "sync_failures": True,
+        "achievement_emails": True,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+    }
+    result = db.email_preferences.insert_one(prefs)
+    prefs["_id"] = result.inserted_id
+    return prefs
+
+
+def get_email_preferences(user_id):
+    """Get email preferences for a user."""
+    return db.email_preferences.find_one({"user_id": ObjectId(user_id)})
+
+
+def update_email_preference(user_id, pref_type, enabled):
+    """Update a specific email preference."""
+    valid_types = ["product_updates", "study_reminders", "sync_failures", "achievement_emails"]
+    
+    if pref_type not in valid_types:
+        return False
+
+    result = db.email_preferences.update_one(
+        {"user_id": ObjectId(user_id)},
+        {
+            "$set": {
+                pref_type: enabled,
+                "updated_at": datetime.utcnow(),
+            }
+        },
+        upsert=True,
+    )
+    return result.modified_count > 0 or result.upserted_id is not None
+
+
+def should_send_email(user_id, email_type):
+    """Check if we should send an email to this user."""
+    if email_type not in ["product_updates", "study_reminders", "sync_failures", "achievement_emails"]:
+        return False
+
+    prefs = get_email_preferences(user_id)
+    if not prefs:
+        return False
+
+    return prefs.get(email_type, False)

--- a/app/notifications/routes.py
+++ b/app/notifications/routes.py
@@ -1,0 +1,160 @@
+from flask import jsonify, request
+from flask_login import current_user, login_required
+from app.notifications import notifications_bp
+from app.notifications.models import (
+    init_notification_preferences,
+    get_notification_preferences,
+    update_notification_permission,
+    update_notification_type,
+)
+from app.notifications.service import (
+    check_review_reminders,
+    check_goal_deadlines,
+    check_challenge_deadlines,
+)
+from app.notifications.email_preferences import (
+    init_email_preferences,
+    get_email_preferences,
+    update_email_preference,
+    should_send_email,
+)
+from app.extensions import db
+from bson import ObjectId
+
+
+@notifications_bp.route("/notifications/init", methods=["POST"])
+@login_required
+def initialize_notifications():
+    """Initialize notification preferences for user."""
+    init_notification_preferences(current_user._id)
+    return jsonify({"status": "success", "message": "Notifications initialized"})
+
+
+@notifications_bp.route("/notifications/permission", methods=["POST"])
+@login_required
+def update_permission():
+    """Update browser notification permission status."""
+    data = request.get_json()
+    permission_status = data.get("permission_status")  # granted, denied, default
+
+    if permission_status not in ["granted", "denied", "default"]:
+        return jsonify({"status": "error", "message": "Invalid permission status"}), 400
+
+    success = update_notification_permission(current_user._id, permission_status)
+    return jsonify({"status": "success" if success else "error"})
+
+
+@notifications_bp.route("/notifications/preferences", methods=["GET"])
+@login_required
+def get_preferences():
+    """Get current notification preferences."""
+    prefs = get_notification_preferences(current_user._id)
+    if not prefs:
+        prefs = init_notification_preferences(current_user._id)
+
+    # Remove MongoDB ObjectId from response
+    prefs.pop("_id", None)
+    return jsonify(prefs)
+
+
+@notifications_bp.route("/notifications/preferences/<notification_type>", methods=["PUT"])
+@login_required
+def update_preference(notification_type):
+    """Update a specific notification type preference."""
+    valid_types = ["due_goals", "reminders", "challenges"]
+    if notification_type not in valid_types:
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": f"Invalid notification type. Must be one of: {', '.join(valid_types)}",
+                }
+            ),
+            400,
+        )
+
+    data = request.get_json()
+    enabled = data.get("enabled", True)
+
+    success = update_notification_type(current_user._id, notification_type, enabled)
+    return jsonify({"status": "success" if success else "error"})
+
+
+@notifications_bp.route("/notifications/subscribe", methods=["POST"])
+@login_required
+def subscribe():
+    """Subscribe to browser notifications (legacy endpoint)."""
+    update_notification_permission(current_user._id, "granted")
+    return jsonify({"status": "success"})
+
+
+@notifications_bp.route("/notifications/unsubscribe", methods=["POST"])
+@login_required
+def unsubscribe():
+    """Unsubscribe from browser notifications (legacy endpoint)."""
+    update_notification_permission(current_user._id, "denied")
+    return jsonify({"status": "success"})
+
+
+@notifications_bp.route("/notifications/check-reminders", methods=["POST"])
+@login_required
+def check_reminders():
+    """Check and send review reminders for current user."""
+    check_review_reminders(current_user._id)
+    return jsonify({"status": "success", "message": "Reminders checked"})
+
+
+@notifications_bp.route("/notifications/check-goals", methods=["POST"])
+@login_required
+def check_goals():
+    """Check and send goal deadline notifications for current user."""
+    check_goal_deadlines(current_user._id)
+    return jsonify({"status": "success", "message": "Goal deadlines checked"})
+
+
+@notifications_bp.route("/notifications/check-challenges", methods=["POST"])
+@login_required
+def check_challenges():
+    """Check and send challenge deadline notifications for current user."""
+    check_challenge_deadlines(current_user._id)
+    return jsonify({"status": "success", "message": "Challenge deadlines checked"})
+
+
+@notifications_bp.route("/notifications/check-all", methods=["POST"])
+@login_required
+def check_all():
+    """Check all notification types for current user."""
+    check_review_reminders(current_user._id)
+    check_goal_deadlines(current_user._id)
+    check_challenge_deadlines(current_user._id)
+    return jsonify({"status": "success", "message": "All notifications checked"})
+
+
+
+@notifications_bp.route("/notifications/email-preferences", methods=["GET"])
+@login_required
+def get_email_prefs():
+    """Get user's email preferences."""
+    prefs = get_email_preferences(current_user._id)
+    if not prefs:
+        prefs = init_email_preferences(current_user._id)
+    
+    # Remove MongoDB ObjectId from response
+    prefs.pop("_id", None)
+    return jsonify(prefs)
+
+
+@notifications_bp.route("/notifications/email-preferences/<pref_type>", methods=["PUT"])
+@login_required
+def update_email_prefs(pref_type):
+    """Update a specific email preference."""
+    valid_types = ["product_updates", "study_reminders", "sync_failures", "achievement_emails"]
+    
+    if pref_type not in valid_types:
+        return jsonify({"status": "error", "message": f"Invalid preference type"}), 400
+    
+    data = request.get_json()
+    enabled = data.get("enabled", True)
+    
+    success = update_email_preference(current_user._id, pref_type, enabled)
+    return jsonify({"status": "success" if success else "error"})

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -217,6 +217,34 @@ body.modal-open {
       </span>
     </div>
     <button class="add-btn ui-btn ui-btn-secondary ui-btn-block" onclick="openSyncModal()" aria-label="Add or connect coding platform accounts"><i class="bi bi-plus" aria-hidden="true"></i> Add Platform</button>
+
+        <div class="sec-title" style="margin-top:14px">Email Preferences</div>
+    <div style="font-size:.82rem;color:var(--text-secondary);margin-bottom:14px">
+      Choose which emails you want to receive:
+    </div>
+    
+    <label style="display:flex;align-items:center;gap:10px;padding:10px;border-radius:8px;cursor:pointer;margin-bottom:8px;transition:all .2s" onmouseover="this.style.background='var(--bg-secondary)'" onmouseout="this.style.background=''">
+      <input type="checkbox" id="email_product_updates" style="cursor:pointer;width:16px;height:16px">
+      <span style="flex:1;font-size:.85rem;font-weight:600;color:var(--text-primary)">Product Updates</span>
+    </label>
+    
+    <label style="display:flex;align-items:center;gap:10px;padding:10px;border-radius:8px;cursor:pointer;margin-bottom:8px;transition:all .2s" onmouseover="this.style.background='var(--bg-secondary)'" onmouseout="this.style.background=''">
+      <input type="checkbox" id="email_study_reminders" style="cursor:pointer;width:16px;height:16px">
+      <span style="flex:1;font-size:.85rem;font-weight:600;color:var(--text-primary)">Study Reminders</span>
+    </label>
+    
+    <label style="display:flex;align-items:center;gap:10px;padding:10px;border-radius:8px;cursor:pointer;margin-bottom:8px;transition:all .2s" onmouseover="this.style.background='var(--bg-secondary)'" onmouseout="this.style.background=''">
+      <input type="checkbox" id="email_sync_failures" style="cursor:pointer;width:16px;height:16px">
+      <span style="flex:1;font-size:.85rem;font-weight:600;color:var(--text-primary)">Sync Failures</span>
+    </label>
+    
+    <label style="display:flex;align-items:center;gap:10px;padding:10px;border-radius:8px;cursor:pointer;margin-bottom:8px;transition:all .2s" onmouseover="this.style.background='var(--bg-secondary)'" onmouseout="this.style.background=''">
+      <input type="checkbox" id="email_achievement_emails" style="cursor:pointer;width:16px;height:16px">
+      <span style="flex:1;font-size:.85rem;font-weight:600;color:var(--text-primary)">Achievement Emails</span>
+    </label>
+    
+    <button onclick="saveEmailPreferences()" style="width:100%;padding:8px;background:var(--accent);border:none;border-radius:8px;color:#fff;font-weight:700;font-size:.85rem;cursor:pointer;font-family:inherit;margin-top:8px">Save Preferences</button>
+
     <div class="sec-title" style="margin-top:14px">Development Stats</div>
     <div class="platform-row">
       <span><i class="bi bi-github" style="margin-right:6px" aria-hidden="true"></i>GitHub</span>
@@ -860,5 +888,58 @@ function handlePhotoUpload(e){
     if(!inp.contains(e.target) && !dd.contains(e.target)) dd.style.display='none';
   });
 })();
+
+
+window.saveEmailPreferences = async function(){
+  const prefs = {
+    product_updates: document.getElementById('email_product_updates').checked,
+    study_reminders: document.getElementById('email_study_reminders').checked,
+    sync_failures: document.getElementById('email_sync_failures').checked,
+    achievement_emails: document.getElementById('email_achievement_emails').checked,
+  };
+
+  try {
+    for (const [type, enabled] of Object.entries(prefs)) {
+      const response = await fetch(`/notifications/email-preferences/${type}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': '{{ csrf_token() }}'
+        },
+        body: JSON.stringify({ enabled })
+      });
+      
+      if (!response.ok) throw new Error('Failed to save preference');
+    }
+    
+    if (typeof showToast === 'function') {
+      showToast('✅ Email preferences saved!');
+    }
+  } catch (e) {
+    if (typeof showToast === 'function') {
+      showToast('❌ Error saving preferences');
+    }
+    console.error('Error:', e);
+  }
+};
+
+// Load preferences on page load
+window.addEventListener('DOMContentLoaded', async function() {
+  try {
+    const response = await fetch('/notifications/email-preferences', {
+      headers: {'X-CSRFToken': '{{ csrf_token() }}'}
+    });
+    
+    if (response.ok) {
+      const prefs = await response.json();
+      document.getElementById('email_product_updates').checked = prefs.product_updates || false;
+      document.getElementById('email_study_reminders').checked = prefs.study_reminders || false;
+      document.getElementById('email_sync_failures').checked = prefs.sync_failures || false;
+      document.getElementById('email_achievement_emails').checked = prefs.achievement_emails || false;
+    }
+  } catch (e) {
+    console.error('Error loading preferences:', e);
+  }
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
Closes #371 

## Overview
Users can now control which types of emails they receive. This gives them granular control over notifications without relying only on browser notifications.

## Problem Statement
Users need preferences for different types of emails:
- Product updates (new features, announcements)
- Study reminders (daily/weekly motivation)
- Sync failures (when data sync breaks)
- Achievement emails (celebration of wins)

## Solution

### Backend (Models & API)
✅ **Email Preferences Model** - Store user preferences in MongoDB
✅ **API Endpoints** - Two new endpoints:
   - `GET /notifications/email-preferences` - Fetch current preferences
   - `PUT /notifications/email-preferences/<type>` - Update specific type

### Database
✅ **email_preferences collection** - One document per user with all preference flags
✅ **Unique index on user_id** - Fast lookups

### Frontend
✅ **Settings Section** - New "Email Preferences" section on profile page
✅ **Checkboxes** - Toggle each email type on/off
✅ **Save Button** - Persists choices to backend
✅ **Load on Page Load** - Displays current preferences

### Implementation Details
- Preferences stored even before email sending is implemented
- Ready for future email integration
- CSRF protected
- Login required
- Clean, consistent UI matching existing design

## User Flow
1. User visits profile page
2. Scrolls to "Email Preferences" section
3. Sees 4 checkboxes (Product Updates, Study Reminders, Sync Failures, Achievement Emails)
4. Checks/unchecks as desired
5. Clicks "Save Preferences"
6. Preferences saved to database
7. On next page load, preferences are displayed

## Files Changed
- `app/notifications/email_preferences.py` - New model with CRUD operations
- `app/notifications/routes.py` - Added 2 new API endpoints
- `app/__init__.py` - Added database index
- `templates/profile.html` - Added UI section + JavaScript
- No breaking changes to existing features

## Testing
1. Go to profile page
2. Find "Email Preferences" section
3. Toggle checkboxes and click Save
4. Refresh page → preferences should persist
5. Open browser console → no errors

## Acceptance Criteria ✅
- ✅ Settings for product updates
- ✅ Settings for study reminders
- ✅ Settings for sync failures
- ✅ Settings for achievement emails
- ✅ Preferences stored in database
- ✅ Preferences persist across page loads
- ✅ Ready for future email implementation

Closes #371