### PR TITLE
perf: maintain in-sheet platform counts

### DIFF
--- a/app/profile/card_service.py
+++ b/app/profile/card_service.py
@@ -8,7 +8,7 @@ from bson.objectid import ObjectId
 import card_generator
 
 from app.extensions import cache, db
-from app.utils import compute_c_score, compute_user_platforms, ensure_utc_datetime
+from app.utils import compute_c_score, compute_user_platforms, ensure_utc_datetime, merge_platform_counts
 from streaks import compute_streak
 
 
@@ -70,9 +70,12 @@ def get_public_card_image(user_id, object_id=None, db_handle=None):
     progress_data = user.get("progress", {})
     current_streak, _ = compute_streak(progress_data)
 
-    all_questions = list(db_handle.question.find())
-    solved_items = {qid: progress for qid, progress in progress_data.items() if progress.get("done")}
-    platforms = compute_user_platforms(solved_items, user.get("external_totals", {}), all_questions)
+    if user.get("in_sheet_platform_counts"):
+        platforms = merge_platform_counts(user.get("in_sheet_platform_counts"), user.get("external_totals", {}))
+    else:
+        all_questions = list(db_handle.question.find())
+        solved_items = {qid: progress for qid, progress in progress_data.items() if progress.get("done")}
+        platforms = compute_user_platforms(solved_items, user.get("external_totals", {}), all_questions)
     etag = _build_card_etag(name, c_score, dsa_progress, current_streak, platforms)
     last_modified = _card_last_modified(user, progress_data)
 

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -13,7 +13,14 @@ from app.profile.sync_service import (
     clear_profile_caches,
     sync_user_platforms,
 )
-from app.utils import json_error, json_success, utc_now, compute_user_platforms
+from app.utils import (
+    compute_in_sheet_platform_counts,
+    compute_user_platforms,
+    json_error,
+    json_success,
+    merge_platform_counts,
+    utc_now,
+)
 from profile_validation import build_profile_updates
 
 profile_bp = Blueprint("profile", __name__)
@@ -366,7 +373,12 @@ def profile():
     dsa_done = len(solved_items)
 
     ext_platform_totals = user.external_totals or {}
-    platforms = compute_user_platforms(solved_items, ext_platform_totals, all_questions)
+    if user.in_sheet_platform_counts:
+        platforms = merge_platform_counts(user.in_sheet_platform_counts, ext_platform_totals)
+    else:
+        in_sheet_counts = compute_in_sheet_platform_counts(solved_items, all_questions)
+        db.user.update_one({"_id": user.id}, {"$set": {"in_sheet_platform_counts": in_sheet_counts}})
+        platforms = merge_platform_counts(in_sheet_counts, ext_platform_totals)
 
     lc_easy = dsa_easy
     lc_medium = dsa_medium

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -4,7 +4,7 @@ from flask_login import current_user, login_required
 
 from app.extensions import db
 from app.leaderboard.cache import invalidate_leaderboard_cache
-from app.utils import json_error, json_success, utc_now
+from app.utils import json_error, json_success, platform_from_question_url, utc_now
 from notes_export import build_all_notes_markdown, build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
 
@@ -31,7 +31,7 @@ TOPIC_PAGE_QUESTION_PROJECTION = {
     "url2": 1,
 }
 TOPIC_NOTES_EXPORT_PROJECTION = {"problem": 1}
