### PR TITLE
feat: add admin custom sheet import

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -1,5 +1,8 @@
 import math
 import re
+import csv
+import io
+import json
 from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
@@ -14,6 +17,8 @@ from app.extensions import db
 
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
+QUESTION_DIFFICULTIES = ("Easy", "Medium", "Hard")
+IMPORT_PREVIEW_SESSION_KEY = "admin_sheet_import_preview"
 
 
 def _safe_int(value, default):
@@ -26,6 +31,171 @@ def _safe_int(value, default):
 def _tail_file(file_path, max_lines=80):
     with file_path.open("r", encoding="utf-8", errors="replace") as file_obj:
         return list(deque(file_obj, maxlen=max_lines))
+
+
+def _load_import_records_from_upload(file_storage):
+    filename = (file_storage.filename or "").strip().lower()
+    raw_text = file_storage.read().decode("utf-8")
+    if filename.endswith(".json"):
+        return "json", json.loads(raw_text)
+    if filename.endswith(".csv"):
+        reader = csv.DictReader(io.StringIO(raw_text))
+        return "csv", list(reader)
+    raise ValueError("Only .json and .csv sheet uploads are supported.")
+
+
+def _normalize_import_rows(kind, payload):
+    if kind == "json":
+        rows = []
+        for topic in payload:
+            topic_name = (topic.get("topicName") or "").strip()
+            topic_position = topic.get("position", 0)
+            for question_position, question in enumerate(topic.get("questions") or []):
+                rows.append(
+                    {
+                        "topic_name": topic_name,
+                        "topic_position": topic_position,
+                        "problem": (question.get("Problem") or "").strip(),
+                        "url": (question.get("URL") or "").strip(),
+                        "url2": (question.get("URL2") or "").strip(),
+                        "difficulty": (question.get("difficulty") or "Medium").strip(),
+                        "position": question.get("position", question_position),
+                    }
+                )
+        return rows
+
+    rows = []
+    for row in payload:
+        rows.append(
+            {
+                "topic_name": (row.get("topic_name") or row.get("topic") or "").strip(),
+                "topic_position": row.get("topic_position", 0),
+                "problem": (row.get("problem") or "").strip(),
+                "url": (row.get("url") or "").strip(),
+                "url2": (row.get("url2") or "").strip(),
+                "difficulty": (row.get("difficulty") or "Medium").strip(),
+                "position": row.get("position", 0),
+            }
+        )
+    return rows
+
+
+def _build_import_preview(rows):
+    errors = []
+    normalized_rows = []
+    seen_topics = {}
+    seen_questions = set()
+
+    for index, row in enumerate(rows, start=1):
+        topic_name = row.get("topic_name", "").strip()
+        problem = row.get("problem", "").strip()
+        url = row.get("url", "").strip()
+        url2 = row.get("url2", "").strip()
+        difficulty = row.get("difficulty", "Medium").strip()
+
+        try:
+            topic_position = int(row.get("topic_position", 0))
+            if topic_position < 0:
+                raise ValueError
+        except (TypeError, ValueError):
+            errors.append(f"Row {index}: topic_position must be a non-negative integer.")
+            topic_position = 0
+
+        try:
+            position = int(row.get("position", 0))
+            if position < 0:
+                raise ValueError
+        except (TypeError, ValueError):
+            errors.append(f"Row {index}: position must be a non-negative integer.")
+            position = 0
+
+        if not topic_name:
+            errors.append(f"Row {index}: topic_name is required.")
+        if not problem:
+            errors.append(f"Row {index}: problem is required.")
+        if not url:
+            errors.append(f"Row {index}: url is required.")
+        if difficulty not in QUESTION_DIFFICULTIES:
+            errors.append(f"Row {index}: difficulty must be Easy, Medium, or Hard.")
+        if url and not re.match(r"^https?://", url):
+            errors.append(f"Row {index}: url must start with http:// or https://.")
+        if url2 and not re.match(r"^https?://", url2):
+            errors.append(f"Row {index}: url2 must start with http:// or https://.")
+
+        topic_key = topic_name.lower()
+        if topic_key in seen_topics and seen_topics[topic_key] != topic_position:
+            errors.append(f"Row {index}: topic '{topic_name}' uses conflicting topic_position values.")
+        seen_topics.setdefault(topic_key, topic_position)
+
+        duplicate_key = (topic_key, problem.lower(), url.lower())
+        if duplicate_key in seen_questions:
+            errors.append(f"Row {index}: duplicate question row detected for '{problem}'.")
+        seen_questions.add(duplicate_key)
+
+        normalized_rows.append(
+            {
+                "topic_name": topic_name,
+                "topic_position": topic_position,
+                "problem": problem,
+                "url": url,
+                "url2": url2,
+                "difficulty": difficulty,
+                "position": position,
+            }
+        )
+
+    preview_topics = []
+    for topic_name_key, topic_position in sorted(seen_topics.items(), key=lambda item: item[1]):
+        topic_name = next(row["topic_name"] for row in normalized_rows if row["topic_name"].lower() == topic_name_key)
+        preview_topics.append({"name": topic_name, "position": topic_position})
+
+    return {
+        "rows": normalized_rows,
+        "errors": errors,
+        "topics": preview_topics,
+        "question_count": len(normalized_rows),
+        "topic_count": len(preview_topics),
+    }
+
+
+def _commit_import_preview(preview):
+    inserted_topic_ids = []
+    inserted_question_ids = []
+    topic_ids = {}
+
+    try:
+        for topic in preview["topics"]:
+            existing = db.topic.find_one({"name": topic["name"]}, {"_id": 1})
+            if existing:
+                db.topic.update_one({"_id": existing["_id"]}, {"$set": {"position": topic["position"]}})
+                topic_ids[topic["name"].lower()] = existing["_id"]
+            else:
+                result = db.topic.insert_one({"name": topic["name"], "position": topic["position"]})
+                inserted_topic_ids.append(result.inserted_id)
+                topic_ids[topic["name"].lower()] = result.inserted_id
+
+        question_docs = []
+        for row in preview["rows"]:
+            question_docs.append(
+                {
+                    "topic": topic_ids[row["topic_name"].lower()],
+                    "problem": row["problem"],
+                    "url": row["url"],
+                    "url2": row["url2"],
+                    "difficulty": row["difficulty"],
+                    "position": row["position"],
+                }
+            )
+
+        if question_docs:
+            result = db.question.insert_many(question_docs)
+            inserted_question_ids.extend(result.inserted_ids)
+    except Exception:
+        if inserted_question_ids:
+            db.question.delete_many({"_id": {"$in": inserted_question_ids}})
+        if inserted_topic_ids:
+            db.topic.delete_many({"_id": {"$in": inserted_topic_ids}})
+        raise
 
 
 def _recent_error_logs(max_entries=120):
