### PR TITLE
feat: support editorial links for questions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,7 +24,12 @@ from app.security import (
 )
 from app.search import search_bp
 from app.tracker import tracker_bp
-from app.utils import platform_color_filter, platform_name_filter, platform_profile_url
+from app.utils import (
+    platform_color_filter,
+    platform_name_filter,
+    platform_profile_url,
+    question_editorial_links,
+)
 
 
 ROUTE_TIMING_ENDPOINTS = {
@@ -152,6 +157,7 @@ def create_app(config_class=None):
                             "problem": question["Problem"],
                             "url": question["URL"],
                             "url2": question.get("URL2", ""),
+                            "editorial_links": question_editorial_links(question),
                             "difficulty": difficulty,
                         }
                     )

--- a/app/search/service.py
+++ b/app/search/service.py
@@ -1,5 +1,5 @@
 import re
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus, urlparse
 
 from bson import ObjectId
 
@@ -69,6 +69,31 @@ def build_external_searches(query, requested_platforms=None):
     ]
 
 
+def normalize_editorial_links(raw_links):
+    """Return safe, labeled editorial links for a question document."""
+    if not raw_links:
+        return []
+    if isinstance(raw_links, str):
+        raw_links = [{"label": "Editorial", "url": raw_links}]
+
+    links = []
+    for index, item in enumerate(raw_links, start=1):
+        if isinstance(item, str):
+            label = f"Editorial {index}"
+            url = item
+        elif isinstance(item, dict):
+            label = str(item.get("label") or item.get("title") or f"Editorial {index}").strip()
+            url = str(item.get("url") or "").strip()
+        else:
+            continue
+
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            continue
+        links.append({"label": label or f"Editorial {index}", "url": url})
+    return links
+
+
 def question_links(question):
     links = []
     for field in ("url", "url2"):
@@ -84,6 +109,10 @@ def question_links(question):
             }
         )
     return links
