### PR TITLE
fix: restore dark profile background contrast

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -10,7 +10,7 @@
     --accent-dim: rgba(255, 107, 0, 0.15);
     --text-primary: #f0f0f0;
     --text-secondary: #a0a0a0;
-    --text-muted: #666666;
+    --text-muted: #8a8a8a;
     --success: #22c55e;
     --warning: #f59e0b;
     --danger: #ef4444;
@@ -32,9 +32,14 @@
     padding: 0;
 }
 
+html {
+    background-color: var(--bg-primary);
+    color-scheme: dark;
+}
+
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-    background-color: var(--bg-primary);
+    background-color: var(--bg-primary) !important;
     color: var(--text-primary);
     min-height: 100vh;
     overflow-x: hidden;
@@ -286,6 +291,7 @@ body {
     margin-left: var(--sidebar-width);
     margin-top: var(--topbar-height);
     min-height: calc(100vh - var(--topbar-height) - 13px);
+    background-color: var(--bg-primary);
 }
 
 /* ── Index Page ── */
@@ -430,7 +436,7 @@ body {
             --accent-dim: rgba(255, 107, 0, 0.15);
             --text-primary: #f0f0f0;
             --text-secondary: #a0a0a0;
-            --text-muted: #666666;
+            --text-muted: #8a8a8a;
             --success: #22c55e;
             --warning: #f59e0b;
             --danger: #ef4444;
@@ -452,9 +458,14 @@ body {
             padding: 0;
         }
 
+        html {
+            background-color: var(--bg-primary);
+            color-scheme: dark;
+        }
+
         body {
             font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-            background-color: var(--bg-primary);
+            background-color: var(--bg-primary) !important;
             color: var(--text-primary);
             min-height: 100vh;
             overflow-x: hidden;
@@ -968,6 +979,7 @@ body {
             margin-top: var(--topbar-height);
             min-height: calc(100vh - var(--topbar-height) - 130px);
             padding: 24px;
+            background-color: var(--bg-primary);
         }
 
         /* ─── Cards ─── */

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,8 +36,6 @@
         })();
     </script>
    
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
-    
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -47,6 +45,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">    
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
     <script src="{{ url_for('static', filename='js/pwa-install.js') }}" defer></script>
     {% block head %}{% endblock %}
     <script>
@@ -302,7 +301,7 @@
                 root.style.setProperty('--border-subtle', '#ececec');
                 root.style.setProperty('--text-primary', '#111111');
                 root.style.setProperty('--text-secondary', '#555555');
-                root.style.setProperty('--text-muted', '#999999');
+                root.style.setProperty('--text-muted', '#6b7280');
                 themeIcon.className = 'bi bi-sun-fill';
             } else {
                 root.style.setProperty('--bg-primary', '#111111');
@@ -313,7 +312,7 @@
                 root.style.setProperty('--border-subtle', '#222222');
                 root.style.setProperty('--text-primary', '#f0f0f0');
                 root.style.setProperty('--text-secondary', '#a0a0a0');
-                root.style.setProperty('--text-muted', '#666666');
+                root.style.setProperty('--text-muted', '#8a8a8a');
                 themeIcon.className = 'bi bi-moon-fill';
             }
         }

--- a/tests/test_button_utility_classes.py
+++ b/tests/test_button_utility_classes.py
@@ -8,6 +8,8 @@ STATIC_DIR = Path(__file__).resolve().parents[1] / "static"
 def test_base_template_defines_shared_button_utility_classes():
     stylesheet = (STATIC_DIR / "css" / "main.css").read_text(encoding="utf-8")
 
+    assert "background-color: var(--bg-primary) !important;" in stylesheet
+    assert "--text-muted: #8a8a8a;" in stylesheet
     assert ".ui-btn {" in stylesheet
     assert ".ui-btn-primary {" in stylesheet
     assert ".ui-btn-secondary {" in stylesheet
@@ -34,3 +36,9 @@ def test_profile_and_topic_templates_use_button_utilities():
     assert "class=\"pill-btn ui-btn ui-btn-secondary ui-btn-pill\"" in base_template
     assert "class=\"pill-btn accent ui-btn ui-btn-primary ui-btn-pill\"" in base_template
     assert "class=\"icon-btn ui-btn ui-btn-secondary ui-btn-icon\"" in base_template
+
+
+def test_app_styles_load_after_bootstrap_for_theme_overrides():
+    base_template = (TEMPLATE_DIR / "base.html").read_text(encoding="utf-8")
+
+    assert base_template.index("bootstrap.min.css") < base_template.index("css/main.css")


### PR DESCRIPTION
# Description
- Fixes the white profile-page background in dark mode by ensuring app theme CSS loads after Bootstrap and applies the theme background to body/main.
- Improves dark-mode muted text contrast for secondary labels and profile stats.
- Adds regression coverage for CSS load order and the dark background rule.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] Tested in Local

Tests:
- python -m pytest -q -> 228 passed
- python -m ruff check . -> All checks passed

Browser verification:
- body background: rgb(17, 17, 17)
- main background: rgb(17, 17, 17)
- muted text: #8a8a8a

## Checklist
- [ ] I have starred this repository.
- [ ] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.