### PR TITLE
fix: vary leaderboard cache by user

### DIFF
--- a/app/leaderboard/cache.py
+++ b/app/leaderboard/cache.py
@@ -1,4 +1,5 @@
 from flask import request
+from flask_login import current_user
 
 from app.extensions import cache
 
@@ -22,7 +23,8 @@ def invalidate_leaderboard_cache():
 
 
 def leaderboard_page_cache_key():
-    return f"leaderboard:v{_leaderboard_cache_version()}:page:{request.path}"
+    user_key = f"user:{current_user.get_id()}" if current_user.is_authenticated else "anon"
+    return f"leaderboard:v{_leaderboard_cache_version()}:page:{request.path}:{user_key}"
 
 
 def api_leaderboard_cache_key():

--- a/tests/test_leaderboard_cache.py
+++ b/tests/test_leaderboard_cache.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from bson import ObjectId
 
 import app.auth.routes as auth_routes
@@ -32,6 +34,27 @@ def test_leaderboard_cache_keys_change_after_invalidation(monkeypatch):
         initial_page_key = leaderboard_page_cache_key()
         invalidate_leaderboard_cache()
         assert leaderboard_page_cache_key() != initial_page_key
+
+
+def test_leaderboard_page_cache_key_varies_by_authenticated_user(monkeypatch):
+    flask_app, _ = build_test_app(monkeypatch)
+
+    with flask_app.test_request_context("/leaderboard"):
+        monkeypatch.setattr(
+            "app.leaderboard.cache.current_user",
+            SimpleNamespace(is_authenticated=True, get_id=lambda: "user-1"),
+        )
+        first_user_key = leaderboard_page_cache_key()
+
+        monkeypatch.setattr(
+            "app.leaderboard.cache.current_user",
+            SimpleNamespace(is_authenticated=True, get_id=lambda: "user-2"),
+        )
+        second_user_key = leaderboard_page_cache_key()
+
+    assert first_user_key != second_user_key
+    assert first_user_key.endswith(":user:user-1")
+    assert second_user_key.endswith(":user:user-2")
 
 
 def test_update_question_invalidates_leaderboard_cache(monkeypatch):


### PR DESCRIPTION
## Summary
- include the authenticated user id in the cached leaderboard page key
- keep anonymous leaderboard pages sharing an anonymous cache bucket
- add regression coverage proving two authenticated users produce different page cache keys

Closes #142

## Testing
- python -m pytest tests/test_leaderboard_cache.py::test_leaderboard_page_cache_key_varies_by_authenticated_user -q
- python -m py_compile app/leaderboard/cache.py