### PR TITLE
fix: add temporary secret key fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ CLOUDINARY_API_KEY=your-api-key
 CLOUDINARY_API_SECRET=your-api-secret
 ```
 
-The app now refuses to start if `SECRET_KEY` is missing or still set to an insecure placeholder. If a secret was ever committed or shared, rotate it before running the app again.
+The app warns and generates a temporary `SECRET_KEY` if the variable is missing or still set to an insecure placeholder. Set a real generated secret in deployed environments so user sessions persist across restarts. If a secret was ever committed or shared, rotate it before running the app again.
 
 **3. Run**
 ```bash
@@ -205,7 +205,7 @@ pytest
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `SECRET_KEY` | Yes | Flask session secret. Must be a real generated secret, not a placeholder. |
+| `SECRET_KEY` | Recommended | Flask session secret. Must be a real generated secret, not a placeholder. Missing or insecure values fall back to a temporary key and reset sessions on restart. |
 | `MONGO_URI` | Yes | MongoDB connection string |
 | `GITHUB_CLIENT_ID` | No | GitHub OAuth app client ID |
 | `GITHUB_CLIENT_SECRET` | No | GitHub OAuth app client secret |

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -60,7 +60,7 @@ def create_app(config_class=None):
     app = Flask(__name__, template_folder="../templates", static_folder="../static")
     config_class = config_class or resolve_config_class()
     app.config.from_object(config_class)
-    # Non-test environments must provide a real SECRET_KEY before the app boots.
+    # Non-test environments without a real SECRET_KEY use a temporary fallback.
     config_class.apply_environment_overrides(app)
     _configure_rate_limit_storage(app, config_class)
     app.config["SESSION_COOKIE_SECURE"] = env_flag(

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,6 @@
 import os
+import secrets
+import warnings
 
 
 def env_flag(name, default=False):
@@ -66,10 +68,13 @@ class BaseConfig:
         if isinstance(secret_key, str):
             secret_key = secret_key.strip()
         if not app.config.get("TESTING") and secret_key in cls.INSECURE_SECRET_KEYS:
-            raise RuntimeError(
-                "SECRET_KEY is not set or is using an insecure default. "
-                "Generate one with: python -c \"import secrets; print(secrets.token_hex(32))\""
+            warnings.warn(
+                "SECRET_KEY is insecure or missing! Using a random temporary key. "
+                "User sessions will not persist across restarts.",
+                RuntimeWarning,
+                stacklevel=2,
             )
+            secret_key = secrets.token_hex(32)
         app.config["SECRET_KEY"] = secret_key
         app.config["MONGO_URI"] = os.environ.get("MONGO_URI", cls.MONGO_URI)
         app.config["MONGO_SERVER_SELECTION_TIMEOUT_MS"] = env_int(

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,8 +1,10 @@
+import warnings
 from types import SimpleNamespace
 
 import app as app_module
+import app.config as config_module
 import app.faq.routes as faq_routes
-from app.config import DevelopmentConfig, ProductionConfig, TestingConfig
+from app.config import BaseConfig, DevelopmentConfig, ProductionConfig, TestingConfig
 from app.extensions import login_manager
 
 
@@ -341,35 +343,47 @@ def test_create_app_allows_mongo_timeout_and_pool_overrides(monkeypatch):
     ]
 
 
-def test_create_app_requires_secret_key_outside_testing(monkeypatch):
+def test_create_app_generates_secret_key_when_missing(monkeypatch):
     monkeypatch.delenv("SECRET_KEY", raising=False)
     monkeypatch.delenv("FLASK_ENV", raising=False)
     monkeypatch.delenv("APP_ENV", raising=False)
     monkeypatch.delenv("ENV", raising=False)
     monkeypatch.delenv("FLASK_DEBUG", raising=False)
+    monkeypatch.setattr(config_module.secrets, "token_hex", lambda length: "generated-secret")
     monkeypatch.setattr(app_module, "load_dotenv", lambda: None)
     monkeypatch.setattr(app_module, "db", FakeDB())
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
+    monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.limiter, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
 
-    try:
-        app_module.create_app()
-    except RuntimeError as exc:
-        assert "SECRET_KEY" in str(exc)
-    else:
-        raise AssertionError("startup should require SECRET_KEY outside testing")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        flask_app = app_module.create_app()
+
+    assert flask_app.config["SECRET_KEY"] == "generated-secret"
+    assert any(
+        "SECRET_KEY is insecure or missing! Using a random temporary key. "
+        "User sessions will not persist across restarts."
+        in str(warning.message)
+        for warning in caught
+    )
 
 
-def test_create_app_rejects_insecure_secret_key_defaults(monkeypatch):
+def test_apply_environment_overrides_generates_secret_key_for_insecure_defaults(monkeypatch):
     monkeypatch.setenv("SECRET_KEY", "supersecretkey")
     monkeypatch.delenv("FLASK_ENV", raising=False)
     monkeypatch.delenv("APP_ENV", raising=False)
     monkeypatch.delenv("ENV", raising=False)
     monkeypatch.delenv("FLASK_DEBUG", raising=False)
-    monkeypatch.setattr(app_module, "load_dotenv", lambda: None)
-    monkeypatch.setattr(app_module, "db", FakeDB())
+    monkeypatch.setattr(config_module.secrets, "token_hex", lambda length: "generated-secret")
+    fake_app = SimpleNamespace(config={})
 
-    try:
-        app_module.create_app()
-    except RuntimeError as exc:
-        assert "SECRET_KEY" in str(exc)
-    else:
-        raise AssertionError("startup should reject insecure SECRET_KEY defaults")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        BaseConfig.apply_environment_overrides(fake_app)
+
+    assert fake_app.config["SECRET_KEY"] == "generated-secret"
+    assert any("SECRET_KEY is insecure or missing!" in str(warning.message) for warning in caught)


### PR DESCRIPTION
# Description
- Adds an ephemeral `SECRET_KEY` fallback when the configured value is missing or uses an insecure placeholder.
- Emits the warning requested in the issue so Vercel/runtime logs explain that sessions will not persist across restarts.
- Updates docs and tests to cover the graceful fallback path.

Fixes #572

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation (non-breaking change which improves documentation)

# How Has This Been Tested?
- [x] Tested in Local

```text
python -m pytest -q
227 passed

python -m ruff check .
All checks passed!
```

## Checklist
- [ ] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs
Vercel runtime logs showed `RuntimeError: SECRET_KEY is not set or is using an insecure default` during `run.py` import. This PR changes that crash into the requested temporary-key warning.