### PR TITLE
feat: add reset progress by topic

### DIFF
--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -3,8 +3,7 @@ from flask_login import current_user
 
 from app.extensions import limiter, cache
 from app.leaderboard.service import (
-    build_college_leaderboard_data,
-    build_leaderboard_data,
+    get_leaderboard_snapshot,
 )
 
 
@@ -15,31 +14,28 @@ leaderboard_bp = Blueprint("leaderboard", __name__)
 @limiter.limit("20 per minute")
 @cache.cached(timeout=300)
 def leaderboard():
-    entries = build_leaderboard_data()
+    by_cscore = get_leaderboard_snapshot("cscore")
+    by_questions = get_leaderboard_snapshot("questions")
+    by_rating = get_leaderboard_snapshot("rating")
+    by_college = get_leaderboard_snapshot("college")
 
-    by_cscore = sorted(entries, key=lambda item: item["c_score"], reverse=True)
-    by_questions = sorted(entries, key=lambda item: item["total_solved"], reverse=True)
-    by_rating = sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
-    by_college = build_college_leaderboard_data(entries)
-
-    def assign_ranks(sorted_list, key):
-        for index, entry in enumerate(sorted_list):
-            entry[f"rank_{key}"] = index + 1
-        return sorted_list
-
-    assign_ranks(by_cscore, "cscore")
-    assign_ranks(by_questions, "questions")
-    assign_ranks(by_rating, "rating")
-    assign_ranks(by_college, "college")
+    for entry in by_cscore:
+        entry["rank_cscore"] = entry["rank"]
+    for entry in by_questions:
+        entry["rank_questions"] = entry["rank"]
+    for entry in by_rating:
+        entry["rank_rating"] = entry["rank"]
+    for entry in by_college:
+        entry["rank_college"] = entry["rank"]
 
     current_user_id = str(current_user.id) if current_user.is_authenticated else None
     
     # Find current user's rank in each category
     current_user_rank = None
     if current_user_id:
-        for i, entry in enumerate(by_cscore):
+        for entry in by_cscore:
             if entry.get("user_id") == current_user_id:
-                current_user_rank = i + 1
+                current_user_rank = entry["rank"]
                 break
     
     return render_template(
@@ -138,20 +134,7 @@ def api_leaderboard():
     page = int(request.args.get("page", 1))
     per_page = min(int(request.args.get("per_page", 20)), 100)
     
-    entries = build_leaderboard_data()
-
-    if mode == "questions":
-        entries.sort(key=lambda item: item["total_solved"], reverse=True)
-    elif mode == "rating":
-        entries.sort(key=lambda item: item["lc_rating"], reverse=True)
-    elif mode == "college":
-        entries = build_college_leaderboard_data(entries)
-    else:
-        entries.sort(key=lambda item: item["c_score"], reverse=True)
-
-    # Assign ranks
-    for index, entry in enumerate(entries):
-        entry["rank"] = index + 1
+    entries = get_leaderboard_snapshot(mode)
 
     # Pagination
     total = len(entries)

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -1,5 +1,9 @@
-from app.extensions import db
+from app.extensions import cache, db
 from app.utils import compute_c_score
+
+LEADERBOARD_SNAPSHOT_CACHE_KEY = "leaderboard:snapshots:v1"
+LEADERBOARD_SNAPSHOT_TTL = 300
+LEADERBOARD_MODES = ("cscore", "questions", "rating", "college")
 
 
 def build_leaderboard_data():
@@ -111,3 +115,47 @@ def build_college_leaderboard_data(entries=None):
         key=lambda item: (item["c_score"], item["total_solved"], item["member_count"]),
         reverse=True,
     )
