### PR TITLE
feat: add college verification workflow

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -95,6 +95,8 @@ def create_app(config_class=None):
         db.user.create_index("github_id", unique=True, sparse=True)
         db.user.create_index("google_id", unique=True, sparse=True)
         db.user.create_index("is_admin")
+        db.user.create_index("college")
+        db.user.create_index("college_verification_status")
         db.topic.create_index("name", unique=True)
         db.topic.create_index("position")
         db.question.create_index("topic")

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -11,6 +11,7 @@ from flask_login import current_user, login_required
 
 from app.decorators import admin_required
 from app.extensions import db
+from app.leaderboard.service import clear_leaderboard_snapshots
 
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
@@ -131,6 +132,14 @@ def dashboard():
 
     stats = _compute_system_stats()
     logs = _recent_error_logs(max_entries=80)
+    pending_college_verifications = list(
+        db.user.find(
+            {"college_verification_status": "pending", "college": {"$nin": ["", None]}},
+            {"name": 1, "email": 1, "college": 1},
+        )
+        .sort("_id", -1)
+        .limit(8)
+    )
 
     return render_template(
         "admin/dashboard.html",
@@ -142,6 +151,7 @@ def dashboard():
         total_pages=total_pages,
         stats=stats,
         logs=logs,
+        pending_college_verifications=pending_college_verifications,
     )
 
 
@@ -178,3 +188,38 @@ def delete_user(user_id):
     display_name = target_user.get("name") or target_user.get("email") or "user"
     flash(f"Deleted account for {display_name}.", "success")
     return redirect(url_for("admin.dashboard", q=search_term, page=page))
+
+
+@admin_bp.route("/users/<user_id>/verify-college", methods=["POST"])
+@login_required
+@admin_required
+def verify_user_college(user_id):
+    form_token = request.form.get("csrf_token", "")
+    session_token = session.get("csrf_token", "")
+    if not form_token or not session_token or form_token != session_token:
+        abort(400)
+
+    if not ObjectId.is_valid(user_id):
+        flash("Invalid user id.", "danger")
+        return redirect(url_for("admin.dashboard"))
+
+    target_id = ObjectId(user_id)
+    target_user = db.user.find_one({"_id": target_id}, {"name": 1, "email": 1, "college": 1})
+    if not target_user or not (target_user.get("college") or "").strip():
+        flash("User does not have a college to verify.", "warning")
+        return redirect(url_for("admin.dashboard"))
+
+    db.user.update_one(
+        {"_id": target_id},
+        {
+            "$set": {
+                "college_verification_status": "verified",
+                "college_verification_method": "admin",
+            }
+        },
+    )
+    clear_leaderboard_snapshots()
+
+    display_name = target_user.get("name") or target_user.get("email") or "user"
+    flash(f"Verified college for {display_name}.", "success")
+    return redirect(url_for("admin.dashboard"))

--- a/app/college_verification.py
+++ b/app/college_verification.py
@@ -1,0 +1,89 @@
+import json
+
+
+def normalize_college_name(value):
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.split()).strip().lower()
+
+
+def normalize_email_domain(email):
+    if not isinstance(email, str) or "@" not in email:
+        return ""
+    return email.rsplit("@", 1)[-1].strip().lower()
+
+
+def parse_college_domain_allowlist(raw_value):
+    if not raw_value:
+        return {}
+
+    try:
+        data = json.loads(raw_value)
+    except (TypeError, ValueError):
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    allowlist = {}
+    for college, domains in data.items():
+        normalized_college = normalize_college_name(college)
+        if not normalized_college:
+            continue
+
+        if isinstance(domains, str):
+            domains = [domains]
+        if not isinstance(domains, list):
+            continue
+
+        normalized_domains = sorted(
+            {
+                domain.strip().lower()
+                for domain in domains
+                if isinstance(domain, str) and domain.strip()
+            }
+        )
+        if normalized_domains:
+            allowlist[normalized_college] = normalized_domains
+
+    return allowlist
+
+
+def build_college_verification_updates(
+    *,
+    college,
+    email,
+    allowlist,
+    previous_college="",
+    previous_status="",
+    previous_method="",
+):
+    normalized_college = normalize_college_name(college)
+    if not normalized_college:
+        return {
+            "college_verification_status": "",
+            "college_verification_method": "",
+        }
+
+    if (
+        previous_status == "verified"
+        and previous_method == "admin"
+        and normalize_college_name(previous_college) == normalized_college
+    ):
+        return {
+            "college_verification_status": "verified",
+            "college_verification_method": "admin",
+        }
+
+    email_domain = normalize_email_domain(email)
+    allowed_domains = allowlist.get(normalized_college, [])
+    if email_domain and email_domain in allowed_domains:
+        return {
+            "college_verification_status": "verified",
+            "college_verification_method": "domain",
+        }
+
+    return {
+        "college_verification_status": "pending",
+        "college_verification_method": "",
+    }

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,7 @@
 import os
 
