### PR TITLE
perf: limit profile heatmap payload

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -1,4 +1,5 @@
 import json
+from datetime import timedelta
 
 import requests
 from flask import Blueprint, current_app, jsonify, render_template, request, send_file
@@ -21,6 +22,20 @@ profile_bp = Blueprint("profile", __name__)
 __all__ = ["CACHE_TTL", "build_sync_platforms_response", "get_public_card_image"]
 
 UNIVERSITY_SEARCH_TIMEOUT_SECONDS = 5
+HEATMAP_DAYS = 168
+
+
+def filter_heatmap_counts(daily_counts, today=None, days=HEATMAP_DAYS):
+    """Return only the daily counts rendered by the profile heatmap."""
+    today = today or utc_now().date()
+    start = today - timedelta(days=days - 1)
+    start_key = start.isoformat()
+    today_key = today.isoformat()
+    return {
+        day: count
+        for day, count in daily_counts.items()
+        if start_key <= day <= today_key
+    }
 
 
 @profile_bp.route("/sync_platforms", methods=["POST"])
@@ -355,6 +370,7 @@ def profile():
             daily_counts[day] = daily_counts.get(day, 0) + count
 
     total_active_days = len(daily_counts)
+    heatmap_daily_counts = filter_heatmap_counts(daily_counts)
     sorted_dates = sorted(daily_counts.keys())
     cumulative_data = []
     cumulative_sum = 0
@@ -435,7 +451,7 @@ def profile():
         gh_prs=gh_prs,
         gh_merged=gh_merged,
         gh_commits=gh_commits,
-        daily_counts=daily_counts,
+        daily_counts=heatmap_daily_counts,
         cumulative_data=cumulative_data,
         total_active_days=total_active_days,
         rating_history=rating_history,

--- a/tests/test_profile_heatmap.py
+++ b/tests/test_profile_heatmap.py
@@ -1,0 +1,19 @@
+from datetime import date, timedelta
+
+from app.profile.routes import HEATMAP_DAYS, filter_heatmap_counts
+
+
+def test_filter_heatmap_counts_keeps_only_rendered_window():
+    today = date(2026, 5, 26)
+    first_visible = today - timedelta(days=HEATMAP_DAYS - 1)
+    counts = {
+        (first_visible - timedelta(days=1)).isoformat(): 9,
+        first_visible.isoformat(): 2,
+        today.isoformat(): 5,
+        (today + timedelta(days=1)).isoformat(): 7,
+    }
+
+    assert filter_heatmap_counts(counts, today=today) == {
+        first_visible.isoformat(): 2,
+        today.isoformat(): 5,
+    }


### PR DESCRIPTION
## Summary
- trim profile heatmap JSON to the 168-day window rendered by the frontend
- keep total active days and cumulative chart data based on the full activity history
- add a regression test for the heatmap date-window filter

Closes #306

## Testing
- `python -m pytest tests/test_profile_heatmap.py -q`
- `git diff --check`