-QUESTION_STATUS_PROJECTION = {"problem": 1}
+QUESTION_STATUS_PROJECTION = {"problem": 1, "url": 1}
 BOOKMARKS_QUESTION_PROJECTION = {
     "topic": 1,
     "problem": 1,
@@ -242,20 +242,26 @@ def update_question(question_id):
     progress = current_user.progress
     existing = progress.get(question_id, {})
     message = ""
+    platform_count_field = f"in_sheet_platform_counts.{platform_from_question_url(question.get('url'))}"
 
     if "done" in data:
         if data["done"] and not existing.get("done"):
             update_fields[f"progress.{question_id}.timestamp"] = utc_now()
             message = f"✅ Marked '{question.get('problem', 'Question')}' as complete!"
             update_fields[f"progress.{question_id}.skipped"] = False
+            update_fields[platform_count_field] = 1
         elif not data["done"] and existing.get("done"):
             message = f"📝 Marked '{question.get('problem', 'Question')}' as incomplete"
+        if not data["done"] and existing.get("done"):
+            update_fields[platform_count_field] = -1
         update_fields[f"progress.{question_id}.done"] = data["done"]
 
     if "skipped" in data:
         if data["skipped"] and not existing.get("skipped"):
             message = f"⏭️ Marked '{question.get('problem', 'Question')}' as skipped for now"
             update_fields[f"progress.{question_id}.done"] = False
+            if existing.get("done"):
+                update_fields[platform_count_field] = -1
         elif not data["skipped"] and existing.get("skipped"):
             message = f"↩️ Removed skipped status for '{question.get('problem', 'Question')}'"
         update_fields[f"progress.{question_id}.skipped"] = data["skipped"]
@@ -272,7 +278,17 @@ def update_question(question_id):
         message = f"📝 Notes saved for '{question.get('problem', 'Question')}'!"
 
     if update_fields:
-        db.user.update_one({"_id": user_id}, {"$set": update_fields})
+        inc_fields = {
+            field: update_fields.pop(field)
+            for field in list(update_fields)
+            if field.startswith("in_sheet_platform_counts.")
+        }
+        update_doc = {}
+        if update_fields:
+            update_doc["$set"] = update_fields
+        if inc_fields:
+            update_doc["$inc"] = inc_fields
+        db.user.update_one({"_id": user_id}, update_doc)
         current_user.reload()
         invalidate_leaderboard_cache()
         return json_success(message=message)

--- a/app/utils.py
+++ b/app/utils.py
@@ -115,6 +115,27 @@ def search_dsa_questions(raw_query, limit=40):
 
 
 EXTERNAL_SOLVED_TOTAL_KEYS = ("LeetCode", "GFG", "Coding Ninjas", "HackerRank", "AtCoder")
+PLATFORM_COUNT_KEYS = ("LeetCode", "GFG", "Coding Ninjas", "HackerRank", "AtCoder", "Other")
+
+
+def empty_platform_counts():
+    return {platform: 0 for platform in PLATFORM_COUNT_KEYS}
+
+
+def platform_from_question_url(url):
+    """Return the tracked platform bucket for a question URL."""
+    url = (url or "").lower()
+    if "leetcode.com" in url:
+        return "LeetCode"
+    if "geeksforgeeks.org" in url:
+        return "GFG"
+    if "codingninjas.com" in url or "naukri.com/code360" in url:
+        return "Coding Ninjas"
+    if "hackerrank.com" in url:
+        return "HackerRank"
+    if "atcoder.jp" in url:
+        return "AtCoder"
+    return "Other"
 
 
 def compute_total_solved(progress, external_totals, all_questions=None):
@@ -188,28 +209,31 @@ def compute_c_score(user_doc, all_questions=None):
 
 def compute_user_platforms(solved_items, external_totals, all_questions):
     """Compute platform counts combining solved DSA questions with external totals."""
-    platforms = {"LeetCode": 0, "GFG": 0, "Coding Ninjas": 0, "HackerRank": 0, "AtCoder": 0, "Other": 0}
+    platforms = compute_in_sheet_platform_counts(solved_items, all_questions)
+    return merge_platform_counts(platforms, external_totals)
+
+
+def compute_in_sheet_platform_counts(solved_items, all_questions):
+    platforms = empty_platform_counts()
     
     for question in all_questions:
         question_id = str(question.get("_id", ""))
         if question_id in solved_items:
-            url = (question.get("url") or "").lower()
-            if "leetcode.com" in url:
-                platforms["LeetCode"] += 1
-            elif "geeksforgeeks.org" in url:
-                platforms["GFG"] += 1
-            elif "codingninjas.com" in url or "naukri.com/code360" in url:
-                platforms["Coding Ninjas"] += 1
-            elif "hackerrank.com" in url:
-                platforms["HackerRank"] += 1
-            else:
-                platforms["Other"] += 1
+            platforms[platform_from_question_url(question.get("url"))] += 1
+
+    return platforms
+
+
+def merge_platform_counts(in_sheet_counts, external_totals):
+    platforms = empty_platform_counts()
+    for platform, count in (in_sheet_counts or {}).items():
+        if platform in platforms:
+            platforms[platform] = max(int(count or 0), 0)
 
     ext_totals = external_totals or {}
     platforms["LeetCode"] = max(platforms["LeetCode"], ext_totals.get("LeetCode", 0), 0)
     platforms["GFG"] = max(platforms["GFG"], ext_totals.get("GFG", 0), 0)
     platforms["Coding Ninjas"] = max(platforms["Coding Ninjas"], ext_totals.get("Coding Ninjas", 0), 0)
     platforms["HackerRank"] = max(platforms["HackerRank"], ext_totals.get("HackerRank", 0), 0)
-    platforms["AtCoder"] = max(ext_totals.get("AtCoder", 0), 0)
-
+    platforms["AtCoder"] = max(platforms["AtCoder"], ext_totals.get("AtCoder", 0), 0)
     return platforms

--- a/tests/test_compute_c_score.py
+++ b/tests/test_compute_c_score.py
@@ -1,4 +1,9 @@
-from app.utils import compute_c_score, compute_total_solved
+from app.utils import (
+    compute_c_score,
+    compute_in_sheet_platform_counts,
+    compute_total_solved,
+    merge_platform_counts,
+)
 
 
 def make_user(progress=None, external_totals=None, external_daily_counts=None):
@@ -147,6 +152,28 @@ def test_active_days_full_year_maxes_consistency():
     assert result["active_days"] == 365
     # consistency component should be fully maxed (100 pts)
     assert result["c_score"] >= 100
+
+
+def test_in_sheet_platform_counts_bucket_solved_questions():
+    counts = compute_in_sheet_platform_counts(
+        {"q1": {"done": True}, "q3": {"done": True}},
+        [
+            {"_id": "q1", "url": "https://leetcode.com/problems/two-sum/"},
+            {"_id": "q2", "url": "https://www.geeksforgeeks.org/problems/x"},
+            {"_id": "q3", "url": "https://www.naukri.com/code360/problems/y"},
+        ],
+    )
+
+    assert counts["LeetCode"] == 1
+    assert counts["Coding Ninjas"] == 1
+    assert counts["GFG"] == 0
+
+
+def test_merge_platform_counts_keeps_external_totals_as_floor():
+    counts = merge_platform_counts({"LeetCode": 2, "GFG": 4}, {"LeetCode": 10, "GFG": 1})
+
+    assert counts["LeetCode"] == 10
+    assert counts["GFG"] == 4
 
 
 # --- Return structure ---

--- a/tests/test_tracker_routes.py
+++ b/tests/test_tracker_routes.py
@@ -231,7 +231,9 @@ def test_topic_page_ignores_unknown_difficulty_filter(monkeypatch):
 
 def test_update_question_accepts_valid_boolean_update(monkeypatch):
     flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
-    question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
+    question_id = test_db.question.insert_one(
+        {"problem": "Two Sum", "url": "https://leetcode.com/problems/two-sum/"}
+    ).inserted_id
 
     with flask_app.test_client() as client:
         user_id = login_test_user(client, test_db)
@@ -243,15 +245,19 @@ def test_update_question_accepts_valid_boolean_update(monkeypatch):
     progress = user["progress"][str(question_id)]
     assert progress["done"] is True
     assert "timestamp" in progress
+    assert user["in_sheet_platform_counts"]["LeetCode"] == 1
 
 
 def test_update_question_sets_skipped_and_clears_done(monkeypatch):
     flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
-    question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
+    question_id = test_db.question.insert_one(
+        {"problem": "Two Sum", "url": "https://leetcode.com/problems/two-sum/"}
+    ).inserted_id
     user_id = test_db.user.insert_one(
         {
             "email": "user@example.com",
             "progress": {str(question_id): {"done": True, "skipped": False}},
+            "in_sheet_platform_counts": {"LeetCode": 1},
             "is_admin": False,
         }
     ).inserted_id
@@ -265,3 +271,4 @@ def test_update_question_sets_skipped_and_clears_done(monkeypatch):
     progress = user["progress"][str(question_id)]
     assert progress["skipped"] is True
     assert progress["done"] is False
+    assert user["in_sheet_platform_counts"]["LeetCode"] == 0


### PR DESCRIPTION
## Summary
- maintain per-user in-sheet platform counters when questions are completed, undone, or skipped
- use denormalized counters in profile and progress-card rendering while preserving the existing scan as a legacy fallback/backfill path
- centralize platform URL bucketing and merge counters with external platform totals
- add focused coverage for platform-count helpers and tracker counter updates

Closes #326

## Testing
- `python -m pytest tests/test_compute_c_score.py -q`
- `python -m py_compile app/utils.py app/tracker/routes.py app/profile/routes.py app/profile/card_service.py`
- `git diff --check`

Note: targeted tracker route tests hit a local Flask/Werkzeug test-client signature mismatch in this environment before reaching assertions.