### PR TITLE
feat: add admin question management

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -14,6 +14,8 @@ from app.extensions import db
 
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
+QUESTION_DIFFICULTIES = ("Easy", "Medium", "Hard")
+QUESTION_SORT = [("position", 1), ("_id", 1)]
 
 
 def _safe_int(value, default):
@@ -26,6 +28,31 @@ def _safe_int(value, default):
 def _tail_file(file_path, max_lines=80):
     with file_path.open("r", encoding="utf-8", errors="replace") as file_obj:
         return list(deque(file_obj, maxlen=max_lines))
+
+
+def _actor_label():
+    return current_user.name or current_user.email or str(current_user.id)
+
+
+def _write_admin_content_history(entity_type, entity_id, action, before=None, after=None):
+    db.admin_content_history.insert_one(
+        {
+            "entity_type": entity_type,
+            "entity_id": str(entity_id) if entity_id is not None else None,
+            "action": action,
+            "before": before or {},
+            "after": after or {},
+            "actor_user_id": str(current_user.id),
+            "actor_label": _actor_label(),
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+
+def _format_datetime(value):
+    if hasattr(value, "astimezone"):
+        return value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    return "-"
 
 
 def _recent_error_logs(max_entries=120):
@@ -106,6 +133,80 @@ def _build_user_query(search_term):
     return {"$or": [{"name": pattern}, {"email": pattern}]}
 
 
+def _question_payload_from_form(form_data):
+    problem = (form_data.get("problem") or "").strip()
+    url = (form_data.get("url") or "").strip()
+    url2 = (form_data.get("url2") or "").strip()
+    difficulty = (form_data.get("difficulty") or "Medium").strip()
+    topic_id = (form_data.get("topic_id") or "").strip()
+    position_raw = (form_data.get("position") or "").strip()
+
+    errors = []
+    if not problem:
+        errors.append("Problem title is required.")
+    if not url:
+        errors.append("Primary URL is required.")
+    if difficulty not in QUESTION_DIFFICULTIES:
+        errors.append("Difficulty must be Easy, Medium, or Hard.")
+    if not ObjectId.is_valid(topic_id):
+        errors.append("A valid topic is required.")
+    try:
+        position = int(position_raw)
+        if position < 0:
+            raise ValueError
+    except (TypeError, ValueError):
+        errors.append("Position must be a non-negative integer.")
+        position = 0
+
+    payload = {
+        "problem": problem,
+        "url": url,
+        "url2": url2,
+        "difficulty": difficulty,
+        "topic": ObjectId(topic_id) if ObjectId.is_valid(topic_id) else None,
+        "position": position,
+    }
+    return payload, errors
+
+
+def _topic_payload_from_form(form_data):
+    name = (form_data.get("name") or "").strip()
+    position_raw = (form_data.get("position") or "").strip()
+    errors = []
+    if not name:
+        errors.append("Topic name is required.")
+    try:
+        position = int(position_raw)
+        if position < 0:
+            raise ValueError
+    except (TypeError, ValueError):
+        errors.append("Topic position must be a non-negative integer.")
+        position = 0
+    return {"name": name, "position": position}, errors
+
+
+def _topic_choices():
+    return list(db.topic.find({}, {"name": 1, "position": 1}).sort("position", 1))
+
+
+def _question_projection():
+    return {"problem": 1, "url": 1, "url2": 1, "difficulty": 1, "topic": 1, "position": 1}
+
+
+def _recent_content_history(limit=12):
+    history = list(
+        db.admin_content_history.find(
+            {},
+            {"entity_type": 1, "entity_id": 1, "action": 1, "actor_label": 1, "created_at": 1, "after": 1},
+        )
+        .sort("created_at", -1)
+        .limit(limit)
+    )
+    for entry in history:
+        entry["created_at_display"] = _format_datetime(entry.get("created_at"))
+    return history
+
+
 @admin_bp.route("", methods=["GET"])
 @login_required
 @admin_required
@@ -143,6 +244,200 @@ def dashboard():
         stats=stats,
         logs=logs,
     )
+
+
+@admin_bp.route("/questions", methods=["GET"])
+@login_required
+@admin_required
+def question_manager():
+    search_term = request.args.get("q", "").strip()
+    topic_filter = request.args.get("topic", "").strip()
+
+    query = {}
+    if search_term:
+        query["problem"] = {"$regex": re.escape(search_term), "$options": "i"}
+    if topic_filter and ObjectId.is_valid(topic_filter):
+        query["topic"] = ObjectId(topic_filter)
+
+    questions = list(db.question.find(query, _question_projection()).sort(QUESTION_SORT))
+    topics = _topic_choices()
+    topic_lookup = {topic["_id"]: topic.get("name", "Unknown Topic") for topic in topics}
+    for question in questions:
+        question["topic_name"] = topic_lookup.get(question.get("topic"), "Unknown Topic")
+
+    return render_template(
+        "admin/questions.html",
+        questions=questions,
+        topics=topics,
+        topic_filter=topic_filter,
+        search_term=search_term,
+        history_entries=_recent_content_history(),
+    )
+
+
+@admin_bp.route("/questions/new", methods=["GET", "POST"])
+@login_required
+@admin_required
+def create_question():
+    topics = _topic_choices()
+    form_values = {"problem": "", "url": "", "url2": "", "difficulty": "Medium", "topic_id": "", "position": "0"}
+
+    if request.method == "POST":
+        form_values.update(request.form)
+        payload, errors = _question_payload_from_form(request.form)
+        if not errors:
+            result = db.question.insert_one(payload)
+            _write_admin_content_history("question", result.inserted_id, "created", after={**payload, "topic": str(payload["topic"])})
+            flash("Question created.", "success")
+            return redirect(url_for("admin.question_manager"))
+        for error in errors:
+            flash(error, "danger")
+
+    return render_template("admin/question_form.html", form_values=form_values, topics=topics, mode="create")
+
+
+@admin_bp.route("/questions/<question_id>/edit", methods=["GET", "POST"])
+@login_required
+@admin_required
+def edit_question(question_id):
+    if not ObjectId.is_valid(question_id):
+        flash("Invalid question id.", "danger")
+        return redirect(url_for("admin.question_manager"))
+
+    question = db.question.find_one({"_id": ObjectId(question_id)}, _question_projection())
+    if not question:
+        flash("Question not found.", "danger")
+        return redirect(url_for("admin.question_manager"))
+
+    topics = _topic_choices()
+    form_values = {
+        "problem": question.get("problem", ""),
+        "url": question.get("url", ""),
+        "url2": question.get("url2", ""),
+        "difficulty": question.get("difficulty", "Medium"),
+        "topic_id": str(question.get("topic") or ""),
+        "position": str(question.get("position", 0)),
+    }
+
+    if request.method == "POST":
+        form_values.update(request.form)
+        payload, errors = _question_payload_from_form(request.form)
+        if not errors:
+            before = {
+                "problem": question.get("problem", ""),
+                "url": question.get("url", ""),
+                "url2": question.get("url2", ""),
+                "difficulty": question.get("difficulty", "Medium"),
+                "topic": str(question.get("topic") or ""),
+                "position": question.get("position", 0),
+            }
+            db.question.update_one({"_id": question["_id"]}, {"$set": payload})
+            _write_admin_content_history("question", question["_id"], "updated", before=before, after={**payload, "topic": str(payload["topic"])})
+            flash("Question updated.", "success")
+            return redirect(url_for("admin.question_manager"))
+        for error in errors:
+            flash(error, "danger")
+
+    return render_template("admin/question_form.html", form_values=form_values, topics=topics, mode="edit", question_id=question_id)
+
+
+@admin_bp.route("/questions/<question_id>/delete", methods=["POST"])
+@login_required
+@admin_required
+def delete_question(question_id):
+    form_token = request.form.get("csrf_token", "")
+    session_token = session.get("csrf_token", "")
+    if not form_token or not session_token or form_token != session_token:
+        abort(400)
+    if not ObjectId.is_valid(question_id):
+        flash("Invalid question id.", "danger")
+        return redirect(url_for("admin.question_manager"))
+    question = db.question.find_one({"_id": ObjectId(question_id)}, _question_projection())
+    if not question:
+        flash("Question not found.", "danger")
+        return redirect(url_for("admin.question_manager"))
+    db.question.delete_one({"_id": question["_id"]})
+    _write_admin_content_history(
+        "question",
+        question["_id"],
+        "deleted",
+        before={
+            "problem": question.get("problem", ""),
+            "difficulty": question.get("difficulty", "Medium"),
+            "topic": str(question.get("topic") or ""),
+            "position": question.get("position", 0),
+        },
+    )
+    flash("Question deleted.", "success")
+    return redirect(url_for("admin.question_manager"))
+
+
+@admin_bp.route("/topics/new", methods=["GET", "POST"])
+@login_required
+@admin_required
+def create_topic():
+    form_values = {"name": "", "position": "0"}
+    if request.method == "POST":
+        form_values.update(request.form)
+        payload, errors = _topic_payload_from_form(request.form)
+        if not errors:
+            result = db.topic.insert_one(payload)
+            _write_admin_content_history("topic", result.inserted_id, "created", after=payload)
+            flash("Topic created.", "success")
+            return redirect(url_for("admin.question_manager"))
+        for error in errors:
+            flash(error, "danger")
+    return render_template("admin/topic_form.html", form_values=form_values, mode="create")
+
+
+@admin_bp.route("/topics/<topic_id>/edit", methods=["GET", "POST"])
+@login_required
+@admin_required
+def edit_topic(topic_id):
+    if not ObjectId.is_valid(topic_id):
+        flash("Invalid topic id.", "danger")
+        return redirect(url_for("admin.question_manager"))
+    topic = db.topic.find_one({"_id": ObjectId(topic_id)}, {"name": 1, "position": 1})
+    if not topic:
+        flash("Topic not found.", "danger")
+        return redirect(url_for("admin.question_manager"))
+    form_values = {"name": topic.get("name", ""), "position": str(topic.get("position", 0))}
+    if request.method == "POST":
+        form_values.update(request.form)
+        payload, errors = _topic_payload_from_form(request.form)
+        if not errors:
+            before = {"name": topic.get("name", ""), "position": topic.get("position", 0)}
+            db.topic.update_one({"_id": topic["_id"]}, {"$set": payload})
+            _write_admin_content_history("topic", topic["_id"], "updated", before=before, after=payload)
+            flash("Topic updated.", "success")
+            return redirect(url_for("admin.question_manager"))
+        for error in errors:
+            flash(error, "danger")
+    return render_template("admin/topic_form.html", form_values=form_values, mode="edit", topic_id=topic_id)
+
+
+@admin_bp.route("/topics/<topic_id>/delete", methods=["POST"])
+@login_required
+@admin_required
+def delete_topic(topic_id):
+    form_token = request.form.get("csrf_token", "")
+    session_token = session.get("csrf_token", "")
+    if not form_token or not session_token or form_token != session_token:
+        abort(400)
+    if not ObjectId.is_valid(topic_id):
+        flash("Invalid topic id.", "danger")
+        return redirect(url_for("admin.question_manager"))
+    topic = db.topic.find_one({"_id": ObjectId(topic_id)}, {"name": 1, "position": 1})
+    if not topic:
+        flash("Topic not found.", "danger")
+        return redirect(url_for("admin.question_manager"))
+    if db.question.count_documents({"topic": topic["_id"]}) > 0:
+        flash("Delete or move the topic's questions before deleting the topic.", "warning")
+        return redirect(url_for("admin.question_manager"))
+    db.topic.delete_one({"_id": topic["_id"]})
+    _write_admin_content_history("topic", topic["_id"], "deleted", before={"name": topic.get("name", ""), "position": topic.get("position", 0)})
+    flash("Topic deleted.", "success")
+    return redirect(url_for("admin.question_manager"))
 
 
 @admin_bp.route("/users/<user_id>/delete", methods=["POST"])

--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -3,8 +3,7 @@ from flask_login import current_user
 
 from app.extensions import limiter, cache
 from app.leaderboard.service import (
-    build_college_leaderboard_data,
-    build_leaderboard_data,
+    get_leaderboard_snapshot,
 )
 
 
@@ -15,31 +14,28 @@ leaderboard_bp = Blueprint("leaderboard", __name__)
 @limiter.limit("20 per minute")
 @cache.cached(timeout=300)
 def leaderboard():
-    entries = build_leaderboard_data()
+    by_cscore = get_leaderboard_snapshot("cscore")
+    by_questions = get_leaderboard_snapshot("questions")
+    by_rating = get_leaderboard_snapshot("rating")
+    by_college = get_leaderboard_snapshot("college")
 
-    by_cscore = sorted(entries, key=lambda item: item["c_score"], reverse=True)
-    by_questions = sorted(entries, key=lambda item: item["total_solved"], reverse=True)
-    by_rating = sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
-    by_college = build_college_leaderboard_data(entries)
-
-    def assign_ranks(sorted_list, key):
-        for index, entry in enumerate(sorted_list):
-            entry[f"rank_{key}"] = index + 1
-        return sorted_list
-
-    assign_ranks(by_cscore, "cscore")
-    assign_ranks(by_questions, "questions")
-    assign_ranks(by_rating, "rating")
-    assign_ranks(by_college, "college")
+    for entry in by_cscore:
+        entry["rank_cscore"] = entry["rank"]
+    for entry in by_questions:
+        entry["rank_questions"] = entry["rank"]
+    for entry in by_rating:
+        entry["rank_rating"] = entry["rank"]
+    for entry in by_college:
+        entry["rank_college"] = entry["rank"]
 
     current_user_id = str(current_user.id) if current_user.is_authenticated else None
     
     # Find current user's rank in each category
     current_user_rank = None
     if current_user_id:
-        for i, entry in enumerate(by_cscore):
+        for entry in by_cscore:
             if entry.get("user_id") == current_user_id:
-                current_user_rank = i + 1
+                current_user_rank = entry["rank"]
                 break
     
     return render_template(
@@ -138,20 +134,7 @@ def api_leaderboard():
     page = int(request.args.get("page", 1))
     per_page = min(int(request.args.get("per_page", 20)), 100)
     
-    entries = build_leaderboard_data()
-
-    if mode == "questions":
-        entries.sort(key=lambda item: item["total_solved"], reverse=True)
-    elif mode == "rating":
-        entries.sort(key=lambda item: item["lc_rating"], reverse=True)
-    elif mode == "college":
-        entries = build_college_leaderboard_data(entries)
-    else:
-        entries.sort(key=lambda item: item["c_score"], reverse=True)
-
-    # Assign ranks
-    for index, entry in enumerate(entries):
-        entry["rank"] = index + 1
+    entries = get_leaderboard_snapshot(mode)
 
     # Pagination
     total = len(entries)

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -1,5 +1,9 @@
-from app.extensions import db
+from app.extensions import cache, db
 from app.utils import compute_c_score
+
+LEADERBOARD_SNAPSHOT_CACHE_KEY = "leaderboard:snapshots:v1"
+LEADERBOARD_SNAPSHOT_TTL = 300
+LEADERBOARD_MODES = ("cscore", "questions", "rating", "college")
 
 
 def build_leaderboard_data():
@@ -111,3 +115,47 @@ def build_college_leaderboard_data(entries=None):
         key=lambda item: (item["c_score"], item["total_solved"], item["member_count"]),
         reverse=True,
     )
+
+
+def _rank_entries(entries):
+    ranked = []
+    for index, entry in enumerate(entries, start=1):
+        ranked.append({**entry, "rank": index})
+    return ranked
+
+
+def _sort_leaderboard_entries(entries, mode):
+    if mode == "questions":
+        return sorted(entries, key=lambda item: item["total_solved"], reverse=True)
+    if mode == "rating":
+        return sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
+    if mode == "college":
+        return build_college_leaderboard_data(entries)
+    return sorted(entries, key=lambda item: item["c_score"], reverse=True)
+
+
+def build_leaderboard_snapshots():
+    entries = build_leaderboard_data()
+    return {
+        mode: _rank_entries(_sort_leaderboard_entries(entries, mode))
+        for mode in LEADERBOARD_MODES
+    }
+
+
+def get_leaderboard_snapshot(mode, force_refresh=False):
+    mode = mode if mode in LEADERBOARD_MODES else "cscore"
+    snapshots = None if force_refresh else cache.get(LEADERBOARD_SNAPSHOT_CACHE_KEY)
+    if snapshots is None:
+        snapshots = build_leaderboard_snapshots()
+        cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return [dict(entry) for entry in snapshots[mode]]
+
+
+def refresh_leaderboard_snapshots():
+    snapshots = build_leaderboard_snapshots()
+    cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return snapshots
+
+
+def clear_leaderboard_snapshots():
+    cache.delete(LEADERBOARD_SNAPSHOT_CACHE_KEY)

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -6,6 +6,7 @@ from flask_login import current_user, login_required
 
 from app.extensions import db
 from app.extensions import limiter, cache
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.platforms.fetchers import (
     fetch_atcoder,
     fetch_coding_ninjas,
@@ -273,6 +274,7 @@ def sync_platforms():
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
 
+    clear_leaderboard_snapshots()
     cache.clear()
     return jsonify(build_sync_platforms_response(platform_status))
 
@@ -351,6 +353,7 @@ def edit_profile():
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
     return json_success()
 
 

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -10,6 +10,7 @@ from progress_export import build_progress_csv
 
 
 tracker_bp = Blueprint("tracker", __name__)
+QUESTION_SORT = [("position", 1), ("_id", 1)]
 
 
 @tracker_bp.route("/")
@@ -58,7 +59,7 @@ def topic(topic_id):
     if not topic_doc:
         return "Topic not found", 404
 
-    questions = list(db.question.find({"topic": topic_doc["_id"]}))
+    questions = list(db.question.find({"topic": topic_doc["_id"]}).sort(QUESTION_SORT))
     
     # Calculate counts based on the unfiltered list of questions
     total_count = len(questions)
@@ -97,7 +98,7 @@ def export_topic_notes(topic_id):
     if not topic_doc:
         return "Topic not found", 404
 
-    questions = list(db.question.find({"topic": topic_doc["_id"]}))
+    questions = list(db.question.find({"topic": topic_doc["_id"]}).sort(QUESTION_SORT))
     markdown = build_topic_notes_markdown(topic_doc["name"], questions, current_user.progress)
     response = Response(markdown, mimetype="text/markdown")
     response.headers["Content-Disposition"] = f'attachment; filename={topic_notes_filename(topic_doc["name"])}'
@@ -220,7 +221,7 @@ def bookmarks():
             object_ids.append(ObjectId(question_id))
         except Exception:
             pass
-    questions = list(db.question.find({"_id": {"$in": object_ids}}))
+    questions = list(db.question.find({"_id": {"$in": object_ids}}).sort(QUESTION_SORT))
 
     topic_ids = list(set(question["topic"] for question in questions))
     topic_docs = {topic["_id"]: topic["name"] for topic in db.topic.find({"_id": {"$in": topic_ids}})}
@@ -233,7 +234,7 @@ def bookmarks():
 @tracker_bp.route("/export/csv")
 @login_required
 def export_csv():
-    questions = list(db.question.find())
+    questions = list(db.question.find().sort(QUESTION_SORT))
     topic_ids = list({q.get('topic') for q in questions if q.get('topic')})
     topic_lookup = {
         topic['_id']: topic.get('name', 'Unknown')

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -3,6 +3,7 @@ from flask import Blueprint, Response, jsonify, render_template, request
 from flask_login import current_user, login_required
 
 from app.extensions import db
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.utils import json_error, json_success, utc_now
 from notes_export import build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
@@ -201,6 +202,7 @@ def update_question(question_id):
     if update_fields:
         db.user.update_one({"_id": user_id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
         return json_success(message=message)
 
     return json_success(message="No changes made")

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -308,6 +308,9 @@
         <h1 class="admin-title">Admin Dashboard</h1>
         <p class="admin-subtitle">Manage users, monitor activity, and review recent server errors.</p>
     </div>
+    <div>
+        <a class="action-btn" href="{{ url_for('admin.question_manager') }}"><i class="bi bi-kanban"></i> Manage Questions</a>
+    </div>
 </section>
 
 <section class="stats-grid">

--- a/templates/admin/question_form.html
+++ b/templates/admin/question_form.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+
+{% block content %}
+<style>
+.form-shell { max-width: 860px; display:grid; gap:16px; }
+.back-btn { display:inline-flex; align-items:center; gap:8px; color:var(--text-secondary); text-decoration:none; font-size:0.85rem; font-weight:600; padding:7px 14px; border:1px solid var(--border-color); border-radius:8px; transition:all 0.2s; width:max-content; }
+.back-btn:hover { border-color:var(--accent); color:var(--accent); text-decoration:none; }
+.panel { background:var(--bg-card); border:1px solid var(--border-color); border-radius:14px; padding:18px; }
+.form-title { font-size:1.5rem; font-weight:800; margin-bottom:6px; }
+.form-subtitle { color:var(--text-secondary); font-size:0.9rem; margin-bottom:16px; }
+.form-grid { display:grid; grid-template-columns: 1fr 1fr; gap:14px; }
+.field { display:grid; gap:6px; }
+.field.full { grid-column:1 / -1; }
+.label { font-size:0.8rem; font-weight:700; color:var(--text-secondary); text-transform:uppercase; letter-spacing:0.06em; }
+.input,.select { width:100%; background:var(--bg-secondary); border:1px solid var(--border-color); color:var(--text-primary); border-radius:10px; padding:10px 12px; font:inherit; }
+.input:focus,.select:focus { outline:none; border-color:var(--accent); }
+.actions { display:flex; justify-content:flex-end; gap:10px; margin-top:18px; flex-wrap:wrap; }
+.btn { display:inline-flex; align-items:center; gap:6px; border-radius:9px; border:1px solid var(--border-color); background:transparent; color:var(--text-secondary); font-weight:700; font-size:0.84rem; padding:9px 14px; text-decoration:none; }
+.btn.primary { background:var(--accent); border-color:var(--accent); color:#fff; }
+@media (max-width: 700px) { .form-grid { grid-template-columns:1fr; } }
+</style>
+
+<section class="form-shell">
+  <a class="back-btn" href="{{ url_for('admin.question_manager') }}"><i class="bi bi-arrow-left"></i> Back to Question Manager</a>
+  <article class="panel">
+    <h1 class="form-title">{% if mode == 'edit' %}Edit Question{% else %}Add Question{% endif %}</h1>
+    <p class="form-subtitle">Manage problem title, links, difficulty, topic, and display position.</p>
+
+    <form method="POST" action="{% if mode == 'edit' %}{{ url_for('admin.edit_question', question_id=question_id) }}{% else %}{{ url_for('admin.create_question') }}{% endif %}">
+      <div class="form-grid">
+        <div class="field full">
+          <label class="label" for="problem">Problem Title</label>
+          <input class="input" id="problem" name="problem" value="{{ form_values.problem }}" required>
+        </div>
+        <div class="field full">
+          <label class="label" for="url">Primary URL</label>
+          <input class="input" id="url" name="url" value="{{ form_values.url }}" required>
+        </div>
+        <div class="field full">
+          <label class="label" for="url2">Secondary URL</label>
+          <input class="input" id="url2" name="url2" value="{{ form_values.url2 }}">
+        </div>
+        <div class="field">
+          <label class="label" for="difficulty">Difficulty</label>
+          <select class="select" id="difficulty" name="difficulty">
+            {% for difficulty in ['Easy', 'Medium', 'Hard'] %}
+            <option value="{{ difficulty }}" {% if form_values.difficulty == difficulty %}selected{% endif %}>{{ difficulty }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="field">
+          <label class="label" for="position">Position</label>
+          <input class="input" id="position" name="position" value="{{ form_values.position }}" inputmode="numeric" required>
+        </div>
+        <div class="field full">
+          <label class="label" for="topic_id">Topic</label>
+          <select class="select" id="topic_id" name="topic_id" required>
+            <option value="">Select topic</option>
+            {% for topic in topics %}
+            <option value="{{ topic._id }}" {% if form_values.topic_id == topic._id|string %}selected{% endif %}>{{ topic.name }} ({{ topic.position }})</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+      <div class="actions">
+        <a class="btn" href="{{ url_for('admin.question_manager') }}">Cancel</a>
+        <button class="btn primary" type="submit">{% if mode == 'edit' %}Save Changes{% else %}Create Question{% endif %}</button>
+      </div>
+    </form>
+  </article>
+</section>
+{% endblock %}

--- a/templates/admin/questions.html
+++ b/templates/admin/questions.html
@@ -1,0 +1,179 @@
+{% extends "base.html" %}
+
+{% block content %}
+<style>
+.admin-shell { display:grid; gap:16px; }
+.admin-header { display:flex; justify-content:space-between; align-items:flex-start; gap:12px; flex-wrap:wrap; }
+.admin-title { font-size:1.7rem; font-weight:800; }
+.admin-subtitle { color:var(--text-secondary); font-size:0.92rem; }
+.action-row { display:flex; gap:10px; flex-wrap:wrap; }
+.action-btn { display:inline-flex; align-items:center; justify-content:center; gap:6px; border-radius:9px; border:1px solid var(--border-color); background:transparent; color:var(--text-secondary); font-weight:600; font-size:0.8rem; padding:8px 12px; text-decoration:none; }
+.action-btn:hover { border-color:var(--accent); color:var(--accent); text-decoration:none; }
+.action-btn.primary { background:var(--accent); color:#fff; border-color:var(--accent); }
+.panel-grid { display:grid; grid-template-columns: 1.4fr 1fr; gap:16px; align-items:start; }
+.panel-stack { display:grid; gap:16px; }
+.panel { background:var(--bg-card); border:1px solid var(--border-color); border-radius:14px; padding:16px; }
+.panel-title-row { display:flex; justify-content:space-between; align-items:center; gap:10px; flex-wrap:wrap; margin-bottom:12px; }
+.panel-title { font-size:1.05rem; font-weight:700; }
+.panel-subtitle { color:var(--text-secondary); font-size:0.82rem; }
+.search-form { display:flex; gap:10px; align-items:center; flex-wrap:wrap; margin-bottom:12px; }
+.search-input,.search-select { background:var(--bg-secondary); border:1px solid var(--border-color); color:var(--text-primary); border-radius:9px; padding:9px 12px; min-width:180px; }
+.table-wrap { overflow-x:auto; }
+.data-table { width:100%; border-collapse:collapse; min-width:740px; }
+.data-table th,.data-table td { padding:11px 8px; border-bottom:1px solid var(--border-subtle); text-align:left; vertical-align:top; }
+.data-table th { font-size:0.78rem; color:var(--text-secondary); text-transform:uppercase; letter-spacing:0.08em; }
+.data-table td { font-size:0.9rem; }
+.question-name { font-weight:700; color:var(--text-primary); }
+.question-url { display:block; color:var(--text-secondary); font-size:0.8rem; max-width:260px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.topic-chip,.difficulty-chip { display:inline-flex; align-items:center; border-radius:999px; padding:4px 10px; font-size:0.74rem; font-weight:700; border:1px solid var(--border-color); }
+.difficulty-chip.easy { color:#22c55e; border-color:rgba(34,197,94,0.35); }
+.difficulty-chip.medium { color:#f59e0b; border-color:rgba(245,158,11,0.35); }
+.difficulty-chip.hard { color:#ef4444; border-color:rgba(239,68,68,0.35); }
+.actions-cell { display:flex; gap:8px; flex-wrap:wrap; }
+.small-btn { display:inline-flex; align-items:center; gap:6px; border-radius:8px; border:1px solid var(--border-color); background:transparent; color:var(--text-secondary); padding:6px 10px; font-size:0.76rem; font-weight:700; text-decoration:none; }
+.small-btn:hover { border-color:var(--accent); color:var(--accent); text-decoration:none; }
+.small-btn.danger { color:#f87171; border-color:rgba(239,68,68,0.35); }
+.topic-list,.history-list { display:grid; gap:10px; }
+.topic-item,.history-item { background:var(--bg-secondary); border:1px solid var(--border-subtle); border-radius:12px; padding:12px; }
+.topic-top,.history-top { display:flex; justify-content:space-between; gap:10px; align-items:center; flex-wrap:wrap; }
+.topic-name,.history-title { font-weight:700; }
+.topic-meta,.history-meta { color:var(--text-secondary); font-size:0.8rem; margin-top:6px; }
+.topic-actions { display:flex; gap:8px; flex-wrap:wrap; margin-top:10px; }
+.empty-state { color:var(--text-secondary); font-size:0.88rem; }
+@media (max-width: 980px) { .panel-grid { grid-template-columns:1fr; } }
+</style>
+
+<section class="admin-shell">
+  <div class="admin-header">
+    <div>
+      <h1 class="admin-title">Question Management</h1>
+      <p class="admin-subtitle">Edit seeded content safely, adjust order, and keep an audit trail for admin content changes.</p>
+    </div>
+    <div class="action-row">
+      <a class="action-btn" href="{{ url_for('admin.dashboard') }}"><i class="bi bi-arrow-left"></i> Admin Dashboard</a>
+      <a class="action-btn" href="{{ url_for('admin.create_topic') }}"><i class="bi bi-folder-plus"></i> Add Topic</a>
+      <a class="action-btn primary" href="{{ url_for('admin.create_question') }}"><i class="bi bi-plus-circle"></i> Add Question</a>
+    </div>
+  </div>
+
+  <div class="panel-grid">
+    <article class="panel">
+      <div class="panel-title-row">
+        <div>
+          <h2 class="panel-title">Questions</h2>
+          <p class="panel-subtitle">{{ questions|length }} question{% if questions|length != 1 %}s{% endif %} shown</p>
+        </div>
+      </div>
+
+      <form class="search-form" method="GET" action="{{ url_for('admin.question_manager') }}">
+        <input class="search-input" type="text" name="q" value="{{ search_term }}" placeholder="Search by problem title" aria-label="Search questions">
+        <select class="search-select" name="topic" aria-label="Filter by topic">
+          <option value="">All topics</option>
+          {% for topic in topics %}
+          <option value="{{ topic._id }}" {% if topic_filter == topic._id|string %}selected{% endif %}>{{ topic.name }}</option>
+          {% endfor %}
+        </select>
+        <button class="action-btn" type="submit"><i class="bi bi-search"></i> Filter</button>
+        {% if search_term or topic_filter %}
+        <a class="action-btn" href="{{ url_for('admin.question_manager') }}">Clear</a>
+        {% endif %}
+      </form>
+
+      <div class="table-wrap">
+        <table class="data-table" aria-label="Question management table">
+          <thead>
+            <tr>
+              <th>Problem</th>
+              <th>Topic</th>
+              <th>Difficulty</th>
+              <th>Position</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% if questions %}
+              {% for question in questions %}
+              <tr>
+                <td>
+                  <div class="question-name">{{ question.problem }}</div>
+                  <span class="question-url">{{ question.url }}</span>
+                  {% if question.url2 %}<span class="question-url">{{ question.url2 }}</span>{% endif %}
+                </td>
+                <td><span class="topic-chip">{{ question.topic_name }}</span></td>
+                <td><span class="difficulty-chip {{ question.difficulty|lower }}">{{ question.difficulty }}</span></td>
+                <td>{{ question.position or 0 }}</td>
+                <td>
+                  <div class="actions-cell">
+                    <a class="small-btn" href="{{ url_for('admin.edit_question', question_id=question._id|string) }}"><i class="bi bi-pencil-square"></i> Edit</a>
+                    <form method="POST" action="{{ url_for('admin.delete_question', question_id=question._id|string) }}">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                      <button class="small-btn danger" type="submit"><i class="bi bi-trash3-fill"></i> Delete</button>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+              {% endfor %}
+            {% else %}
+              <tr><td colspan="5" class="empty-state">No questions matched the current filters.</td></tr>
+            {% endif %}
+          </tbody>
+        </table>
+      </div>
+    </article>
+
+    <div class="panel-stack">
+      <article class="panel">
+        <div class="panel-title-row">
+          <div>
+            <h2 class="panel-title">Topics</h2>
+            <p class="panel-subtitle">Manage names and sort order before editing linked questions.</p>
+          </div>
+        </div>
+        <div class="topic-list">
+          {% for topic in topics %}
+          <article class="topic-item">
+            <div class="topic-top">
+              <span class="topic-name">{{ topic.name }}</span>
+              <span class="topic-chip">Position {{ topic.position }}</span>
+            </div>
+            <div class="topic-actions">
+              <a class="small-btn" href="{{ url_for('admin.edit_topic', topic_id=topic._id|string) }}"><i class="bi bi-pencil-square"></i> Edit</a>
+              <form method="POST" action="{{ url_for('admin.delete_topic', topic_id=topic._id|string) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button class="small-btn danger" type="submit"><i class="bi bi-trash3-fill"></i> Delete</button>
+              </form>
+            </div>
+          </article>
+          {% endfor %}
+        </div>
+      </article>
+
+      <article class="panel">
+        <div class="panel-title-row">
+          <div>
+            <h2 class="panel-title">Recent Edit History</h2>
+            <p class="panel-subtitle">Safe edit trail for question and topic changes.</p>
+          </div>
+        </div>
+        <div class="history-list">
+          {% if history_entries %}
+            {% for entry in history_entries %}
+            <article class="history-item">
+              <div class="history-top">
+                <span class="history-title">{{ entry.entity_type|title }} {{ entry.action|title }}</span>
+                <span class="topic-chip">{{ entry.created_at_display }}</span>
+              </div>
+              <div class="history-meta">
+                {{ entry.actor_label }} · {{ entry.after.problem or entry.after.name or entry.entity_id }}
+              </div>
+            </article>
+            {% endfor %}
+          {% else %}
+            <p class="empty-state">No admin content changes recorded yet.</p>
+          {% endif %}
+        </div>
+      </article>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/admin/topic_form.html
+++ b/templates/admin/topic_form.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block content %}
+<style>
+.form-shell { max-width: 720px; display:grid; gap:16px; }
+.back-btn { display:inline-flex; align-items:center; gap:8px; color:var(--text-secondary); text-decoration:none; font-size:0.85rem; font-weight:600; padding:7px 14px; border:1px solid var(--border-color); border-radius:8px; transition:all 0.2s; width:max-content; }
+.back-btn:hover { border-color:var(--accent); color:var(--accent); text-decoration:none; }
+.panel { background:var(--bg-card); border:1px solid var(--border-color); border-radius:14px; padding:18px; }
+.form-title { font-size:1.5rem; font-weight:800; margin-bottom:6px; }
+.form-subtitle { color:var(--text-secondary); font-size:0.9rem; margin-bottom:16px; }
+.field { display:grid; gap:6px; margin-bottom:14px; }
+.label { font-size:0.8rem; font-weight:700; color:var(--text-secondary); text-transform:uppercase; letter-spacing:0.06em; }
+.input { width:100%; background:var(--bg-secondary); border:1px solid var(--border-color); color:var(--text-primary); border-radius:10px; padding:10px 12px; font:inherit; }
+.input:focus { outline:none; border-color:var(--accent); }
+.actions { display:flex; justify-content:flex-end; gap:10px; flex-wrap:wrap; margin-top:18px; }
+.btn { display:inline-flex; align-items:center; gap:6px; border-radius:9px; border:1px solid var(--border-color); background:transparent; color:var(--text-secondary); font-weight:700; font-size:0.84rem; padding:9px 14px; text-decoration:none; }
+.btn.primary { background:var(--accent); border-color:var(--accent); color:#fff; }
+</style>
+
+<section class="form-shell">
+  <a class="back-btn" href="{{ url_for('admin.question_manager') }}"><i class="bi bi-arrow-left"></i> Back to Question Manager</a>
+  <article class="panel">
+    <h1 class="form-title">{% if mode == 'edit' %}Edit Topic{% else %}Add Topic{% endif %}</h1>
+    <p class="form-subtitle">Manage topic names and ordering before curating linked questions.</p>
+
+    <form method="POST" action="{% if mode == 'edit' %}{{ url_for('admin.edit_topic', topic_id=topic_id) }}{% else %}{{ url_for('admin.create_topic') }}{% endif %}">
+      <div class="field">
+        <label class="label" for="name">Topic Name</label>
+        <input class="input" id="name" name="name" value="{{ form_values.name }}" required>
+      </div>
+      <div class="field">
+        <label class="label" for="position">Position</label>
+        <input class="input" id="position" name="position" value="{{ form_values.position }}" inputmode="numeric" required>
+      </div>
+      <div class="actions">
+        <a class="btn" href="{{ url_for('admin.question_manager') }}">Cancel</a>
+        <button class="btn primary" type="submit">{% if mode == 'edit' %}Save Changes{% else %}Create Topic{% endif %}</button>
+      </div>
+    </form>
+  </article>
+</section>
+{% endblock %}

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -6,6 +6,7 @@ from bson import ObjectId
 import app as app_module
 import app.admin.routes as admin_routes
 import app.auth.routes as auth_routes
+import app.tracker.routes as tracker_routes
 
 
 def create_test_app(monkeypatch):
@@ -14,6 +15,7 @@ def create_test_app(monkeypatch):
     monkeypatch.setattr(app_module, "db", test_db)
     monkeypatch.setattr(admin_routes, "db", test_db)
     monkeypatch.setattr(auth_routes, "db", test_db)
+    monkeypatch.setattr(tracker_routes, "db", test_db)
 
     monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app: None)
     monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
@@ -217,3 +219,116 @@ def test_non_admin_cannot_delete_users(monkeypatch):
 
     assert response.status_code == 403
     assert test_db.user.find_one({"_id": victim_id}) is not None
+
+
+def test_admin_can_create_question_with_history(monkeypatch):
+    flask_app, test_db = create_test_app(monkeypatch)
+    admin_id = test_db.user.insert_one({"name": "Admin", "email": "admin@example.com", "is_admin": True, "progress": {}}).inserted_id
+    topic_id = test_db.topic.insert_one({"name": "Array", "position": 0}).inserted_id
+
+    with flask_app.test_client() as client:
+        login_as(client, admin_id)
+        response = client.post(
+            "/admin/questions/new",
+            data={
+                "problem": "Two Sum",
+                "url": "https://leetcode.com/problems/two-sum/",
+                "url2": "",
+                "difficulty": "Easy",
+                "topic_id": str(topic_id),
+                "position": "3",
+            },
+            follow_redirects=True,
+        )
+
+    assert response.status_code == 200
+    created = test_db.question.find_one({"problem": "Two Sum"})
+    assert created is not None
+    assert created["position"] == 3
+    history = test_db.admin_content_history.find_one({"entity_type": "question", "action": "created"})
+    assert history is not None
+    assert history["after"]["problem"] == "Two Sum"
+
+
+def test_admin_can_edit_topic_and_delete_empty_topic(monkeypatch):
+    flask_app, test_db = create_test_app(monkeypatch)
+    admin_id = test_db.user.insert_one({"name": "Admin", "email": "admin@example.com", "is_admin": True, "progress": {}}).inserted_id
+    topic_id = test_db.topic.insert_one({"name": "Graphs", "position": 7}).inserted_id
+
+    with flask_app.test_client() as client:
+        login_as(client, admin_id)
+        response = client.post(
+            f"/admin/topics/{topic_id}/edit",
+            data={"name": "Graph Theory", "position": "6"},
+            follow_redirects=True,
+        )
+        csrf_token = set_csrf_token(client)
+        delete_response = client.post(
+            f"/admin/topics/{topic_id}/delete",
+            data={"csrf_token": csrf_token},
+            follow_redirects=True,
+        )
+
+    assert response.status_code == 200
+    assert delete_response.status_code == 200
+    assert test_db.topic.find_one({"_id": topic_id}) is None
+    assert test_db.admin_content_history.find_one({"entity_type": "topic", "action": "updated"}) is not None
+    assert test_db.admin_content_history.find_one({"entity_type": "topic", "action": "deleted"}) is not None
+
+
+def test_admin_question_manager_renders_question_and_history(monkeypatch):
+    flask_app, test_db = create_test_app(monkeypatch)
+    admin_id = test_db.user.insert_one({"name": "Admin", "email": "admin@example.com", "is_admin": True, "progress": {}}).inserted_id
+    topic_id = test_db.topic.insert_one({"name": "Dynamic Programming", "position": 4}).inserted_id
+    question_id = test_db.question.insert_one(
+        {
+            "problem": "Longest Increasing Subsequence",
+            "url": "https://leetcode.com/problems/longest-increasing-subsequence/",
+            "url2": "",
+            "difficulty": "Medium",
+            "topic": topic_id,
+            "position": 2,
+        }
+    ).inserted_id
+    test_db.admin_content_history.insert_one(
+        {
+            "entity_type": "question",
+            "entity_id": str(question_id),
+            "action": "updated",
+            "after": {"problem": "Longest Increasing Subsequence"},
+            "actor_label": "Admin",
+            "created_at": datetime(2026, 5, 26, 12, 0, tzinfo=timezone.utc),
+        }
+    )
+
+    with flask_app.test_client() as client:
+        login_as(client, admin_id)
+        response = client.get("/admin/questions?q=Longest")
+
+    body = response.data.decode("utf-8")
+    assert response.status_code == 200
+    assert "Question Management" in body
+    assert "Longest Increasing Subsequence" in body
+    assert "Dynamic Programming" in body
+    assert "Recent Edit History" in body
+    assert "Admin" in body
+
+
+def test_admin_cannot_delete_topic_with_questions(monkeypatch):
+    flask_app, test_db = create_test_app(monkeypatch)
+    admin_id = test_db.user.insert_one({"name": "Admin", "email": "admin@example.com", "is_admin": True, "progress": {}}).inserted_id
+    topic_id = test_db.topic.insert_one({"name": "Greedy", "position": 5}).inserted_id
+    test_db.question.insert_one({"problem": "Jump Game", "url": "https://leetcode.com/problems/jump-game/", "url2": "", "difficulty": "Medium", "topic": topic_id, "position": 1})
+
+    with flask_app.test_client() as client:
+        login_as(client, admin_id)
+        csrf_token = set_csrf_token(client)
+        response = client.post(
+            f"/admin/topics/{topic_id}/delete",
+            data={"csrf_token": csrf_token},
+            follow_redirects=True,
+        )
+
+    assert response.status_code == 200
+    assert test_db.topic.find_one({"_id": topic_id}) is not None
+    assert "Delete or move the topic&#39;s questions before deleting the topic." in response.data.decode("utf-8")

--- a/tests/test_leaderboard_snapshots.py
+++ b/tests/test_leaderboard_snapshots.py
@@ -1,0 +1,156 @@
+from bson import ObjectId
+
+from conftest import build_test_app, login_test_user
+from app.leaderboard.service import (
+    LEADERBOARD_SNAPSHOT_CACHE_KEY,
+    build_leaderboard_snapshots,
+    clear_leaderboard_snapshots,
+    get_leaderboard_snapshot,
+    refresh_leaderboard_snapshots,
+)
+from app.leaderboard import service as leaderboard_service
+import app.profile.routes as profile_routes
+import app.tracker.routes as tracker_routes
+
+
+class FakeCache:
+    def __init__(self):
+        self.values = {}
+        self.set_calls = []
+        self.delete_calls = []
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value, timeout=None):
+        self.values[key] = value
+        self.set_calls.append((key, timeout))
+
+    def delete(self, key):
+        self.values.pop(key, None)
+        self.delete_calls.append(key)
+
+
+def test_get_leaderboard_snapshot_uses_cached_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+    build_calls = []
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: build_calls.append("built") or {
+            "cscore": [{"user_id": "1", "rank": 1, "c_score": 42}],
+            "questions": [{"user_id": "1", "rank": 1, "total_solved": 10}],
+            "rating": [{"user_id": "1", "rank": 1, "lc_rating": 1800}],
+            "college": [{"user_id": "", "rank": 1, "college": "Alpha"}],
+        },
+    )
+
+    first = get_leaderboard_snapshot("cscore")
+    second = get_leaderboard_snapshot("questions")
+
+    assert build_calls == ["built"]
+    assert fake_cache.set_calls == [(LEADERBOARD_SNAPSHOT_CACHE_KEY, leaderboard_service.LEADERBOARD_SNAPSHOT_TTL)]
+    assert first[0]["c_score"] == 42
+    assert second[0]["total_solved"] == 10
+
+
+def test_refresh_and_clear_leaderboard_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: {
+            "cscore": [{"rank": 1}],
+            "questions": [{"rank": 1}],
+            "rating": [{"rank": 1}],
+            "college": [{"rank": 1}],
+        },
+    )
+
+    snapshots = refresh_leaderboard_snapshots()
+    clear_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert fake_cache.delete_calls == [LEADERBOARD_SNAPSHOT_CACHE_KEY]
+
+
+def test_build_leaderboard_snapshots_assigns_ranks(monkeypatch):
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_data",
+        lambda: [
+            {
+                "user_id": "1",
+                "name": "Alice",
+                "college": "Alpha",
+                "profile_photo": "",
+                "c_score": 20,
+                "total_solved": 15,
+                "dsa_done": 8,
+                "lc_total": 10,
+                "gfg_total": 2,
+                "cn_total": 1,
+                "hr_total": 0,
+                "lc_rating": 1500,
+            },
+            {
+                "user_id": "2",
+                "name": "Bob",
+                "college": "Beta",
+                "profile_photo": "",
+                "c_score": 30,
+                "total_solved": 12,
+                "dsa_done": 7,
+                "lc_total": 9,
+                "gfg_total": 1,
+                "cn_total": 0,
+                "hr_total": 0,
+                "lc_rating": 1700,
+            },
+        ],
+    )
+
+    snapshots = build_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["user_id"] == "2"
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert snapshots["questions"][0]["user_id"] == "1"
+    assert snapshots["rating"][0]["user_id"] == "2"
+    assert snapshots["college"][0]["rank"] == 1
+
+
+def test_update_question_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
+    invalidations = []
+
+    monkeypatch.setattr(tracker_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        login_test_user(client, test_db)
+        response = client.post(f"/update_question/{question_id}", json={"done": True})
+
+    assert response.status_code == 200
+    assert invalidations == ["cleared"]
+
+
+def test_edit_profile_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(profile_routes,))
+    invalidations = []
+
+    monkeypatch.setattr(profile_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        user_id = test_db.user.insert_one(
+            {"email": "user@example.com", "progress": {}, "is_admin": False, "name": "Before"}
+        ).inserted_id
+        login_test_user(client, user_id)
+        response = client.post("/edit_profile", json={"name": "After", "college": "New College"})
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert invalidations == ["cleared"]


### PR DESCRIPTION
## Summary
- add an admin question-management UI with question and topic create/edit/delete flows
- validate problem fields, topic selection, difficulty, and position, while recording safe content-history entries for admin edits
- make tracker topic views and exports respect question position ordering so managed ordering is visible to users

## Testing
- python3 -m pytest tests/test_admin_routes.py -q
- python3 -m pytest tests/test_tracker_routes.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/450dsa-issue-295/.pycache python3 -m py_compile app/admin/routes.py app/tracker/routes.py tests/test_admin_routes.py
- git diff --check