### PR TITLE
fix: point gunicorn at run app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ COPY . .
 EXPOSE 5000
 
 # Run the application using Gunicorn for production
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "app:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "run:app"]
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD curl -f http://localhost:5000/health || exit 1

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_dockerfile_starts_gunicorn_from_run_module():
+    dockerfile = Path("Dockerfile").read_text(encoding="utf-8")
+
+    assert '"run:app"' in dockerfile
+    assert '"app:app"' not in dockerfile


### PR DESCRIPTION
## Summary
- update the Docker Gunicorn startup target from app:app to run:app
- add a regression check so the container entrypoint does not drift back to the wrong module

Closes #189

## Testing
- python -m pytest tests/test_dockerfile.py -q