### PR TITLE
perf: warm progress card cache after stats change

### DIFF
--- a/app/profile/card_service.py
+++ b/app/profile/card_service.py
@@ -90,3 +90,12 @@ def get_public_card_image(user_id, object_id=None, db_handle=None):
 
     cache.set(f"card_{user_id}", (etag, img_io.getvalue()), timeout=CACHE_TTL)
     return img_io, etag, last_modified
+
+
+def warm_public_card_cache(user_id, db_handle=None):
+    """Generate and cache a user's public progress card after stats change."""
+    try:
+        get_public_card_image(str(user_id), db_handle=db_handle)
+        return True
+    except Exception:
+        return False

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -7,7 +7,7 @@ from flask_login import current_user, login_required
 from app.extensions import cache, db, limiter
 from app.leaderboard.cache import invalidate_leaderboard_cache
 from app.leaderboard.service import build_leaderboard_data, get_user_rank_by_c_score
-from app.profile.card_service import CACHE_TTL, get_public_card_image
+from app.profile.card_service import CACHE_TTL, get_public_card_image, warm_public_card_cache
 from app.profile.sync_service import (
     build_sync_platforms_response,
     clear_profile_caches,
@@ -18,7 +18,7 @@ from profile_validation import build_profile_updates
 
 profile_bp = Blueprint("profile", __name__)
 
-__all__ = ["CACHE_TTL", "build_sync_platforms_response", "get_public_card_image"]
+__all__ = ["CACHE_TTL", "build_sync_platforms_response", "get_public_card_image", "warm_public_card_cache"]
 
 UNIVERSITY_SEARCH_TIMEOUT_SECONDS = 5
 
@@ -91,6 +91,8 @@ def sync_platforms():
     if not isinstance(data, dict):
         return json_error("Request body must be a JSON object.", status_code=400)
     payload, status_code = sync_user_platforms(current_user, data, db, cache)
+    if payload.get("success"):
+        warm_public_card_cache(current_user.id, db_handle=db)
     return jsonify(payload), status_code
 
 
@@ -170,6 +172,7 @@ def edit_profile():
         current_user.reload()
         invalidate_leaderboard_cache()
         clear_profile_caches(cache, current_user.id)
+        warm_public_card_cache(current_user.id, db_handle=db)
     return json_success()
 
 

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -4,6 +4,7 @@ from flask_login import current_user, login_required
 
 from app.extensions import db
 from app.leaderboard.cache import invalidate_leaderboard_cache
+from app.profile.card_service import warm_public_card_cache
 from app.utils import json_error, json_success, utc_now
 from notes_export import build_all_notes_markdown, build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
@@ -275,6 +276,7 @@ def update_question(question_id):
         db.user.update_one({"_id": user_id}, {"$set": update_fields})
         current_user.reload()
         invalidate_leaderboard_cache()
+        warm_public_card_cache(user_id, db_handle=db)
         return json_success(message=message)
 
     return json_success(message="No changes made")

--- a/tests/test_progress_card.py
+++ b/tests/test_progress_card.py
@@ -559,3 +559,19 @@ def test_public_card_cache_reuse(client, app):
         assert response2.status_code == 200
 
         assert response1.data == response2.data
+
+
+def test_warm_public_card_cache_generates_card(app):
+    from app.profile.card_service import warm_public_card_cache
+
+    user_id = ObjectId()
+    app.mock_db.user.data[str(user_id)] = {
+        "_id": user_id,
+        "name": "Warm Cache User",
+        "progress": {},
+        "external_totals": {},
+    }
+    app.mock_db.question.data = {}
+
+    with patch("app.profile.card_service.db", app.mock_db):
+        assert warm_public_card_cache(user_id, db_handle=app.mock_db) is True


### PR DESCRIPTION
## Summary
- add a reusable helper that generates and stores the public progress card cache
- warm the cache after platform syncs, profile edits, and tracker progress updates
- keep the existing public card route fallback intact for missing/expired cached cards
- add regression coverage for the cache-warming helper

Closes #322

## Testing
- `python -m pytest tests/test_progress_card.py::test_warm_public_card_cache_generates_card -q`
- `python -m py_compile app/profile/card_service.py app/profile/routes.py app/tracker/routes.py`
- `git diff --check`