### PR TITLE
Fix #210: handle missing password on login without 500 error

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -151,7 +151,7 @@ def login():
         email = normalize_email(request.form.get("email"))
         password = request.form.get("password")
         user_doc = db.user.find_one({"email": email})
-        if user_doc and user_doc.get("password") and bcrypt.check_password_hash(user_doc["password"], password):
+        if user_doc and user_doc.get("password") and password and bcrypt.check_password_hash(user_doc["password"], password):
             user_doc = reactivate_user_if_needed(user_doc)
             login_user(UserWrapper(user_doc))
             flash(f"Welcome back, {user_doc.get('name', 'User')}! 👋", "success")

--- a/tests/test_login_validation.py
+++ b/tests/test_login_validation.py
@@ -1,0 +1,80 @@
+import app.auth.routes as auth_routes
+from conftest import build_test_app, csrf_headers
+from app.extensions import bcrypt
+
+
+def _create_user(test_db, email, password, name="Test User"):
+    test_db.user.insert_one(
+        {
+            "name": name,
+            "email": email,
+            "password": bcrypt.generate_password_hash(password).decode("utf-8"),
+            "progress": {},
+            "is_admin": False,
+        }
+    )
+
+
+def test_login_rejects_missing_password(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    monkeypatch.setattr(auth_routes, "db", test_db)
+    _create_user(test_db, "test@example.com", "RealPass1!")
+
+    with flask_app.test_client() as client:
+        headers = csrf_headers(client)
+        response = client.post(
+            "/login",
+            data={"email": "test@example.com"},
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert b"Login unsuccessful" in response.data
+
+
+def test_login_rejects_empty_password(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    monkeypatch.setattr(auth_routes, "db", test_db)
+    _create_user(test_db, "test2@example.com", "RealPass1!")
+
+    with flask_app.test_client() as client:
+        headers = csrf_headers(client)
+        response = client.post(
+            "/login",
+            data={"email": "test2@example.com", "password": ""},
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert b"Login unsuccessful" in response.data
+
+
+def test_login_rejects_missing_email(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+
+    with flask_app.test_client() as client:
+        headers = csrf_headers(client)
+        response = client.post(
+            "/login",
+            data={"password": "SomePass1!"},
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert b"Login unsuccessful" in response.data
+
+
+def test_login_succeeds_with_valid_credentials(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    monkeypatch.setattr(auth_routes, "db", test_db)
+    _create_user(test_db, "valid@example.com", "CorrectPass1!")
+
+    with flask_app.test_client() as client:
+        headers = csrf_headers(client)
+        response = client.post(
+            "/login",
+            data={"email": "valid@example.com", "password": "CorrectPass1!"},
+            headers=headers,
+        )
+
+    assert response.status_code == 302


### PR DESCRIPTION
The login route passes request.form.get('password') directly to
bcrypt.check_password_hash. When the password field is missing from
the POST body, this returns None and causes a TypeError.

Added a truthiness check for the submitted password before calling
bcrypt, so missing or empty passwords render the login page with a
flash message instead of crashing.

Added regression tests for:
- missing password
- empty password
- missing email
- successful login with valid credentials
