### PR TITLE
feat: export study plan calendar

### DIFF
--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -5,6 +5,7 @@ from flask_login import current_user, login_required
 from app.extensions import db
 from app.leaderboard.cache import invalidate_leaderboard_cache
 from app.utils import json_error, json_success, utc_now
+from calendar_export import build_study_plan_ics
 from notes_export import build_all_notes_markdown, build_topic_notes_markdown, topic_notes_filename
 from progress_export import build_progress_csv
 
@@ -314,6 +315,26 @@ def export_csv():
     csv_content = build_progress_csv(questions, topic_lookup, current_user.progress)
     response = Response(csv_content, mimetype='text/csv')
     response.headers['Content-Disposition'] = 'attachment; filename=progress.csv'
+    return response
+
+
+@tracker_bp.route("/export/study-plan.ics")
+@login_required
+def export_study_plan_ics():
+    topics = list(db.topic.find({}, {"name": 1, "position": 1}).sort("position", 1))
+    topic_ids = [topic["_id"] for topic in topics]
+    questions = list(db.question.find({"topic": {"$in": topic_ids}}, {"topic": 1}))
+
+    questions_by_topic = {}
+    for question in questions:
+        questions_by_topic.setdefault(question["topic"], []).append(question)
+
+    for topic in topics:
+        topic["questions"] = questions_by_topic.get(topic["_id"], [])
+
+    calendar_text = build_study_plan_ics(topics, current_user.progress)
+    response = Response(calendar_text, mimetype="text/calendar")
+    response.headers["Content-Disposition"] = "attachment; filename=study-plan.ics"
     return response
 
 

--- a/calendar_export.py
+++ b/calendar_export.py
@@ -1,0 +1,62 @@
+from datetime import date, timedelta
+
+
+def _ics_escape(value):
+    return (
+        str(value or "")
+        .replace("\\", "\\\\")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+        .replace("\n", "\\n")
+    )
+
+
+def build_study_plan_ics(topics, progress, start_date=None, cadence_days=7):
+    """Build an iCalendar file with upcoming topic study milestones."""
+    start_date = start_date or date.today()
+    progress = progress or {}
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//450 DSA Tracker//Study Plan//EN",
+        "CALSCALE:GREGORIAN",
+        "METHOD:PUBLISH",
+    ]
+
+    milestone_index = 0
+    for topic in topics:
+        questions = topic.get("questions", [])
+        if not questions:
+            continue
+        total = len(questions)
+        done = sum(
+            1
+            for question in questions
+            if progress.get(str(question.get("_id")), {}).get("done")
+        )
+        if done >= total:
+            continue
+
+        due_date = start_date + timedelta(days=milestone_index * cadence_days)
+        end_date = due_date + timedelta(days=1)
+        topic_id = str(topic.get("_id") or topic.get("name") or milestone_index)
+        name = topic.get("name", "Study topic")
+        summary = f"Study milestone: {name}"
+        description = f"Complete remaining questions for {name}. Progress: {done}/{total}."
+
+        lines.extend(
+            [
+                "BEGIN:VEVENT",
+                f"UID:450-dsa-{_ics_escape(topic_id)}@450-dsa-tracker",
+                f"DTSTAMP:{start_date.strftime('%Y%m%d')}T000000Z",
+                f"DTSTART;VALUE=DATE:{due_date.strftime('%Y%m%d')}",
+                f"DTEND;VALUE=DATE:{end_date.strftime('%Y%m%d')}",
+                f"SUMMARY:{_ics_escape(summary)}",
+                f"DESCRIPTION:{_ics_escape(description)}",
+                "END:VEVENT",
+            ]
+        )
+        milestone_index += 1
+
+    lines.append("END:VCALENDAR")
+    return "\r\n".join(lines) + "\r\n"

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -66,6 +66,9 @@
     <a class="card-btn ui-btn ui-btn-secondary ui-btn-block" href="{{ url_for('tracker.export_csv') }}" aria-label="Export progress as CSV file">
       <i class="bi bi-download" style="margin-right:6px" aria-hidden="true"></i> Export Progress CSV
     </a>
+    <a class="card-btn ui-btn ui-btn-secondary ui-btn-block" href="{{ url_for('tracker.export_study_plan_ics') }}" aria-label="Export study plan calendar file">
+      <i class="bi bi-calendar-event" style="margin-right:6px" aria-hidden="true"></i> Export Study Calendar
+    </a>
     <div class="prof-bio">{{ user.bio or 'Software Engineer | Problem Solver | DSA Enthusiast' }}</div>
     <div class="social-row">
       {% if user.email %}<a href="mailto:{{ user.email }}" class="social-icon" title="Email" aria-label="Send email to {{ user.email }}"><i class="bi bi-envelope" aria-hidden="true"></i></a>{% endif %}

--- a/tests/test_calendar_export.py
+++ b/tests/test_calendar_export.py
@@ -1,0 +1,27 @@
+from datetime import date
+
+from calendar_export import build_study_plan_ics
+
+
+def test_build_study_plan_ics_exports_incomplete_topic_milestones():
+    topics = [
+        {
+            "_id": "arrays",
+            "name": "Arrays",
+            "questions": [{"_id": "q1"}, {"_id": "q2"}],
+        },
+        {
+            "_id": "trees",
+            "name": "Trees",
+            "questions": [{"_id": "q3"}],
+        },
+    ]
+    progress = {"q1": {"done": True}, "q3": {"done": True}}
+
+    calendar_text = build_study_plan_ics(topics, progress, start_date=date(2026, 5, 26))
+
+    assert "BEGIN:VCALENDAR" in calendar_text
+    assert "SUMMARY:Study milestone: Arrays" in calendar_text
+    assert "DESCRIPTION:Complete remaining questions for Arrays. Progress: 1/2." in calendar_text
+    assert "Study milestone: Trees" not in calendar_text
+    assert "DTSTART;VALUE=DATE:20260526" in calendar_text


### PR DESCRIPTION
## Summary
- add an authenticated `study-plan.ics` export for incomplete topic milestones
- generate standards-friendly iCalendar output with escaped summaries/descriptions
- add a profile action to download the study calendar
- add focused calendar-builder coverage

Closes #372

## Testing
- `python -m pytest tests/test_calendar_export.py -q`
- `python -m py_compile calendar_export.py app/tracker/routes.py`
- `git diff --check`