+from app.college_verification import parse_college_domain_allowlist
+
 
 def env_flag(name, default=False):
     value = os.environ.get(name)
@@ -31,6 +33,7 @@ class BaseConfig:
         "uiversion": 3,
     }
     RATELIMIT_STORAGE_URI = "memory://"
+    COLLEGE_DOMAIN_ALLOWLIST = {}
 
     @classmethod
     def apply_environment_overrides(cls, app):
@@ -43,6 +46,9 @@ class BaseConfig:
         app.config["RATELIMIT_STORAGE_URI"] = os.environ.get(
             "RATELIMIT_STORAGE_URI",
             cls.RATELIMIT_STORAGE_URI,
+        )
+        app.config["COLLEGE_DOMAIN_ALLOWLIST"] = parse_college_domain_allowlist(
+            os.environ.get("COLLEGE_DOMAIN_ALLOWLIST")
         )
 
 

--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -3,8 +3,7 @@ from flask_login import current_user
 
 from app.extensions import limiter, cache
 from app.leaderboard.service import (
-    build_college_leaderboard_data,
-    build_leaderboard_data,
+    get_leaderboard_snapshot,
 )
 
 
@@ -15,31 +14,28 @@ leaderboard_bp = Blueprint("leaderboard", __name__)
 @limiter.limit("20 per minute")
 @cache.cached(timeout=300)
 def leaderboard():
-    entries = build_leaderboard_data()
+    by_cscore = get_leaderboard_snapshot("cscore")
+    by_questions = get_leaderboard_snapshot("questions")
+    by_rating = get_leaderboard_snapshot("rating")
+    by_college = get_leaderboard_snapshot("college")
 
-    by_cscore = sorted(entries, key=lambda item: item["c_score"], reverse=True)
-    by_questions = sorted(entries, key=lambda item: item["total_solved"], reverse=True)
-    by_rating = sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
-    by_college = build_college_leaderboard_data(entries)
-
-    def assign_ranks(sorted_list, key):
-        for index, entry in enumerate(sorted_list):
-            entry[f"rank_{key}"] = index + 1
-        return sorted_list
-
-    assign_ranks(by_cscore, "cscore")
-    assign_ranks(by_questions, "questions")
-    assign_ranks(by_rating, "rating")
-    assign_ranks(by_college, "college")
+    for entry in by_cscore:
+        entry["rank_cscore"] = entry["rank"]
+    for entry in by_questions:
+        entry["rank_questions"] = entry["rank"]
+    for entry in by_rating:
+        entry["rank_rating"] = entry["rank"]
+    for entry in by_college:
+        entry["rank_college"] = entry["rank"]
 
     current_user_id = str(current_user.id) if current_user.is_authenticated else None
     
     # Find current user's rank in each category
     current_user_rank = None
     if current_user_id:
-        for i, entry in enumerate(by_cscore):
+        for entry in by_cscore:
             if entry.get("user_id") == current_user_id:
