### PR TITLE
Pin remaining runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY requirements.txt .
 
 # Install dependencies
-RUN pip install --no-cache-dir -r requirements.txt gunicorn
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the application
 COPY . .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.3.2
-Werkzeug<3
+Werkzeug==2.3.8
 Flask-PyMongo==2.3.0
 pymongo==4.7.2
 Flask-Login==0.6.3
@@ -15,3 +15,4 @@ redis==5.0.4
 # pyjson5==1.6.2
 Flask-Caching==2.0.2
 flasgger==0.9.7.1
+gunicorn==22.0.0


### PR DESCRIPTION
### Description
Addresses #27 by pinning all remaining unpinned and loosely bounded runtime dependencies.

### Changes
* **requirements.txt**: 
  * Pinned `Werkzeug` to `==2.3.8` (replacing the loose range boundary `Werkzeug<3`).
  * Added and pinned `gunicorn` to `==22.0.0`.
* **Dockerfile**: 
  * Updated `pip install` to install strictly from `requirements.txt` (which now installs the pinned version of `gunicorn`).

### Closes #27 