### PR TITLE
fix: rate limit auth submissions

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -5,7 +5,7 @@ from bson import ObjectId
 from flask import Blueprint, abort, current_app, flash, redirect, render_template, request, session, url_for
 from flask_login import UserMixin, current_user, login_required, login_user, logout_user
 
-from app.extensions import bcrypt, db, github, google, login_manager
+from app.extensions import bcrypt, db, github, google, limiter, login_manager
 from app.utils import utc_now
 
 
@@ -144,6 +144,7 @@ def load_user(user_id):
 
 
 @auth_bp.route("/login", methods=["GET", "POST"])
+@limiter.limit("5 per minute", methods=["POST"])
 def login():
     if current_user.is_authenticated:
         return redirect(url_for("tracker.index"))
@@ -161,6 +162,7 @@ def login():
 
 
 @auth_bp.route("/register", methods=["GET", "POST"])
+@limiter.limit("3 per hour", methods=["POST"])
 def register():
     if current_user.is_authenticated:
         return redirect(url_for("tracker.index"))

--- a/tests/test_auth_rate_limits.py
+++ b/tests/test_auth_rate_limits.py
@@ -1,0 +1,21 @@
+import app.auth.routes as auth_routes
+
+
+def _route_limits(endpoint):
+    decorated_limits = auth_routes.limiter.limit_manager._decorated_limits
+    matching_key = f"app.auth.routes.{endpoint}.{endpoint}"
+    return list(decorated_limits[matching_key])
+
+
+def test_login_route_has_post_rate_limit():
+    limit = _route_limits("login")[0]
+
+    assert limit.limit_provider == "5 per minute"
+    assert limit.methods == ("POST",)
+
+
+def test_register_route_has_post_rate_limit():
+    limit = _route_limits("register")[0]
+
+    assert limit.limit_provider == "3 per hour"
+    assert limit.methods == ("POST",)


### PR DESCRIPTION
## Summary
- add route-level POST rate limits to login and registration
- keep GET requests unaffected so auth pages can still render normally
- add focused tests to verify both auth routes are decorated with POST-only limits

Closes #228

## Testing
- python -m pytest tests/test_auth_rate_limits.py -q
- python -m py_compile app/auth/routes.py