-                current_user_rank = i + 1
+                current_user_rank = entry["rank"]
                 break
     
     return render_template(
@@ -138,20 +134,7 @@ def api_leaderboard():
     page = int(request.args.get("page", 1))
     per_page = min(int(request.args.get("per_page", 20)), 100)
     
-    entries = build_leaderboard_data()
-
-    if mode == "questions":
-        entries.sort(key=lambda item: item["total_solved"], reverse=True)
-    elif mode == "rating":
-        entries.sort(key=lambda item: item["lc_rating"], reverse=True)
-    elif mode == "college":
-        entries = build_college_leaderboard_data(entries)
-    else:
-        entries.sort(key=lambda item: item["c_score"], reverse=True)
-
-    # Assign ranks
-    for index, entry in enumerate(entries):
-        entry["rank"] = index + 1
+    entries = get_leaderboard_snapshot(mode)
 
     # Pagination
     total = len(entries)

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -1,3 +1,4 @@
+from app.college_verification import normalize_college_name
 from app.extensions import cache, db
 from app.utils import compute_c_score
 
@@ -16,6 +17,7 @@ def build_leaderboard_data():
                 "email": 1,
                 "profile_photo": 1,
                 "college": 1,
+                "college_verification_status": 1,
                 "leetcode_username": 1,
                 "github_username": 1,
                 "gfg_username": 1,
@@ -41,6 +43,7 @@ def build_leaderboard_data():
                 "name": name,
                 "profile_photo": user.get("profile_photo", ""),
                 "college": user.get("college", ""),
+                "college_verification_status": user.get("college_verification_status", ""),
                 "leetcode_username": user.get("leetcode_username", ""),
                 "codingninjas_username": user.get("codingninjas_username", ""),
                 **stats,
@@ -59,11 +62,16 @@ def build_college_leaderboard_data(entries=None):
         college = (entry.get("college") or "").strip()
         if not college:
             continue
+        verification_status = (
+            "verified" if entry.get("college_verification_status") == "verified" else "pending"
+        )
+        college_key = (normalize_college_name(college), verification_status)
 
         college_entry = colleges.setdefault(
-            college.lower(),
+            college_key,
             {
                 "college": college,
+                "verification_status": verification_status,
                 "member_count": 0,
                 "c_score": 0,
                 "total_solved": 0,
@@ -112,7 +120,12 @@ def build_college_leaderboard_data(entries=None):
 
     return sorted(
         college_entries,
-        key=lambda item: (item["c_score"], item["total_solved"], item["member_count"]),
+        key=lambda item: (
+            item["verification_status"] == "verified",
+            item["c_score"],
+            item["total_solved"],
+            item["member_count"],
+        ),
         reverse=True,
     )
 

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -1,5 +1,9 @@
-from app.extensions import db
+from app.extensions import cache, db
 from app.utils import compute_c_score
+
+LEADERBOARD_SNAPSHOT_CACHE_KEY = "leaderboard:snapshots:v1"
+LEADERBOARD_SNAPSHOT_TTL = 300
+LEADERBOARD_MODES = ("cscore", "questions", "rating", "college")
 
 
 def build_leaderboard_data():
@@ -111,3 +115,47 @@ def build_college_leaderboard_data(entries=None):
         key=lambda item: (item["c_score"], item["total_solved"], item["member_count"]),
         reverse=True,
     )
+
+
+def _rank_entries(entries):
+    ranked = []
+    for index, entry in enumerate(entries, start=1):
+        ranked.append({**entry, "rank": index})
+    return ranked
+
+
+def _sort_leaderboard_entries(entries, mode):
+    if mode == "questions":
+        return sorted(entries, key=lambda item: item["total_solved"], reverse=True)
+    if mode == "rating":
+        return sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
+    if mode == "college":
+        return build_college_leaderboard_data(entries)
+    return sorted(entries, key=lambda item: item["c_score"], reverse=True)
+
+
+def build_leaderboard_snapshots():
+    entries = build_leaderboard_data()
+    return {
+        mode: _rank_entries(_sort_leaderboard_entries(entries, mode))
+        for mode in LEADERBOARD_MODES
+    }
+
+
+def get_leaderboard_snapshot(mode, force_refresh=False):
+    mode = mode if mode in LEADERBOARD_MODES else "cscore"
+    snapshots = None if force_refresh else cache.get(LEADERBOARD_SNAPSHOT_CACHE_KEY)
+    if snapshots is None:
+        snapshots = build_leaderboard_snapshots()
+        cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return [dict(entry) for entry in snapshots[mode]]
+
+
+def refresh_leaderboard_snapshots():
+    snapshots = build_leaderboard_snapshots()
+    cache.set(LEADERBOARD_SNAPSHOT_CACHE_KEY, snapshots, timeout=LEADERBOARD_SNAPSHOT_TTL)
+    return snapshots
+
+
+def clear_leaderboard_snapshots():
+    cache.delete(LEADERBOARD_SNAPSHOT_CACHE_KEY)

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -4,6 +4,7 @@ import requests
 from flask import Blueprint, current_app, jsonify, render_template, request, send_file
 from flask_login import current_user, login_required
 
+from app.college_verification import build_college_verification_updates
 from app.extensions import db
 from app.extensions import limiter, cache
 from app.leaderboard.service import clear_leaderboard_snapshots
@@ -351,6 +352,17 @@ def edit_profile():
     if error:
         return json_error(error, status_code=400)
     if update_fields:
+        if "college" in update_fields:
+            update_fields.update(
+                build_college_verification_updates(
+                    college=update_fields.get("college", ""),
+                    email=current_user.email,
+                    allowlist=current_app.config.get("COLLEGE_DOMAIN_ALLOWLIST", {}),
+                    previous_college=current_user.college or "",
+                    previous_status=current_user.college_verification_status or "",
+                    previous_method=current_user.college_verification_method or "",
+                )
+            )
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
         clear_leaderboard_snapshots()

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -6,6 +6,7 @@ from flask_login import current_user, login_required
 
 from app.extensions import db
 from app.extensions import limiter, cache
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.platforms.fetchers import (
     fetch_atcoder,
     fetch_coding_ninjas,
@@ -273,6 +274,7 @@ def sync_platforms():
     db.user.update_one({"_id": user_id}, {"$set": update_fields})
     current_user.reload()
 
+    clear_leaderboard_snapshots()
     cache.clear()
     return jsonify(build_sync_platforms_response(platform_status))
 
@@ -351,6 +353,7 @@ def edit_profile():
     if update_fields:
         db.user.update_one({"_id": current_user.id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
     return json_success()
 
 

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -3,6 +3,7 @@ from flask import Blueprint, Response, jsonify, render_template, request
 from flask_login import current_user, login_required
 
 from app.extensions import db
+from app.leaderboard.service import clear_leaderboard_snapshots
 from app.utils import json_error, json_success, utc_now
 from notes_export import build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
@@ -201,6 +202,7 @@ def update_question(question_id):
     if update_fields:
         db.user.update_one({"_id": user_id}, {"$set": update_fields})
         current_user.reload()
+        clear_leaderboard_snapshots()
         return json_success(message=message)
 
     return json_success(message="No changes made")

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -182,6 +182,12 @@
     background: var(--accent-dim);
 }
 
+.role-pill.pending {
+    color: #f59e0b;
+    border-color: rgba(245, 158, 11, 0.45);
+    background: rgba(245, 158, 11, 0.12);
+}
+
 .pagination-row {
     margin-top: 14px;
     display: flex;
@@ -417,6 +423,49 @@
     </article>
 
     <article class="panel">
+        <div class="panel-title-row">
+            <div>
+                <h2 class="panel-title">Pending College Verification</h2>
+                <p class="panel-subtitle">Approve colleges that could not be auto-verified by email domain.</p>
+            </div>
+        </div>
+
+        {% if pending_college_verifications %}
+        <div class="table-wrap" style="margin-bottom:16px">
+            <table class="users-table" aria-label="Pending college verifications">
+                <thead>
+                    <tr>
+                        <th>User</th>
+                        <th>College</th>
+                        <th>Action</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for user in pending_college_verifications %}
+                    <tr>
+                        <td>
+                            <div>{{ user.name or '-' }}</div>
+                            <div class="panel-subtitle">{{ user.email or '-' }}</div>
+                        </td>
+                        <td>
+                            <div>{{ user.college }}</div>
+                            <span class="role-pill pending"><i class="bi bi-hourglass-split"></i> Pending</span>
+                        </td>
+                        <td>
+                            <form method="POST" action="{{ url_for('admin.verify_user_college', user_id=user._id) }}">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button class="action-btn" type="submit"><i class="bi bi-patch-check"></i> Verify</button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="empty-state" style="margin-bottom:16px">No pending college verification requests right now.</p>
+        {% endif %}
+
         <div class="panel-title-row">
             <div>
                 <h2 class="panel-title">Recent Error Logs</h2>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -154,6 +154,19 @@
 .user-cell-name a { color: inherit; text-decoration: none; }
 .user-cell-name a:hover { color: var(--accent); text-decoration: underline; }
 .user-cell-college { font-size: 0.72rem; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 180px; }
+.verify-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 6px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  vertical-align: middle;
+}
+.verify-badge.ok { background: rgba(16,185,129,0.12); color: #10b981; border: 1px solid rgba(16,185,129,0.25); }
+.verify-badge.pending { background: rgba(245,158,11,0.12); color: #f59e0b; border: 1px solid rgba(245,158,11,0.25); }
 
 .stat-badge {
   display: inline-flex;
@@ -387,13 +400,19 @@ function renderTable(entries, mode) {
     else if (mode === 'college') score = e.c_score;
     
     const profileURL = !isCollegeMode && e.user_id ? `/u/${encodeURIComponent(e.user_id)}` : '';
+    const verificationStatus = isCollegeMode ? e.verification_status : e.college_verification_status;
+    const verificationBadge = verificationStatus === 'verified'
+      ? '<span class="verify-badge ok"><i class="bi bi-patch-check-fill" aria-hidden="true"></i>Verified</span>'
+      : verificationStatus === 'pending'
+        ? '<span class="verify-badge pending"><i class="bi bi-hourglass-split" aria-hidden="true"></i>Pending</span>'
+        : '';
     const nameHTML = isCollegeMode
-      ? `${escapeHTML(e.college)}`
+      ? `${escapeHTML(e.college)}${verificationBadge}`
       : `<a href="${profileURL}" aria-label="View profile of ${escapeHTML(e.name)}">${escapeHTML(e.name)}</a>${isMe ? '<span class="me-tag" aria-label="This is you">YOU</span>' : ''}`;
     
     const subtitleHTML = isCollegeMode
       ? `${e.member_count} coder${e.member_count === 1 ? '' : 's'} · Top: ${escapeHTML(e.top_user?.name || 'N/A')}`
-      : (escapeHTML(e.college) || '—');
+      : `${escapeHTML(e.college) || '—'}${verificationBadge}`;
     
     const dsaHTML = `<span class="stat-badge dsa">${e.dsa_done} / 450</span>`;
     

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -85,6 +85,9 @@
 .m-lbl{font-size:0.8rem;font-weight:600;color:var(--text-secondary);display:block;margin-bottom:5px}
 .m-inp{width:100%;padding:9px 12px;background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:8px;color:var(--text-primary);font-size:0.85rem;font-family:inherit;outline:none;margin-bottom:12px}
 .m-inp:focus{border-color:var(--accent)}
+.verify-pill{display:inline-flex;align-items:center;gap:6px;border-radius:999px;padding:4px 10px;font-size:.72rem;font-weight:700;border:1px solid var(--border-color)}
+.verify-pill.ok{color:#10b981;border-color:rgba(16,185,129,.4);background:rgba(16,185,129,.12)}
+.verify-pill.pending{color:#f59e0b;border-color:rgba(245,158,11,.4);background:rgba(245,158,11,.12)}
 .m-actions{display:flex;justify-content:flex-end;gap:10px;margin-top:4px}
 .m-cancel{padding:8px 16px;border:1px solid var(--border-color);border-radius:8px;background:none;color:var(--text-secondary);font-size:0.83rem;cursor:pointer;font-family:inherit}
 .m-save{padding:8px 16px;background:var(--accent);border:none;border-radius:8px;color:#fff;font-size:0.83rem;font-weight:700;cursor:pointer;font-family:inherit;display:inline-flex;align-items:center;gap:6px;transition:opacity .2s}
@@ -175,7 +178,16 @@ body.modal-open {
     </div>
     {% if user.location or user.college %}
     <div class="meta-row">{% if user.location %}<i class="bi bi-geo-alt" style="color:var(--accent)" aria-hidden="true"></i> {{ user.location }}{% endif %}</div>
-    <div class="meta-row">{% if user.college %}<i class="bi bi-mortarboard" style="color:var(--info)" aria-hidden="true"></i> {{ user.college }}{% endif %}</div>
+    <div class="meta-row">
+      {% if user.college %}
+      <i class="bi bi-mortarboard" style="color:var(--info)" aria-hidden="true"></i> {{ user.college }}
+      {% if user.college_verification_status == 'verified' %}
+      <span class="verify-pill ok"><i class="bi bi-patch-check-fill" aria-hidden="true"></i> Verified</span>
+      {% elif user.college_verification_status == 'pending' %}
+      <span class="verify-pill pending"><i class="bi bi-hourglass-split" aria-hidden="true"></i> Pending</span>
+      {% endif %}
+      {% endif %}
+    </div>
     {% else %}
     <div class="meta-row"><i class="bi bi-geo-alt" style="color:var(--accent)" aria-hidden="true"></i> India</div>
     <div class="meta-row"><i class="bi bi-mortarboard" style="color:var(--info)" aria-hidden="true"></i> Computer Science</div>
@@ -540,6 +552,11 @@ body.modal-open {
         <label class="m-lbl"><i class="bi bi-mortarboard"></i> College / University</label>
         <input class="m-inp" id="ep_college" placeholder="Start typing to search globally..." value="{{ user.college or '' }}" autocomplete="off">
         <div id="collegeDropdown" style="display:none;position:absolute;top:100%;left:0;right:0;max-height:200px;overflow-y:auto;background:var(--bg-card);border:1px solid var(--accent);border-radius:0 0 10px 10px;z-index:100;margin-top:-13px;box-shadow:0 8px 24px rgba(0,0,0,.4)"></div>
+        {% if user.college_verification_status == 'verified' %}
+        <div style="font-size:.72rem;color:#10b981;margin-top:-4px">Verified for leaderboard rankings.</div>
+        {% else %}
+        <div style="font-size:.72rem;color:var(--text-muted);margin-top:-4px">Auto-verifies when your email domain matches an approved college domain. Otherwise it stays pending until admin review.</div>
+        {% endif %}
       </div>
     </div>
     <!-- Social Links -->

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -217,3 +217,72 @@ def test_non_admin_cannot_delete_users(monkeypatch):
 
     assert response.status_code == 403
     assert test_db.user.find_one({"_id": victim_id}) is not None
+
+
+def test_admin_dashboard_lists_pending_college_verifications(monkeypatch):
+    flask_app, test_db = create_test_app(monkeypatch)
+    admin_id = test_db.user.insert_one(
+        {
+            "name": "Admin",
+            "email": "admin@example.com",
+            "is_admin": True,
+            "progress": {},
+        }
+    ).inserted_id
+    test_db.user.insert_one(
+        {
+            "name": "Student",
+            "email": "student@example.com",
+            "is_admin": False,
+            "progress": {},
+            "college": "Alpha University",
+            "college_verification_status": "pending",
+        }
+    )
+
+    with flask_app.test_client() as client:
+        login_as(client, admin_id)
+        response = client.get("/admin")
+
+    body = response.data.decode("utf-8")
+    assert response.status_code == 200
+    assert "Pending College Verification" in body
+    assert "Alpha University" in body
+    assert "Verify" in body
+
+
+def test_admin_can_verify_pending_college(monkeypatch):
+    flask_app, test_db = create_test_app(monkeypatch)
+    admin_id = test_db.user.insert_one(
+        {
+            "name": "Admin",
+            "email": "admin@example.com",
+            "is_admin": True,
+            "progress": {},
+        }
+    ).inserted_id
+    user_id = test_db.user.insert_one(
+        {
+            "name": "Student",
+            "email": "student@example.com",
+            "is_admin": False,
+            "progress": {},
+            "college": "Alpha University",
+            "college_verification_status": "pending",
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_as(client, admin_id)
+        csrf_token = set_csrf_token(client)
+        response = client.post(
+            f"/admin/users/{user_id}/verify-college",
+            data={"csrf_token": csrf_token},
+            follow_redirects=True,
+        )
+
+    user = test_db.user.find_one({"_id": user_id})
+    assert response.status_code == 200
+    assert user["college_verification_status"] == "verified"
+    assert user["college_verification_method"] == "admin"
+    assert "Verified college for Student." in response.data.decode("utf-8")

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -89,6 +89,7 @@ def test_create_app_preserves_routes_and_blueprints(monkeypatch):
     assert (([("problem", "text")],), {"name": "problem_text"}) in question_indexes
     assert "/admin" in routes
     assert "/admin/users/<user_id>/delete" in routes
+    assert "/admin/users/<user_id>/verify-college" in routes
 
     docs_response = flask_app.test_client().get("/apidocs/")
     assert docs_response.status_code == 200

--- a/tests/test_college_verification.py
+++ b/tests/test_college_verification.py
@@ -1,0 +1,106 @@
+import app.admin.routes as admin_routes
+import app.profile.routes as profile_routes
+from app.college_verification import build_college_verification_updates, parse_college_domain_allowlist
+from conftest import build_test_app, login_test_user
+
+
+def test_parse_college_domain_allowlist_handles_json_mapping():
+    allowlist = parse_college_domain_allowlist(
+        '{"Alpha University": ["alpha.edu", "mail.alpha.edu"], "Ignored": 1}'
+    )
+
+    assert allowlist == {
+        "alpha university": ["alpha.edu", "mail.alpha.edu"],
+    }
+
+
+def test_build_college_verification_updates_verifies_matching_domain():
+    updates = build_college_verification_updates(
+        college="Alpha University",
+        email="student@alpha.edu",
+        allowlist={"alpha university": ["alpha.edu"]},
+    )
+
+    assert updates == {
+        "college_verification_status": "verified",
+        "college_verification_method": "domain",
+    }
+
+
+def test_build_college_verification_updates_preserves_admin_verification():
+    updates = build_college_verification_updates(
+        college="Alpha University",
+        email="student@elsewhere.com",
+        allowlist={"alpha university": ["alpha.edu"]},
+        previous_college=" alpha   university ",
+        previous_status="verified",
+        previous_method="admin",
+    )
+
+    assert updates == {
+        "college_verification_status": "verified",
+        "college_verification_method": "admin",
+    }
+
+
+def test_edit_profile_marks_college_pending_when_domain_does_not_match(monkeypatch):
+    flask_app, test_db = build_test_app(
+        monkeypatch,
+        extra_db_targets=(profile_routes, admin_routes),
+    )
+    flask_app.config["COLLEGE_DOMAIN_ALLOWLIST"] = {
+        "alpha university": ["alpha.edu"],
+    }
+    user_id = test_db.user.insert_one(
+        {
+            "name": "Student",
+            "email": "student@example.com",
+            "progress": {},
+            "is_admin": False,
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.post(
+            "/edit_profile",
+            json={"name": "Student", "college": "Alpha University"},
+        )
+
+    user = test_db.user.find_one({"_id": user_id})
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert user["college"] == "Alpha University"
+    assert user["college_verification_status"] == "pending"
+    assert user["college_verification_method"] == ""
+
+
+def test_edit_profile_auto_verifies_matching_college_domain(monkeypatch):
+    flask_app, test_db = build_test_app(
+        monkeypatch,
+        extra_db_targets=(profile_routes, admin_routes),
+    )
+    flask_app.config["COLLEGE_DOMAIN_ALLOWLIST"] = {
+        "alpha university": ["alpha.edu"],
+    }
+    user_id = test_db.user.insert_one(
+        {
+            "name": "Student",
+            "email": "student@alpha.edu",
+            "progress": {},
+            "is_admin": False,
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.post(
+            "/edit_profile",
+            json={"name": "Student", "college": "Alpha University"},
+        )
+
+    user = test_db.user.find_one({"_id": user_id})
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert user["college_verification_status"] == "verified"
+    assert user["college_verification_method"] == "domain"

--- a/tests/test_leaderboard_service.py
+++ b/tests/test_leaderboard_service.py
@@ -150,3 +150,48 @@ def test_build_college_leaderboard_data_aggregates_and_sorts():
     beta = college_entries[1]
     assert beta["member_count"] == 1
     assert beta["lc_rating"] == 1700
+
+
+def test_build_college_leaderboard_data_distinguishes_verified_colleges():
+    entries = [
+        {
+            "user_id": "1",
+            "name": "Alice",
+            "college": "Alpha University",
+            "profile_photo": "alice.png",
+            "college_verification_status": "verified",
+            "c_score": 90,
+            "total_solved": 30,
+            "dsa_done": 20,
+            "lc_total": 10,
+            "gfg_total": 5,
+            "cn_total": 3,
+            "hr_total": 1,
+            "lc_rating": 1600,
+        },
+        {
+            "user_id": "2",
+            "name": "Bob",
+            "college": "Alpha University",
+            "profile_photo": "bob.png",
+            "college_verification_status": "pending",
+            "c_score": 120,
+            "total_solved": 40,
+            "dsa_done": 22,
+            "lc_total": 16,
+            "gfg_total": 7,
+            "cn_total": 4,
+            "hr_total": 2,
+            "lc_rating": 1700,
+        },
+    ]
+
+    college_entries = build_college_leaderboard_data(entries)
+
+    assert len(college_entries) == 2
+    assert college_entries[0]["verification_status"] == "verified"
+    assert college_entries[0]["college"] == "Alpha University"
+    assert college_entries[0]["member_count"] == 1
+    assert college_entries[1]["verification_status"] == "pending"
+    assert college_entries[1]["college"] == "Alpha University"
+    assert college_entries[1]["member_count"] == 1

--- a/tests/test_leaderboard_snapshots.py
+++ b/tests/test_leaderboard_snapshots.py
@@ -1,0 +1,156 @@
+from bson import ObjectId
+
+from conftest import build_test_app, login_test_user
+from app.leaderboard.service import (
+    LEADERBOARD_SNAPSHOT_CACHE_KEY,
+    build_leaderboard_snapshots,
+    clear_leaderboard_snapshots,
+    get_leaderboard_snapshot,
+    refresh_leaderboard_snapshots,
+)
+from app.leaderboard import service as leaderboard_service
+import app.profile.routes as profile_routes
+import app.tracker.routes as tracker_routes
+
+
+class FakeCache:
+    def __init__(self):
+        self.values = {}
+        self.set_calls = []
+        self.delete_calls = []
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value, timeout=None):
+        self.values[key] = value
+        self.set_calls.append((key, timeout))
+
+    def delete(self, key):
+        self.values.pop(key, None)
+        self.delete_calls.append(key)
+
+
+def test_get_leaderboard_snapshot_uses_cached_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+    build_calls = []
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: build_calls.append("built") or {
+            "cscore": [{"user_id": "1", "rank": 1, "c_score": 42}],
+            "questions": [{"user_id": "1", "rank": 1, "total_solved": 10}],
+            "rating": [{"user_id": "1", "rank": 1, "lc_rating": 1800}],
+            "college": [{"user_id": "", "rank": 1, "college": "Alpha"}],
+        },
+    )
+
+    first = get_leaderboard_snapshot("cscore")
+    second = get_leaderboard_snapshot("questions")
+
+    assert build_calls == ["built"]
+    assert fake_cache.set_calls == [(LEADERBOARD_SNAPSHOT_CACHE_KEY, leaderboard_service.LEADERBOARD_SNAPSHOT_TTL)]
+    assert first[0]["c_score"] == 42
+    assert second[0]["total_solved"] == 10
+
+
+def test_refresh_and_clear_leaderboard_snapshots(monkeypatch):
+    fake_cache = FakeCache()
+
+    monkeypatch.setattr(leaderboard_service, "cache", fake_cache)
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_snapshots",
+        lambda: {
+            "cscore": [{"rank": 1}],
+            "questions": [{"rank": 1}],
+            "rating": [{"rank": 1}],
+            "college": [{"rank": 1}],
+        },
+    )
+
+    snapshots = refresh_leaderboard_snapshots()
+    clear_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert fake_cache.delete_calls == [LEADERBOARD_SNAPSHOT_CACHE_KEY]
+
+
+def test_build_leaderboard_snapshots_assigns_ranks(monkeypatch):
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_data",
+        lambda: [
+            {
+                "user_id": "1",
+                "name": "Alice",
+                "college": "Alpha",
+                "profile_photo": "",
+                "c_score": 20,
+                "total_solved": 15,
+                "dsa_done": 8,
+                "lc_total": 10,
+                "gfg_total": 2,
+                "cn_total": 1,
+                "hr_total": 0,
+                "lc_rating": 1500,
+            },
+            {
+                "user_id": "2",
+                "name": "Bob",
+                "college": "Beta",
+                "profile_photo": "",
+                "c_score": 30,
+                "total_solved": 12,
+                "dsa_done": 7,
+                "lc_total": 9,
+                "gfg_total": 1,
+                "cn_total": 0,
+                "hr_total": 0,
+                "lc_rating": 1700,
+            },
+        ],
+    )
+
+    snapshots = build_leaderboard_snapshots()
+
+    assert snapshots["cscore"][0]["user_id"] == "2"
+    assert snapshots["cscore"][0]["rank"] == 1
+    assert snapshots["questions"][0]["user_id"] == "1"
+    assert snapshots["rating"][0]["user_id"] == "2"
+    assert snapshots["college"][0]["rank"] == 1
+
+
+def test_update_question_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
+    invalidations = []
+
+    monkeypatch.setattr(tracker_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        login_test_user(client, test_db)
+        response = client.post(f"/update_question/{question_id}", json={"done": True})
+
+    assert response.status_code == 200
+    assert invalidations == ["cleared"]
+
+
+def test_edit_profile_invalidates_leaderboard_snapshots(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(profile_routes,))
+    invalidations = []
+
+    monkeypatch.setattr(profile_routes, "clear_leaderboard_snapshots", lambda: invalidations.append("cleared"))
+
+    with flask_app.test_client() as client:
+        user_id = test_db.user.insert_one(
+            {"email": "user@example.com", "progress": {}, "is_admin": False, "name": "Before"}
+        ).inserted_id
+        login_test_user(client, user_id)
+        response = client.post("/edit_profile", json={"name": "After", "college": "New College"})
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert invalidations == ["cleared"]


### PR DESCRIPTION
## Summary\n- add configurable college domain verification helpers and profile verification state\n- add admin approval flow for pending college verification requests\n- distinguish verified and pending colleges in leaderboard aggregation and UI\n\n## Testing\n- python3 -m pytest tests/test_college_verification.py tests/test_admin_routes.py tests/test_leaderboard_service.py tests/test_app_factory.py -q\n- python3 -m pytest -q\n- PYTHONPYCACHEPREFIX=/private/tmp/450dsa-issue-289/.pycache python3 -m py_compile app/college_verification.py app/config.py app/__init__.py app/profile/routes.py app/leaderboard/service.py app/admin/routes.py tests/test_college_verification.py tests/test_admin_routes.py tests/test_leaderboard_service.py tests/test_app_factory.py\n- git diff --check