### PR TITLE
fix: handle missing login credentials

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -149,9 +149,15 @@ def login():
         return redirect(url_for("tracker.index"))
     if request.method == "POST":
         email = normalize_email(request.form.get("email"))
-        password = request.form.get("password")
+        password = request.form.get("password") or ""
         user_doc = db.user.find_one({"email": email})
-        if user_doc and user_doc.get("password") and bcrypt.check_password_hash(user_doc["password"], password):
+        if (
+            email
+            and password
+            and user_doc
+            and user_doc.get("password")
+            and bcrypt.check_password_hash(user_doc["password"], password)
+        ):
             user_doc = reactivate_user_if_needed(user_doc)
             login_user(UserWrapper(user_doc))
             flash(f"Welcome back, {user_doc.get('name', 'User')}! 👋", "success")

--- a/tests/test_account_deactivation.py
+++ b/tests/test_account_deactivation.py
@@ -1,4 +1,5 @@
 import mongomock
+import re
 import werkzeug
 from bson import ObjectId
 
@@ -37,6 +38,16 @@ def login_as(client, user_id):
     with client.session_transaction() as session:
         session["_user_id"] = str(user_id)
         session["_fresh"] = True
+
+
+def get_csrf_from_login(client):
+    response = client.get("/login")
+    match = re.search(
+        rb'name="csrf_token" value="([^"]+)"',
+        response.data,
+    )
+    assert match is not None
+    return match.group(1).decode("utf-8")
 
 
 def test_deactivate_account_marks_user_and_logs_out(monkeypatch):
@@ -99,6 +110,46 @@ def test_login_reactivates_deactivated_password_user(monkeypatch):
     assert response.headers["Location"].endswith("/")
     assert user_doc["is_deactivated"] is False
     assert "deactivated_at" not in user_doc
+
+
+def test_login_missing_password_returns_invalid_login(monkeypatch):
+    flask_app, test_db = create_test_app(monkeypatch)
+    hashed = auth_routes.bcrypt.generate_password_hash("StrongPass1!").decode("utf-8")
+    test_db.user.insert_one(
+        {
+            "name": "Missing Password",
+            "email": "missing-password@example.com",
+            "password": hashed,
+            "progress": {},
+        }
+    )
+
+    with flask_app.test_client() as client:
+        csrf_token = get_csrf_from_login(client)
+        response = client.post(
+            "/login",
+            data={
+                "email": "missing-password@example.com",
+                "csrf_token": csrf_token,
+            },
+        )
+
+    assert response.status_code == 200
+    assert b"Login unsuccessful" in response.data
+
+
+def test_login_missing_email_returns_invalid_login(monkeypatch):
+    flask_app, _ = create_test_app(monkeypatch)
+
+    with flask_app.test_client() as client:
+        csrf_token = get_csrf_from_login(client)
+        response = client.post(
+            "/login",
+            data={"password": "StrongPass1!", "csrf_token": csrf_token},
+        )
+
+    assert response.status_code == 200
+    assert b"Login unsuccessful" in response.data
 
 
 def test_public_profile_and_card_hide_deactivated_user(monkeypatch):


### PR DESCRIPTION
## Summary
- normalize missing login passwords to an empty string before bcrypt checks
- require both email and password before attempting password verification
- add regression tests for missing password and missing email login submissions

Closes #210

## Testing
- python -m pytest tests/test_account_deactivation.py::test_login_missing_password_returns_invalid_login tests/test_account_deactivation.py::test_login_missing_email_returns_invalid_login -q

## Notes
- Full tests/test_account_deactivation.py was blocked locally by an existing Flask/Werkzeug test-client compatibility issue unrelated to this change.