@@ -143,6 +313,56 @@ def dashboard():
         stats=stats,
         logs=logs,
     )
+
+
+@admin_bp.route("/import-sheet", methods=["GET", "POST"])
+@login_required
+@admin_required
+def import_sheet():
+    preview = session.get(IMPORT_PREVIEW_SESSION_KEY)
+    if request.method == "POST":
+        file_storage = request.files.get("sheet_file")
+        if not file_storage or not file_storage.filename:
+            flash("Upload a JSON or CSV sheet file first.", "danger")
+            return render_template("admin/import_sheet.html", preview=preview)
+
+        try:
+            kind, payload = _load_import_records_from_upload(file_storage)
+            rows = _normalize_import_rows(kind, payload)
+            preview = _build_import_preview(rows)
+            session[IMPORT_PREVIEW_SESSION_KEY] = preview
+        except Exception as exc:
+            preview = None
+            session.pop(IMPORT_PREVIEW_SESSION_KEY, None)
+            flash(f"Import preview failed: {exc}", "danger")
+
+    return render_template("admin/import_sheet.html", preview=preview)
+
+
+@admin_bp.route("/import-sheet/confirm", methods=["POST"])
+@login_required
+@admin_required
+def confirm_import_sheet():
+    form_token = request.form.get("csrf_token", "")
+    session_token = session.get("csrf_token", "")
+    if not form_token or not session_token or form_token != session_token:
+        abort(400)
+
+    preview = session.get(IMPORT_PREVIEW_SESSION_KEY)
+    if not preview:
+        flash("No validated import preview found. Upload a sheet first.", "warning")
+        return redirect(url_for("admin.import_sheet"))
+    if preview.get("errors"):
+        flash("Fix the preview errors before importing.", "danger")
+        return redirect(url_for("admin.import_sheet"))
+
+    _commit_import_preview(preview)
+    session.pop(IMPORT_PREVIEW_SESSION_KEY, None)
+    flash(
+        f"Imported {preview['question_count']} questions across {preview['topic_count']} topics.",
+        "success",
+    )
+    return redirect(url_for("admin.dashboard"))
 
 
 @admin_bp.route("/users/<user_id>/delete", methods=["POST"])

