### PR TITLE
fix: treat null user progress as empty

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -103,7 +103,7 @@ class UserWrapper(UserMixin):
 
     @property
     def progress(self):
-        return self._doc.get("progress", {})
+        return self._doc.get("progress") or {}
 
     @property
     def is_admin(self):

--- a/tests/test_user_progress.py
+++ b/tests/test_user_progress.py
@@ -1,0 +1,14 @@
+from app.auth.routes import UserWrapper
+
+
+def test_user_wrapper_treats_null_progress_as_empty_dict():
+    user = UserWrapper({"_id": "user-1", "progress": None})
+
+    assert user.progress == {}
+
+
+def test_user_wrapper_preserves_existing_progress_dict():
+    progress = {"question-1": {"done": True}}
+    user = UserWrapper({"_id": "user-1", "progress": progress})
+
+    assert user.progress == progress


### PR DESCRIPTION
## Summary
- treat explicit null progress values as empty progress in the login user wrapper
- preserve existing progress dictionaries unchanged
- add focused tests for null and populated progress values

Closes #233

## Testing
- python -m pytest tests/test_user_progress.py -q