+
+
+def question_editorial_links(question):
+    return normalize_editorial_links(question.get("editorial_links") or question.get("editorials"))
 
 
 PLATFORM_FILTER_MAP = {
@@ -159,7 +188,7 @@ def search_dsa_questions(raw_query, limit=40, db_handle=None, filters=None, prog
         except Exception:
             return empty_payload()
 
-    projection = {"problem": 1, "topic": 1, "url": 1, "url2": 1}
+    projection = {"problem": 1, "topic": 1, "url": 1, "url2": 1, "editorial_links": 1}
     post_fetch_filters = bool(
         requested_platforms
         or difficulty_filter in DIFFICULTY_FILTERS
@@ -217,6 +246,7 @@ def search_dsa_questions(raw_query, limit=40, db_handle=None, filters=None, prog
                 "topic_id": str(question.get("topic")),
                 "topic_position": topic_doc.get("position", 999),
                 "links": links,
+                "editorial_links": question_editorial_links(question),
                 "external_searches": build_external_searches(problem, requested_platforms),
                 "score": question.get("score", 0),
                 "done": progress_item.get("done", False),

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -4,7 +4,7 @@ from flask_login import current_user, login_required
 
 from app.extensions import db
 from app.leaderboard.cache import invalidate_leaderboard_cache
-from app.utils import json_error, json_success, utc_now
+from app.utils import json_error, json_success, question_editorial_links, utc_now
 from notes_export import build_all_notes_markdown, build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
 
@@ -29,6 +29,7 @@ TOPIC_PAGE_QUESTION_PROJECTION = {
     "difficulty": 1,
     "url": 1,
     "url2": 1,
+    "editorial_links": 1,
 }
 TOPIC_NOTES_EXPORT_PROJECTION = {"problem": 1}
 QUESTION_STATUS_PROJECTION = {"problem": 1}
@@ -37,6 +38,7 @@ BOOKMARKS_QUESTION_PROJECTION = {
     "problem": 1,
     "url": 1,
     "url2": 1,
+    "editorial_links": 1,
 }
 CSV_EXPORT_QUESTION_PROJECTION = {
     "topic": 1,
@@ -94,6 +96,8 @@ def topic(topic_id):
         return "Topic not found", 404
 
     questions = list(db.question.find({"topic": topic_doc["_id"]}, TOPIC_PAGE_QUESTION_PROJECTION))
+    for question in questions:
+        question["editorial_links"] = question_editorial_links(question)
     progress_dict = current_user.progress if current_user.is_authenticated else {}
     
     # Calculate counts based on the unfiltered list of questions

--- a/app/utils.py
+++ b/app/utils.py
@@ -110,6 +110,10 @@ def question_links(question):
     return search_service.question_links(question)
 
 
+def question_editorial_links(question):
+    return search_service.question_editorial_links(question)
+
+
 def search_dsa_questions(raw_query, limit=40):
     return search_service.search_dsa_questions(raw_query, limit=limit, db_handle=db)
 

--- a/templates/search.html
+++ b/templates/search.html
@@ -546,6 +546,11 @@ function renderResults(payload) {
         <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>${escapeHtml(link.platform)}
       </a>`
     ).join('');
+    const editorialLinks = (item.editorial_links || []).map(link =>
+      `<a class="q-badge badge-link" href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="Read ${escapeHtml(link.label)} (opens new tab)">
+        <i class="bi bi-journal-text" aria-hidden="true"></i>${escapeHtml(link.label)}
+      </a>`
+    ).join('');
     const platformSearches = (item.external_searches || []).map(link =>
       `<a class="q-badge ${badgeClass(link.color)}" href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="Search ${escapeHtml(link.platform)} for this problem (opens new tab)">
         <i class="bi bi-search" aria-hidden="true"></i>${escapeHtml(link.platform)}
@@ -558,7 +563,7 @@ function renderResults(payload) {
         <div>
           <a href="${topicUrl}" class="result-topic" aria-label="Go to ${escapeHtml(item.topic)} topic page">${escapeHtml(item.topic)}</a>
           <div class="result-name">${escapeHtml(item.problem)}</div>
-          <div class="link-row">${directLinks}${platformSearches}</div>
+          <div class="link-row">${directLinks}${editorialLinks}${platformSearches}</div>
         </div>
         <div class="result-actions">
           <a class="topic-open" href="${topicUrl}" title="Open topic" aria-label="Go to ${escapeHtml(item.topic)} topic">

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -174,6 +174,13 @@
                                <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i> {{ p2 }}
                             </a>
                         {% endif %}
+                        {% for editorial in q.editorial_links %}
+                            <a href="{{ editorial.url }}" target="_blank" rel="noopener noreferrer"
+                               class="q-badge badge-link"
+                               aria-label="Read {{ editorial.label }} (opens in new tab)">
+                               <i class="bi bi-journal-text" aria-hidden="true"></i> {{ editorial.label }}
+                            </a>
+                        {% endfor %}
                     </div>
                 </td>
                 <td>

--- a/tests/test_search_utils.py
+++ b/tests/test_search_utils.py
@@ -74,6 +74,7 @@ def test_search_uses_mongodb_text_search_and_score_sort(monkeypatch):
                 "topic": 1,
                 "url": 1,
                 "url2": 1,
+                "editorial_links": 1,
                 "score": {"$meta": "textScore"},
             },
         )
@@ -115,6 +116,36 @@ def test_search_preserves_topic_names_and_platform_links(monkeypatch):
             "url": "https://practice.geeksforgeeks.org/problems/overlapping-intervals/",
             "color": "gfg",
         },
+    ]
+
+
+def test_search_includes_valid_editorial_links(monkeypatch):
+    fake_db = FakeDB(
+        questions=[
+            {
+                "_id": "q1",
+                "problem": "Merge Intervals",
+                "topic": "intervals",
+                "url": "https://leetcode.com/problems/merge-intervals/",
+                "url2": "",
+                "editorial_links": [
+                    {"label": "Official Editorial", "url": "https://leetcode.com/problems/merge-intervals/editorial/"},
+                    {"label": "Bad", "url": "javascript:alert(1)"},
+                ],
+                "score": 2.25,
+            }
+        ],
+        topics=[{"_id": "intervals", "name": "Intervals", "position": 7}],
+    )
+    monkeypatch.setattr(utils, "db", fake_db)
+
+    result = utils.search_dsa_questions("merge intervals")["results"][0]
+
+    assert result["editorial_links"] == [
+        {
+            "label": "Official Editorial",
+            "url": "https://leetcode.com/problems/merge-intervals/editorial/",
+        }
     ]
 
 


### PR DESCRIPTION
## Summary
- add normalized editorial/explanation link support for question documents
- seed editorial links from data imports when present and expose them on topic/search views
- validate editorial URLs so unsafe schemes are ignored
- add search utility coverage for valid and invalid editorial links

Closes #344

## Testing
- `python -m pytest tests/test_search_utils.py -q`
- `git diff --check`