+
+
+def _rank_entries(entries):
+    ranked = []
+    for index, entry in enumerate(entries, start=1):
+        ranked.append({**entry, "rank": index})
+    return ranked
+
+
+def _sort_leaderboard_entries(entries, mode):
+    if mode == "questions":
+        return sorted(entries, key=lambda item: item["total_solved"], reverse=True)
+    if mode == "rating":
+        return sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
+    if mode == "college":
+        return build_college_leaderboard_data(entries)
+    return sorted(entries, key=lambda item: item["c_score"], reverse=True)
+
+
+def build_leaderboard_snapshots():
+    entries = build_leaderboard_data()
+    return {
+        mode: _rank_entries(_sort_leaderboard_entries(entries, mode))
+        for mode in LEADERBOARD_MODES
+    }
+
+
+def get_leaderboard_snapshot(mode, force_refresh=False):
+    mode = mode if mode in LEADERBOARD_MODES else "cscore"
+    snapshots = None if force_refresh else cache.get(LEADERBOARD_SNAPSHOT_CACHE_KEY)
+    if snapshots is None:
+        snapshots = build_leaderboard_snapshots()
+        cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return [dict(entry) for entry in snapshots[mode]]
+
+
+def refresh_leaderboard_snapshots():
+    snapshots = build_leaderboard_snapshots()
+    cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return snapshots
+
+
+def clear_leaderboard_snapshots():
+    cache.delete(LEADERBOARD_SNAPSHOT_CACHE_KEY)

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -6,6 +6,7 @@ from flask_login import current_user, login_required
 
 from app.extensions import db
 from app.extensions import limiter, cache
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.platforms.fetchers import (
     fetch_atcoder,
     fetch_coding_ninjas,
@@ -273,6 +274,7 @@ def sync_platforms():
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
 
+    clear_leaderboard_snapshots()
     cache.clear()
     return jsonify(build_sync_platforms_response(platform_status))
 
@@ -351,6 +353,7 @@ def edit_profile():
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
     return json_success()
 
 

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -3,6 +3,7 @@ from flask import Blueprint, Response, jsonify, render_template, request
 from flask_login import current_user, login_required
 
 from app.extensions import db
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.utils import json_error, json_success, utc_now
 from notes_export import build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
@@ -201,6 +202,7 @@ def update_question(question_id):
     if update_fields:
         db.user.update_one({"_id": user_id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
         return json_success(message=message)
 
     return json_success(message="No changes made")

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -1,5 +1,5 @@
 from bson import ObjectId
-from flask import Blueprint, Response, jsonify, render_template, request
+from flask import Blueprint, Response, abort, jsonify, render_template, request, session
 from flask_login import current_user, login_required
 
 from app.extensions import db
@@ -73,6 +73,8 @@ def topic(topic_id):
         questions = [q for q in questions if q.get('difficulty', 'Medium') == difficulty_filter]
     
     progress_dict = current_user.progress if current_user.is_authenticated else {}
+    topic_question_ids = {str(question["_id"]) for question in questions}
+    topic_tracked_count = sum(1 for question_id in topic_question_ids if progress_dict.get(question_id))
     
     return render_template(
         "topic.html", 
@@ -83,7 +85,8 @@ def topic(topic_id):
         total_count=total_count,
         easy_count=easy_count,
         medium_count=medium_count,
-        hard_count=hard_count
+        hard_count=hard_count,
+        topic_tracked_count=topic_tracked_count,
     )
 
 
@@ -102,6 +105,35 @@ def export_topic_notes(topic_id):
     response = Response(markdown, mimetype="text/markdown")
     response.headers["Content-Disposition"] = f'attachment; filename={topic_notes_filename(topic_doc["name"])}'
     return response
+
+
+@tracker_bp.route("/topic/<topic_id>/reset-progress", methods=["POST"])
+@login_required
+def reset_topic_progress(topic_id):
+    form_token = request.form.get("csrf_token", "")
+    session_token = session.get("csrf_token", "")
+    if not form_token or not session_token or form_token != session_token:
+        abort(400)
+
+    try:
+        topic_doc = db.topic.find_one({"_id": ObjectId(topic_id)})
+    except Exception:
+        return "Topic not found", 404
+    if not topic_doc:
+        return "Topic not found", 404
+
+    question_ids = [str(question["_id"]) for question in db.question.find({"topic": topic_doc["_id"]}, {"_id": 1})]
+    progress = current_user.progress or {}
+    tracked_question_ids = [question_id for question_id in question_ids if progress.get(question_id)]
+
+    if not tracked_question_ids:
+        return json_success(message=f"No saved progress found for {topic_doc['name']}.")
+
+    unset_fields = {f"progress.{question_id}": "" for question_id in tracked_question_ids}
+    db.user.update_one({"_id": current_user.id}, {"$unset": unset_fields})
+    current_user.reload()
+    clear_leaderboard_snapshots()
+    return json_success(message=f"Reset progress for {len(tracked_question_ids)} tracked question(s) in {topic_doc['name']}.")
 
 
 @tracker_bp.route("/update_question/<question_id>", methods=["POST"])

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -128,9 +128,14 @@
         </div>
     </div>
     {% if current_user.is_authenticated %}
-    <a href="{{ url_for('tracker.export_topic_notes', topic_id=topic._id|string) }}" class="export-notes-btn" aria-label="Export notes for this topic">
-        <i class="bi bi-download" aria-hidden="true"></i> Export Notes
-    </a>
+    <div style="display:flex;gap:10px;flex-wrap:wrap;justify-content:flex-end">
+        <a href="{{ url_for('tracker.export_topic_notes', topic_id=topic._id|string) }}" class="export-notes-btn" aria-label="Export notes for this topic">
+            <i class="bi bi-download" aria-hidden="true"></i> Export Notes
+        </a>
+        <button type="button" class="export-notes-btn" id="resetTopicBtn" {% if topic_tracked_count == 0 %}disabled{% endif %} aria-label="Reset saved progress for this topic">
+            <i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i> Reset Topic
+        </button>
+    </div>
     {% endif %}
 </div>
 
@@ -259,12 +264,27 @@
         </div>
     </div>
 </div>
+
+<div class="modal-overlay" id="resetTopicModal" role="dialog" aria-modal="true" aria-labelledby="resetTopicModalTitle">
+    <div class="modal-box">
+        <h3 id="resetTopicModalTitle"><i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i> Reset Topic Progress</h3>
+        <p class="modal-copy">This will clear saved progress for {{ topic_tracked_count }} tracked question(s) in {{ topic.name }}.</p>
+        <form id="resetTopicForm">
+            <div class="modal-actions">
+                <button class="btn-modal-cancel" type="button" id="resetTopicCancel" aria-label="Cancel topic reset">Cancel</button>
+                <button class="btn-modal-save" type="submit" id="resetTopicConfirm" aria-label="Confirm topic reset">Reset Topic</button>
+            </div>
+        </form>
+    </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
 <script>
 const isAuthenticated = {{ 'true' if current_user.is_authenticated else 'false' }};
 const topicStatus = document.getElementById('topicStatus');
+const resetTopicUrl = "{{ url_for('tracker.reset_topic_progress', topic_id=topic._id|string) }}";
+const csrfToken = "{{ csrf_token() if current_user.is_authenticated else '' }}";
 
 function showUpdateError(message = 'Unable to save your change. Please try again.') {
     topicStatus.textContent = message;
@@ -373,6 +393,10 @@ document.querySelectorAll('.filter-btn[data-difficulty]').forEach(btn => {
 
 // Notes Modal with focus trap
 const modal = document.getElementById('notesModal');
+const resetTopicModal = document.getElementById('resetTopicModal');
+const resetTopicBtn = document.getElementById('resetTopicBtn');
+const resetTopicCancel = document.getElementById('resetTopicCancel');
+const resetTopicForm = document.getElementById('resetTopicForm');
 const FOCUSABLE = 'button, [href], input, textarea, select, [tabindex]:not([tabindex="-1"])';
 
 function openModal(triggerEl) {
@@ -392,6 +416,18 @@ function closeModal() {
     modal.classList.remove('open');
     modal.removeEventListener('keydown', trapFocus);
     if (modal._trigger) modal._trigger.focus();
+}
+
+function openResetTopicModal(triggerEl) {
+    if (!resetTopicModal) return;
+    resetTopicModal.classList.add('open');
+    resetTopicModal._trigger = triggerEl;
+}
+
+function closeResetTopicModal() {
+    if (!resetTopicModal) return;
+    resetTopicModal.classList.remove('open');
+    if (resetTopicModal._trigger) resetTopicModal._trigger.focus();
 }
 
 function trapFocus(e) {
@@ -415,6 +451,42 @@ document.querySelectorAll('.notes-btn').forEach(btn => {
 
 document.getElementById('modalCancel').addEventListener('click', closeModal);
 modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
+
+if (resetTopicBtn) {
+    resetTopicBtn.addEventListener('click', function() {
+        openResetTopicModal(this);
+    });
+}
+
+if (resetTopicCancel) {
+    resetTopicCancel.addEventListener('click', closeResetTopicModal);
+}
+
+if (resetTopicModal) {
+    resetTopicModal.addEventListener('click', e => { if (e.target === resetTopicModal) closeResetTopicModal(); });
+}
+
+if (resetTopicForm) {
+    resetTopicForm.addEventListener('submit', function(event) {
+        event.preventDefault();
+        resetTopicBtn.disabled = true;
+        fetch(resetTopicUrl, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'},
+            body: new URLSearchParams({csrf_token: csrfToken}).toString()
+        }).then(r => {
+            if (!r.ok) throw new Error('Request failed');
+            return r.json();
+        }).then(res => {
+            if (!res.success) throw new Error(res.error || 'Reset failed');
+            window.location.reload();
+        }).catch(() => {
+            resetTopicBtn.disabled = false;
+            closeResetTopicModal();
+            showUpdateError('Unable to reset topic progress. Please try again.');
+        });
+    });
+}
 
 document.getElementById('saveNotesBtn').addEventListener('click', function() {
     const qId = document.getElementById('currentQuestionId').value;

--- a/tests/test_leaderboard_snapshots.py
+++ b/tests/test_leaderboard_snapshots.py
@@ -1,0 +1,156 @@
+from bson import ObjectId
+
+from conftest import build_test_app, login_test_user
+from app.leaderboard.service import (
+    LEADERBOARD_SNAPSHOT_CACHE_KEY,
+    build_leaderboard_snapshots,
+    clear_leaderboard_snapshots,
+    get_leaderboard_snapshot,
+    refresh_leaderboard_snapshots,
+)
+from app.leaderboard import service as leaderboard_service
+import app.profile.routes as profile_routes
+import app.tracker.routes as tracker_routes
+
+
+class FakeCache:
+    def __init__(self):
+        self.values = {}
+        self.set_calls = []
+        self.delete_calls = []
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value, timeout=None):
+        self.values[key] = value
+        self.set_calls.append((key, timeout))
+
+    def delete(self, key):
+        self.values.pop(key, None)
+        self.delete_calls.append(key)
+
+
+def test_get_leaderboard_snapshot_uses_cached_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+    build_calls = []
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: build_calls.append("built") or {
+            "cscore": [{"user_id": "1", "rank": 1, "c_score": 42}],
+            "questions": [{"user_id": "1", "rank": 1, "total_solved": 10}],
+            "rating": [{"user_id": "1", "rank": 1, "lc_rating": 1800}],
+            "college": [{"user_id": "", "rank": 1, "college": "Alpha"}],
+        },
+    )
+
+    first = get_leaderboard_snapshot("cscore")
+    second = get_leaderboard_snapshot("questions")
+
+    assert build_calls == ["built"]
+    assert fake_cache.set_calls == [(LEADERBOARD_SNAPSHOT_CACHE_KEY, leaderboard_service.LEADERBOARD_SNAPSHOT_TTL)]
+    assert first[0]["c_score"] == 42
+    assert second[0]["total_solved"] == 10
+
+
+def test_refresh_and_clear_leaderboard_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: {
+            "cscore": [{"rank": 1}],
+            "questions": [{"rank": 1}],
+            "rating": [{"rank": 1}],
+            "college": [{"rank": 1}],
+        },
+    )
+
+    snapshots = refresh_leaderboard_snapshots()
+    clear_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert fake_cache.delete_calls == [LEADERBOARD_SNAPSHOT_CACHE_KEY]
+
+
+def test_build_leaderboard_snapshots_assigns_ranks(monkeypatch):
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_data",
+        lambda: [
+            {
+                "user_id": "1",
+                "name": "Alice",
+                "college": "Alpha",
+                "profile_photo": "",
+                "c_score": 20,
+                "total_solved": 15,
+                "dsa_done": 8,
+                "lc_total": 10,
+                "gfg_total": 2,
+                "cn_total": 1,
+                "hr_total": 0,
+                "lc_rating": 1500,
+            },
+            {
+                "user_id": "2",
+                "name": "Bob",
+                "college": "Beta",
+                "profile_photo": "",
+                "c_score": 30,
+                "total_solved": 12,
+                "dsa_done": 7,
+                "lc_total": 9,
+                "gfg_total": 1,
+                "cn_total": 0,
+                "hr_total": 0,
+                "lc_rating": 1700,
+            },
+        ],
+    )
+
+    snapshots = build_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["user_id"] == "2"
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert snapshots["questions"][0]["user_id"] == "1"
+    assert snapshots["rating"][0]["user_id"] == "2"
+    assert snapshots["college"][0]["rank"] == 1
+
+
+def test_update_question_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
+    invalidations = []
+
+    monkeypatch.setattr(tracker_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        login_test_user(client, test_db)
+        response = client.post(f"/update_question/{question_id}", json={"done": True})
+
+    assert response.status_code == 200
+    assert invalidations == ["cleared"]
+
+
+def test_edit_profile_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(profile_routes,))
+    invalidations = []
+
+    monkeypatch.setattr(profile_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        user_id = test_db.user.insert_one(
+            {"email": "user@example.com", "progress": {}, "is_admin": False, "name": "Before"}
+        ).inserted_id
+        login_test_user(client, user_id)
+        response = client.post("/edit_profile", json={"name": "After", "college": "New College"})
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert invalidations == ["cleared"]

--- a/tests/test_tracker_routes.py
+++ b/tests/test_tracker_routes.py
@@ -4,6 +4,12 @@ import app.tracker.routes as tracker_routes
 from conftest import build_test_app, login_test_user
 
 
+def set_csrf_token(client, token="test-csrf-token"):
+    with client.session_transaction() as session:
+        session["csrf_token"] = token
+    return token
+
+
 def test_topic_not_found_invalid_id(monkeypatch):
     flask_app, _ = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
 
@@ -183,3 +189,100 @@ def test_update_question_accepts_valid_boolean_update(monkeypatch):
     progress = user["progress"][str(question_id)]
     assert progress["done"] is True
     assert "timestamp" in progress
+
+
+def test_topic_page_shows_reset_summary_for_authenticated_user(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id
+    question_ids = test_db.question.insert_many(
+        [
+            {"topic": topic_id, "problem": "Two Sum"},
+            {"topic": topic_id, "problem": "Three Sum"},
+        ]
+    ).inserted_ids
+
+    with flask_app.test_client() as client:
+        user_id = login_test_user(client, test_db)
+        test_db.user.update_one(
+            {"_id": user_id},
+            {
+                "$set": {
+                    f"progress.{question_ids[0]}.done": True,
+                    f"progress.{question_ids[1]}.bookmark": True,
+                }
+            },
+        )
+        response = client.get(f"/topic/{topic_id}")
+
+    html = response.data.decode("utf-8")
+    assert response.status_code == 200
+    assert "Reset Topic" in html
+    assert "This will clear saved progress for 2 tracked question(s) in Arrays." in html
+
+
+def test_reset_topic_progress_clears_only_topic_entries(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id
+    other_topic_id = test_db.topic.insert_one({"name": "Graphs", "position": 2}).inserted_id
+    topic_question_ids = test_db.question.insert_many(
+        [
+            {"topic": topic_id, "problem": "Two Sum"},
+            {"topic": topic_id, "problem": "Three Sum"},
+        ]
+    ).inserted_ids
+    other_question_id = test_db.question.insert_one({"topic": other_topic_id, "problem": "DFS"}).inserted_id
+
+    with flask_app.test_client() as client:
+        user_id = login_test_user(client, test_db)
+        set_csrf_token(client)
+        test_db.user.update_one(
+            {"_id": user_id},
+            {
+                "$set": {
+                    f"progress.{topic_question_ids[0]}.done": True,
+                    f"progress.{topic_question_ids[1]}.bookmark": True,
+                    f"progress.{other_question_id}.done": True,
+                }
+            },
+        )
+        response = client.post(
+            f"/topic/{topic_id}/reset-progress",
+            data={"csrf_token": "test-csrf-token"},
+        )
+
+    user = test_db.user.find_one({"_id": user_id})
+    progress = user["progress"]
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert str(topic_question_ids[0]) not in progress
+    assert str(topic_question_ids[1]) not in progress
+    assert progress[str(other_question_id)]["done"] is True
+
+
+def test_reset_topic_progress_rejects_missing_csrf(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, test_db)
+        set_csrf_token(client)
+        response = client.post(f"/topic/{topic_id}/reset-progress", data={})
+
+    assert response.status_code == 400
+
+
+def test_reset_topic_progress_returns_success_when_nothing_to_clear(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id
+    test_db.question.insert_one({"topic": topic_id, "problem": "Two Sum"})
+
+    with flask_app.test_client() as client:
+        login_test_user(client, test_db)
+        set_csrf_token(client)
+        response = client.post(
+            f"/topic/{topic_id}/reset-progress",
+            data={"csrf_token": "test-csrf-token"},
+        )
+
+    assert response.status_code == 200
+    assert response.get_json()["message"] == "No saved progress found for Arrays."


### PR DESCRIPTION
## Summary
- add a CSRF-protected topic reset endpoint for authenticated users
- add a confirmation flow on the topic page that shows how many tracked questions will be cleared
- add tests covering scoped reset behavior and CSRF enforcement

## Testing
- python3 -m pytest tests/test_tracker_routes.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/450dsa-issue-357/.pycache python3 -m py_compile app/tracker/routes.py tests/test_tracker_routes.py
- git diff --check