--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -3,8 +3,7 @@ from flask_login import current_user
 
 from app.extensions import limiter, cache
 from app.leaderboard.service import (
-    build_college_leaderboard_data,
-    build_leaderboard_data,
+    get_leaderboard_snapshot,
 )
 
 
@@ -15,31 +14,28 @@ leaderboard_bp = Blueprint("leaderboard", __name__)
 @limiter.limit("20 per minute")
 @cache.cached(timeout=300)
 def leaderboard():
-    entries = build_leaderboard_data()
+    by_cscore = get_leaderboard_snapshot("cscore")
+    by_questions = get_leaderboard_snapshot("questions")
+    by_rating = get_leaderboard_snapshot("rating")
+    by_college = get_leaderboard_snapshot("college")
 
-    by_cscore = sorted(entries, key=lambda item: item["c_score"], reverse=True)
-    by_questions = sorted(entries, key=lambda item: item["total_solved"], reverse=True)
-    by_rating = sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
-    by_college = build_college_leaderboard_data(entries)
-
-    def assign_ranks(sorted_list, key):
-        for index, entry in enumerate(sorted_list):
-            entry[f"rank_{key}"] = index + 1
-        return sorted_list
-
-    assign_ranks(by_cscore, "cscore")
-    assign_ranks(by_questions, "questions")
-    assign_ranks(by_rating, "rating")
-    assign_ranks(by_college, "college")
+    for entry in by_cscore:
+        entry["rank_cscore"] = entry["rank"]
+    for entry in by_questions:
+        entry["rank_questions"] = entry["rank"]
+    for entry in by_rating:
+        entry["rank_rating"] = entry["rank"]
+    for entry in by_college:
+        entry["rank_college"] = entry["rank"]
 
     current_user_id = str(current_user.id) if current_user.is_authenticated else None
     
     # Find current user's rank in each category
     current_user_rank = None
     if current_user_id:
-        for i, entry in enumerate(by_cscore):
+        for entry in by_cscore:
             if entry.get("user_id") == current_user_id:
-                current_user_rank = i + 1
+                current_user_rank = entry["rank"]
                 break
     
     return render_template(
@@ -138,20 +134,7 @@ def api_leaderboard():
     page = int(request.args.get("page", 1))
     per_page = min(int(request.args.get("per_page", 20)), 100)
     
-    entries = build_leaderboard_data()
-
-    if mode == "questions":
-        entries.sort(key=lambda item: item["total_solved"], reverse=True)
-    elif mode == "rating":
-        entries.sort(key=lambda item: item["lc_rating"], reverse=True)
-    elif mode == "college":
-        entries = build_college_leaderboard_data(entries)
-    else:
-        entries.sort(key=lambda item: item["c_score"], reverse=True)
-
-    # Assign ranks
-    for index, entry in enumerate(entries):
-        entry["rank"] = index + 1
+    entries = get_leaderboard_snapshot(mode)
 
     # Pagination
     total = len(entries)

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -1,5 +1,9 @@
-from app.extensions import db
+from app.extensions import cache, db
 from app.utils import compute_c_score
+
+LEADERBOARD_SNAPSHOT_CACHE_KEY = "leaderboard:snapshots:v1"
+LEADERBOARD_SNAPSHOT_TTL = 300
+LEADERBOARD_MODES = ("cscore", "questions", "rating", "college")
 
 
 def build_leaderboard_data():
@@ -111,3 +115,47 @@ def build_college_leaderboard_data(entries=None):
         key=lambda item: (item["c_score"], item["total_solved"], item["member_count"]),
         reverse=True,
     )
+
+
+def _rank_entries(entries):
+    ranked = []
+    for index, entry in enumerate(entries, start=1):
+        ranked.append({**entry, "rank": index})
+    return ranked
+
+
+def _sort_leaderboard_entries(entries, mode):
+    if mode == "questions":
+        return sorted(entries, key=lambda item: item["total_solved"], reverse=True)
+    if mode == "rating":
+        return sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
+    if mode == "college":
+        return build_college_leaderboard_data(entries)
+    return sorted(entries, key=lambda item: item["c_score"], reverse=True)
+
+
+def build_leaderboard_snapshots():
+    entries = build_leaderboard_data()
+    return {
+        mode: _rank_entries(_sort_leaderboard_entries(entries, mode))
+        for mode in LEADERBOARD_MODES
+    }
+
+
+def get_leaderboard_snapshot(mode, force_refresh=False):
+    mode = mode if mode in LEADERBOARD_MODES else "cscore"
+    snapshots = None if force_refresh else cache.get(LEADERBOARD_SNAPSHOT_CACHE_KEY)
+    if snapshots is None:
+        snapshots = build_leaderboard_snapshots()
+        cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return [dict(entry) for entry in snapshots[mode]]
+
+
+def refresh_leaderboard_snapshots():
+    snapshots = build_leaderboard_snapshots()
+    cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return snapshots
+
+
+def clear_leaderboard_snapshots():
+    cache.delete(LEADERBOARD_SNAPSHOT_CACHE_KEY)

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -6,6 +6,7 @@ from flask_login import current_user, login_required
 
 from app.extensions import db
 from app.extensions import limiter, cache
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.platforms.fetchers import (
     fetch_atcoder,
     fetch_coding_ninjas,
@@ -273,6 +274,7 @@ def sync_platforms():
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
 
+    clear_leaderboard_snapshots()
     cache.clear()
     return jsonify(build_sync_platforms_response(platform_status))
 
@@ -351,6 +353,7 @@ def edit_profile():
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
     return json_success()
 
 

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -3,6 +3,7 @@ from flask import Blueprint, Response, jsonify, render_template, request
 from flask_login import current_user, login_required
 
 from app.extensions import db
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.utils import json_error, json_success, utc_now
 from notes_export import build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
@@ -201,6 +202,7 @@ def update_question(question_id):
     if update_fields:
         db.user.update_one({"_id": user_id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
         return json_success(message=message)
 
     return json_success(message="No changes made")

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -308,6 +308,9 @@
         <h1 class="admin-title">Admin Dashboard</h1>
         <p class="admin-subtitle">Manage users, monitor activity, and review recent server errors.</p>
     </div>
+    <div>
+        <a class="action-btn" href="{{ url_for('admin.import_sheet') }}"><i class="bi bi-upload"></i> Import Sheet</a>
+    </div>
 </section>
 
 <section class="stats-grid">

--- a/templates/admin/import_sheet.html
+++ b/templates/admin/import_sheet.html
@@ -1,0 +1,132 @@
+{% extends "base.html" %}
+
+{% block content %}
+<style>
+.import-shell { display:grid; gap:16px; max-width:1100px; }
+.top-row { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; flex-wrap:wrap; }
+.title { font-size:1.7rem; font-weight:800; }
+.subtitle { color:var(--text-secondary); font-size:0.92rem; }
+.action-btn { display:inline-flex; align-items:center; justify-content:center; gap:6px; border-radius:9px; border:1px solid var(--border-color); background:transparent; color:var(--text-secondary); font-weight:600; font-size:0.8rem; padding:8px 12px; text-decoration:none; }
+.action-btn:hover { border-color:var(--accent); color:var(--accent); text-decoration:none; }
+.panel-grid { display:grid; grid-template-columns: 1.1fr 1fr; gap:16px; align-items:start; }
+.panel { background:var(--bg-card); border:1px solid var(--border-color); border-radius:14px; padding:16px; }
+.panel-title { font-size:1.05rem; font-weight:700; margin-bottom:10px; }
+.panel-subtitle { color:var(--text-secondary); font-size:0.82rem; margin-bottom:12px; }
+.upload-form { display:grid; gap:14px; }
+.field { display:grid; gap:6px; }
+.label { font-size:0.8rem; font-weight:700; color:var(--text-secondary); text-transform:uppercase; letter-spacing:0.06em; }
+.file-input { background:var(--bg-secondary); border:1px solid var(--border-color); color:var(--text-primary); border-radius:10px; padding:10px 12px; font:inherit; }
+.submit-row { display:flex; gap:10px; flex-wrap:wrap; }
+.btn { display:inline-flex; align-items:center; gap:6px; border-radius:9px; border:1px solid var(--border-color); background:transparent; color:var(--text-secondary); font-weight:700; font-size:0.84rem; padding:9px 14px; text-decoration:none; }
+.btn.primary { background:var(--accent); border-color:var(--accent); color:#fff; }
+.format-box { background:var(--bg-secondary); border:1px solid var(--border-subtle); border-radius:12px; padding:12px; font-size:0.84rem; color:var(--text-secondary); }
+.format-box code { color:var(--text-primary); }
+.stats-row { display:flex; gap:10px; flex-wrap:wrap; margin-bottom:12px; }
+.stat-chip { display:inline-flex; align-items:center; gap:6px; border-radius:999px; padding:6px 10px; font-size:0.78rem; font-weight:700; border:1px solid var(--border-color); }
+.error-list,.topic-list { display:grid; gap:10px; margin-top:12px; }
+.error-item { border:1px solid rgba(239,68,68,0.3); background:rgba(239,68,68,0.08); color:#fca5a5; border-radius:10px; padding:10px 12px; font-size:0.84rem; }
+.topic-item { border:1px solid var(--border-subtle); background:var(--bg-secondary); border-radius:10px; padding:10px 12px; font-size:0.84rem; }
+.table-wrap { overflow-x:auto; }
+.data-table { width:100%; border-collapse:collapse; min-width:680px; }
+.data-table th,.data-table td { padding:10px 8px; border-bottom:1px solid var(--border-subtle); text-align:left; vertical-align:top; }
+.data-table th { font-size:0.78rem; color:var(--text-secondary); text-transform:uppercase; letter-spacing:0.08em; }
+.difficulty-chip { display:inline-flex; align-items:center; border-radius:999px; padding:4px 10px; font-size:0.74rem; font-weight:700; border:1px solid var(--border-color); }
+.difficulty-chip.easy { color:#22c55e; border-color:rgba(34,197,94,0.35); }
+.difficulty-chip.medium { color:#f59e0b; border-color:rgba(245,158,11,0.35); }
+.difficulty-chip.hard { color:#ef4444; border-color:rgba(239,68,68,0.35); }
+@media (max-width: 980px) { .panel-grid { grid-template-columns:1fr; } }
+</style>
+
+<section class="import-shell">
+  <div class="top-row">
+    <div>
+      <h1 class="title">Import Custom Sheet</h1>
+      <p class="subtitle">Upload a JSON or CSV sheet, preview every parsed row, then import only after the whole sheet validates cleanly.</p>
+    </div>
+    <a class="action-btn" href="{{ url_for('admin.dashboard') }}"><i class="bi bi-arrow-left"></i> Admin Dashboard</a>
+  </div>
+
+  <div class="panel-grid">
+    <article class="panel">
+      <h2 class="panel-title">Upload Sheet</h2>
+      <p class="panel-subtitle">Validation checks topic names and positions, question ordering, duplicate rows, and question URLs before anything is inserted.</p>
+      <form class="upload-form" method="POST" enctype="multipart/form-data" action="{{ url_for('admin.import_sheet') }}">
+        <div class="field">
+          <label class="label" for="sheet_file">JSON or CSV file</label>
+          <input class="file-input" id="sheet_file" name="sheet_file" type="file" accept=".json,.csv" required>
+        </div>
+        <div class="submit-row">
+          <button class="btn primary" type="submit"><i class="bi bi-eye"></i> Preview Import</button>
+        </div>
+      </form>
+
+      <div class="format-box">
+        <strong>CSV columns:</strong> <code>topic_name</code>, <code>topic_position</code>, <code>problem</code>, <code>url</code>, <code>url2</code>, <code>difficulty</code>, <code>position</code><br>
+        <strong>JSON format:</strong> same structure as <code>data.json</code> with <code>topicName</code>, <code>position</code>, and per-question <code>Problem</code>/<code>URL</code>/<code>URL2</code>/<code>difficulty</code>.
+      </div>
+    </article>
+
+    <article class="panel">
+      <h2 class="panel-title">Preview Summary</h2>
+      {% if preview %}
+      <div class="stats-row">
+        <span class="stat-chip">{{ preview.topic_count }} topics</span>
+        <span class="stat-chip">{{ preview.question_count }} questions</span>
+        <span class="stat-chip">{{ preview.errors|length }} errors</span>
+      </div>
+      <div class="topic-list">
+        {% for topic in preview.topics %}
+        <div class="topic-item">{{ topic.name }} · position {{ topic.position }}</div>
+        {% endfor %}
+      </div>
+      {% if preview.errors %}
+      <div class="error-list">
+        {% for error in preview.errors %}
+        <div class="error-item">{{ error }}</div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <form method="POST" action="{{ url_for('admin.confirm_import_sheet') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="submit-row" style="margin-top:14px;">
+          <button class="btn primary" type="submit"><i class="bi bi-database-add"></i> Import Sheet</button>
+        </div>
+      </form>
+      {% endif %}
+      {% else %}
+      <p class="panel-subtitle">Upload a sheet to see the preview here.</p>
+      {% endif %}
+    </article>
+  </div>
+
+  {% if preview %}
+  <article class="panel">
+    <h2 class="panel-title">Row Preview</h2>
+    <div class="table-wrap">
+      <table class="data-table" aria-label="Sheet row preview">
+        <thead>
+          <tr>
+            <th>Topic</th>
+            <th>Problem</th>
+            <th>Difficulty</th>
+            <th>Position</th>
+            <th>URL</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in preview.rows %}
+          <tr>
+            <td>{{ row.topic_name }} <br><small>topic position {{ row.topic_position }}</small></td>
+            <td>{{ row.problem }}</td>
+            <td><span class="difficulty-chip {{ row.difficulty|lower }}">{{ row.difficulty }}</span></td>
+            <td>{{ row.position }}</td>
+            <td>{{ row.url }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </article>
+  {% endif %}
+</section>
+{% endblock %}

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -1,3 +1,5 @@
+import io
+import json
 from datetime import datetime, timezone
 
 import mongomock
@@ -217,3 +219,79 @@ def test_non_admin_cannot_delete_users(monkeypatch):
 
     assert response.status_code == 403
     assert test_db.user.find_one({"_id": victim_id}) is not None
+
+
+def test_admin_can_preview_and_import_json_sheet(monkeypatch):
+    flask_app, test_db = create_test_app(monkeypatch)
+    admin_id = test_db.user.insert_one(
+        {"name": "Admin", "email": "admin@example.com", "is_admin": True, "progress": {}}
+    ).inserted_id
+
+    payload = [
+        {
+            "topicName": "Graphs",
+            "position": 9,
+            "questions": [
+                {
+                    "Problem": "Clone Graph",
+                    "URL": "https://leetcode.com/problems/clone-graph/",
+                    "URL2": "",
+                    "difficulty": "Medium",
+                    "position": 0,
+                }
+            ],
+        }
+    ]
+
+    with flask_app.test_client() as client:
+        login_as(client, admin_id)
+        preview_response = client.post(
+            "/admin/import-sheet",
+            data={
+                "sheet_file": (io.BytesIO(json.dumps(payload).encode("utf-8")), "custom-sheet.json"),
+            },
+            content_type="multipart/form-data",
+            follow_redirects=True,
+        )
+        csrf_token = set_csrf_token(client)
+        import_response = client.post(
+            "/admin/import-sheet/confirm",
+            data={"csrf_token": csrf_token},
+            follow_redirects=True,
+        )
+
+    assert preview_response.status_code == 200
+    preview_body = preview_response.data.decode("utf-8")
+    assert "Clone Graph" in preview_body
+    assert "Import Sheet" in preview_body
+    assert import_response.status_code == 200
+    assert test_db.topic.find_one({"name": "Graphs"}) is not None
+    assert test_db.question.find_one({"problem": "Clone Graph"}) is not None
+
+
+def test_admin_import_preview_rejects_duplicate_csv_rows(monkeypatch):
+    flask_app, test_db = create_test_app(monkeypatch)
+    admin_id = test_db.user.insert_one(
+        {"name": "Admin", "email": "admin@example.com", "is_admin": True, "progress": {}}
+    ).inserted_id
+    csv_text = "\n".join(
+        [
+            "topic_name,topic_position,problem,url,url2,difficulty,position",
+            "Array,0,Two Sum,https://leetcode.com/problems/two-sum/,,Easy,0",
+            "Array,0,Two Sum,https://leetcode.com/problems/two-sum/,,Easy,1",
+        ]
+    )
+
+    with flask_app.test_client() as client:
+        login_as(client, admin_id)
+        response = client.post(
+            "/admin/import-sheet",
+            data={"sheet_file": (io.BytesIO(csv_text.encode("utf-8")), "sheet.csv")},
+            content_type="multipart/form-data",
+            follow_redirects=True,
+        )
+
+    body = response.data.decode("utf-8")
+    assert response.status_code == 200
+    assert "duplicate question row detected" in body.lower()
+    assert test_db.question.count_documents({}) == 0

--- a/tests/test_leaderboard_snapshots.py
+++ b/tests/test_leaderboard_snapshots.py
@@ -1,0 +1,156 @@
+from bson import ObjectId
+
+from conftest import build_test_app, login_test_user
+from app.leaderboard.service import (
+    LEADERBOARD_SNAPSHOT_CACHE_KEY,
+    build_leaderboard_snapshots,
+    clear_leaderboard_snapshots,
+    get_leaderboard_snapshot,
+    refresh_leaderboard_snapshots,
+)
+from app.leaderboard import service as leaderboard_service
+import app.profile.routes as profile_routes
+import app.tracker.routes as tracker_routes
+
+
+class FakeCache:
+    def __init__(self):
+        self.values = {}
+        self.set_calls = []
+        self.delete_calls = []
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value, timeout=None):
+        self.values[key] = value
+        self.set_calls.append((key, timeout))
+
+    def delete(self, key):
+        self.values.pop(key, None)
+        self.delete_calls.append(key)
+
+
+def test_get_leaderboard_snapshot_uses_cached_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+    build_calls = []
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: build_calls.append("built") or {
+            "cscore": [{"user_id": "1", "rank": 1, "c_score": 42}],
+            "questions": [{"user_id": "1", "rank": 1, "total_solved": 10}],
+            "rating": [{"user_id": "1", "rank": 1, "lc_rating": 1800}],
+            "college": [{"user_id": "", "rank": 1, "college": "Alpha"}],
+        },
+    )
+
+    first = get_leaderboard_snapshot("cscore")
+    second = get_leaderboard_snapshot("questions")
+
+    assert build_calls == ["built"]
+    assert fake_cache.set_calls == [(LEADERBOARD_SNAPSHOT_CACHE_KEY, leaderboard_service.LEADERBOARD_SNAPSHOT_TTL)]
+    assert first[0]["c_score"] == 42
+    assert second[0]["total_solved"] == 10
+
+
+def test_refresh_and_clear_leaderboard_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: {
+            "cscore": [{"rank": 1}],
+            "questions": [{"rank": 1}],
+            "rating": [{"rank": 1}],
+            "college": [{"rank": 1}],
+        },
+    )
+
+    snapshots = refresh_leaderboard_snapshots()
+    clear_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert fake_cache.delete_calls == [LEADERBOARD_SNAPSHOT_CACHE_KEY]
+
+
+def test_build_leaderboard_snapshots_assigns_ranks(monkeypatch):
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_data",
+        lambda: [
+            {
+                "user_id": "1",
+                "name": "Alice",
+                "college": "Alpha",
+                "profile_photo": "",
+                "c_score": 20,
+                "total_solved": 15,
+                "dsa_done": 8,
+                "lc_total": 10,
+                "gfg_total": 2,
+                "cn_total": 1,
+                "hr_total": 0,
+                "lc_rating": 1500,
+            },
+            {
+                "user_id": "2",
+                "name": "Bob",
+                "college": "Beta",
+                "profile_photo": "",
+                "c_score": 30,
+                "total_solved": 12,
+                "dsa_done": 7,
+                "lc_total": 9,
+                "gfg_total": 1,
+                "cn_total": 0,
+                "hr_total": 0,
+                "lc_rating": 1700,
+            },
+        ],
+    )
+
+    snapshots = build_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["user_id"] == "2"
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert snapshots["questions"][0]["user_id"] == "1"
+    assert snapshots["rating"][0]["user_id"] == "2"
+    assert snapshots["college"][0]["rank"] == 1
+
+
+def test_update_question_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
+    invalidations = []
+
+    monkeypatch.setattr(tracker_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        login_test_user(client, test_db)
+        response = client.post(f"/update_question/{question_id}", json={"done": True})
+
+    assert response.status_code == 200
+    assert invalidations == ["cleared"]
+
+
+def test_edit_profile_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(profile_routes,))
+    invalidations = []
+
+    monkeypatch.setattr(profile_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        user_id = test_db.user.insert_one(
+            {"email": "user@example.com", "progress": {}, "is_admin": False, "name": "Before"}
+        ).inserted_id
+        login_test_user(client, user_id)
+        response = client.post("/edit_profile", json={"name": "After", "college": "New College"})
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert invalidations == ["cleared"]


### PR DESCRIPTION
## Summary
- add an admin import flow for JSON and CSV question sheets with validation-first preview
- validate topic names and positions, question ordering, URL format, and duplicate rows before any insert happens
- commit imports only after the preview is clean, so bad sheets never partially seed the database

## Testing
- python3 -m pytest tests/test_admin_routes.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/450dsa-issue-276/.pycache python3 -m py_compile app/admin/routes.py tests/test_admin_routes.py
- git diff --check