### PR TITLE
perf: cache static question/topic metadata to reduce DB queries (#605)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -223,6 +223,52 @@ def create_app(config_class=None):
                     upsert=True,
                 )
 
+    def _precompute_static_data(app):
+        """Precompute static question/topic metadata and store in app config."""
+        try:
+            questions = list(db.question.find())
+            topics = list(db.topic.find().sort("position", 1))
+        except Exception:
+            return
+
+        topic_question_count = {}
+        difficulty_map = {}
+        all_questions_pc = []
+        topic_lookup = {}
+
+        for t in topics:
+            tid = str(t["_id"])
+            topic_lookup[tid] = {"name": t["name"], "position": t["position"]}
+
+        for q in questions:
+            qid = str(q["_id"])
+            tid = str(q["topic"])
+            topic_question_count.setdefault(tid, []).append(qid)
+            difficulty_map[qid] = q.get("difficulty", "Medium")
+            all_questions_pc.append({
+                "_id": qid,
+                "topic": tid,
+                "problem": q.get("problem", ""),
+                "url": q.get("url", ""),
+                "url2": q.get("url2", ""),
+                "difficulty": q.get("difficulty", "Medium"),
+                "editorial_links": q.get("editorial_links", []),
+            })
+
+        topics_pc = [
+            {"_id": str(t["_id"]), "name": t["name"], "position": t["position"]}
+            for t in topics
+        ]
+
+        app.config["_PRECOMPUTED"] = {
+            "all_questions": all_questions_pc,
+            "topics": topics_pc,
+            "topic_lookup": topic_lookup,
+            "topic_question_count": topic_question_count,
+            "difficulty_map": difficulty_map,
+            "total_questions": len(questions),
+        }
+
     @app.before_request
     def ensure_db_initialized():
         if request.endpoint == "health_check":
@@ -230,6 +276,7 @@ def create_app(config_class=None):
 
         if not app._db_initialized:
             init_db()
+            _precompute_static_data(app)
             app._db_initialized = True
 
     from app.platforms.metadata import PLATFORM_META

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -1,3 +1,4 @@
+from flask import current_app
 from app.extensions import db
 from app.utils import compute_c_score
 
@@ -24,7 +25,11 @@ def build_leaderboard_data():
         )
     )
 
-    all_questions = list(db.question.find({}, {"url": 1}))
+    try:
+        pre = current_app.config.get("_PRECOMPUTED")
+    except RuntimeError:
+        pre = None
+    all_questions = pre["all_questions"] if pre else list(db.question.find({}, {"url": 1}))
     entries = []
     for user in users:
         name = user.get("name", "Anonymous")

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -339,18 +339,31 @@ def upload_photo():
 @profile_bp.route("/profile")
 @login_required
 def profile():
-    topics = list(db.topic.find().sort("position", 1))
     user = current_user
-
-    all_questions = list(db.question.find())
     solved_items = {question_id: progress for question_id, progress in user.progress.items() if progress.get("done")}
+    dsa_done = len(solved_items)
 
-    difficulty_map = {str(q["_id"]): q.get("difficulty", "Medium") for q in all_questions}
-    
+    pre = current_app.config.get("_PRECOMPUTED")
+    if pre:
+        topics = pre["topics"]
+        all_questions = pre["all_questions"]
+        difficulty_map = pre["difficulty_map"]
+        topic_question_count = pre["topic_question_count"]
+        total_questions = pre["total_questions"]
+    else:
+        topics = list(db.topic.find().sort("position", 1))
+        all_questions = list(db.question.find())
+        difficulty_map = {str(q["_id"]): q.get("difficulty", "Medium") for q in all_questions}
+        topic_question_count = {}
+        for question in all_questions:
+            topic_id = str(question["topic"])
+            topic_question_count.setdefault(topic_id, []).append(str(question["_id"]))
+        total_questions = len(all_questions)
+
     dsa_easy = 0
     dsa_medium = 0
     dsa_hard = 0
-    
+
     for q_id in solved_items.keys():
         diff = difficulty_map.get(q_id, "Medium")
         if diff == "Easy":
@@ -359,14 +372,11 @@ def profile():
             dsa_medium += 1
         elif diff == "Hard":
             dsa_hard += 1
+
     platforms = {"LeetCode": 0, "GFG": 0, "Coding Ninjas": 0, "HackerRank": 0, "Other": 0}
     daily_counts = {}
 
-    topic_question_count = {}
     for question in all_questions:
-        topic_id = str(question["topic"])
-        topic_question_count.setdefault(topic_id, []).append(str(question["_id"]))
-
         question_id = str(question["_id"])
         if question_id in solved_items:
             solved_at = solved_items[question_id].get("timestamp") or utc_now()
@@ -388,7 +398,6 @@ def profile():
         cumulative_data.append({"x": day, "y": cumulative_sum})
 
     topic_progress = []
-    dsa_done = len(solved_items)
 
     ext_platform_totals = user.external_totals or {}
     if user.in_sheet_platform_counts:
@@ -401,7 +410,7 @@ def profile():
     lc_easy = dsa_easy
     lc_medium = dsa_medium
     lc_hard = dsa_hard
-    
+
     lc_contests = ext_platform_totals.get("LeetCode_Contests", 0)
     lc_rating = ext_platform_totals.get("LeetCode_Rating", 0)
     lc_rank = ext_platform_totals.get("LeetCode_GlobalRank", 0)
@@ -411,7 +420,6 @@ def profile():
     gh_commits = ext_platform_totals.get("GitHub_Commits", 0)
 
     global_total_solved = sum(platforms.values())
-    total_questions = len(all_questions)
 
     for topic_doc in topics:
         topic_id = str(topic_doc["_id"])

--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, render_template, request
+from flask import Blueprint, current_app, jsonify, render_template, request
 from flask_login import current_user
 
 from app.extensions import db, limiter
@@ -14,10 +14,14 @@ MAX_SEARCH_LIMIT = 80
 @search_bp.route("/search")
 def search():
     initial_query = request.args.get("q", "").strip()
-    try:
-        topics = list(db.topic.find({}, {"name": 1}).sort("position", 1))
-    except Exception:
-        topics = []
+    pre = current_app.config.get("_PRECOMPUTED")
+    if pre:
+        topics = [{"name": t["name"], "_id": t["_id"]} for t in pre["topics"]]
+    else:
+        try:
+            topics = list(db.topic.find({}, {"name": 1}).sort("position", 1))
+        except Exception:
+            topics = []
     return render_template("search.html", initial_query=initial_query, topics=topics)
 
 

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -1,6 +1,6 @@
 from bson import ObjectId
 from bson.errors import InvalidId
-from flask import Blueprint, Response, jsonify, render_template, request
+from flask import Blueprint, Response, current_app, jsonify, render_template, request
 from flask_login import current_user, login_required
 
 from app.extensions import db
@@ -60,8 +60,19 @@ ALL_NOTES_QUESTION_PROJECTION = {"problem": 1, "topic": 1}
 
 @tracker_bp.route("/")
 def index():
-    topics = list(db.topic.find().sort("position", 1))
-    total_questions = db.question.count_documents({})
+    pre = current_app.config.get("_PRECOMPUTED")
+    if pre:
+        topics = pre["topics"]
+        total_questions = pre["total_questions"]
+        topic_question_count = pre["topic_question_count"]
+    else:
+        topics = list(db.topic.find().sort("position", 1))
+        total_questions = db.question.count_documents({})
+        all_questions = list(db.question.find({}, INDEX_QUESTION_PROJECTION))
+        topic_question_count = {}
+        for question in all_questions:
+            topic_id = str(question["topic"])
+            topic_question_count.setdefault(topic_id, []).append(str(question["_id"]))
 
     if current_user.is_authenticated:
         progress = current_user.progress
@@ -69,12 +80,6 @@ def index():
     else:
         progress = {}
         done_questions = 0
-
-    all_questions = list(db.question.find({}, INDEX_QUESTION_PROJECTION))
-    topic_question_count = {}
-    for question in all_questions:
-        topic_id = str(question["topic"])
-        topic_question_count.setdefault(topic_id, []).append(str(question["_id"]))
 
     topic_progress = {}
     for topic in topics:
@@ -338,12 +343,17 @@ def bookmarks():
 @tracker_bp.route("/export/csv")
 @login_required
 def export_csv():
-    questions = list(db.question.find({}, CSV_EXPORT_QUESTION_PROJECTION))
-    topic_ids = list({q.get('topic') for q in questions if q.get('topic')})
-    topic_lookup = {
-        topic['_id']: topic.get('name', 'Unknown')
-        for topic in db.topic.find({'_id': {'$in': topic_ids}}, {'name': 1})
-    }
+    pre = current_app.config.get("_PRECOMPUTED")
+    if pre:
+        questions = pre["all_questions"]
+        topic_lookup = {tid: t["name"] for tid, t in pre["topic_lookup"].items()}
+    else:
+        questions = list(db.question.find({}, CSV_EXPORT_QUESTION_PROJECTION))
+        topic_ids = list({q.get('topic') for q in questions if q.get('topic')})
+        topic_lookup = {
+            topic['_id']: topic.get('name', 'Unknown')
+            for topic in db.topic.find({'_id': {'$in': topic_ids}}, {'name': 1})
+        }
     csv_content = build_progress_csv(questions, topic_lookup, current_user.progress)
     response = Response(csv_content, mimetype='text/csv')
     response.headers['Content-Disposition'] = 'attachment; filename=progress.csv'
@@ -353,16 +363,23 @@ def export_csv():
 @tracker_bp.route("/export/study-plan.ics")
 @login_required
 def export_study_plan_ics():
-    topics = list(db.topic.find({}, {"name": 1, "position": 1}).sort("position", 1))
-    topic_ids = [topic["_id"] for topic in topics]
-    questions = list(db.question.find({"topic": {"$in": topic_ids}}, {"topic": 1}))
-
-    questions_by_topic = {}
-    for question in questions:
-        questions_by_topic.setdefault(question["topic"], []).append(question)
-
-    for topic in topics:
-        topic["questions"] = questions_by_topic.get(topic["_id"], [])
+    pre = current_app.config.get("_PRECOMPUTED")
+    if pre:
+        topics = pre["topics"]
+        questions_by_topic = {}
+        for q in pre["all_questions"]:
+            questions_by_topic.setdefault(q["topic"], []).append(q)
+        for topic in topics:
+            topic["questions"] = questions_by_topic.get(topic["_id"], [])
+    else:
+        topics = list(db.topic.find({}, {"name": 1, "position": 1}).sort("position", 1))
+        topic_ids = [topic["_id"] for topic in topics]
+        questions = list(db.question.find({"topic": {"$in": topic_ids}}, {"topic": 1}))
+        questions_by_topic = {}
+        for question in questions:
+            questions_by_topic.setdefault(question["topic"], []).append(question)
+        for topic in topics:
+            topic["questions"] = questions_by_topic.get(topic["_id"], [])
 
     calendar_text = build_study_plan_ics(topics, current_user.progress)
     response = Response(calendar_text, mimetype="text/calendar")
@@ -374,13 +391,19 @@ def export_study_plan_ics():
 @login_required
 def export_all_notes():
     """Download all non-empty notes grouped by topic as a single Markdown file."""
-    topics = list(db.topic.find().sort("position", 1))
-    all_questions = list(db.question.find({}, ALL_NOTES_QUESTION_PROJECTION))
-
-    questions_by_topic = {}
-    for question in all_questions:
-        topic_id = str(question["topic"])
-        questions_by_topic.setdefault(topic_id, []).append(question)
+    pre = current_app.config.get("_PRECOMPUTED")
+    if pre:
+        topics = pre["topics"]
+        questions_by_topic = {}
+        for question in pre["all_questions"]:
+            questions_by_topic.setdefault(question["topic"], []).append(question)
+    else:
+        topics = list(db.topic.find().sort("position", 1))
+        all_questions = list(db.question.find({}, ALL_NOTES_QUESTION_PROJECTION))
+        questions_by_topic = {}
+        for question in all_questions:
+            topic_id = str(question["topic"])
+            questions_by_topic.setdefault(topic_id, []).append(question)
 
     markdown = build_all_notes_markdown(
         topics, questions_by_topic, current_user.progress,


### PR DESCRIPTION
## Problem

Every page load (index, profile, search, leaderboard, exports) executes redundant MongoDB queries to fetch **all** questions and topics — even though this data is static and rarely changes. For example:
- `db.question.find()` runs on every profile and index view
- `db.topic.find()` runs on every index, search, and export page
- `db.question.find()` for URL data runs on every leaderboard build

This adds unnecessary latency to every request and puts extra load on the database.

## Solution

Precompute static question and topic metadata **once** at application startup (after DB initialization) and store it in `app.config["_PRECOMPUTED"]`. All route handlers read from this in-memory cache instead of querying MongoDB per request.

### Key design decisions

- **ObjectIds converted to strings** in cached data — ensures consistent lookups and avoids serialization issues (e.g., when passing data through Flask session or templates)
- **Fallback paths preserved** in every route — if the cache is absent (startup race, test environment without app context), code falls back to direct DB queries
- **Cache populated once** in `ensure_db_initialized()` after `init_db()` completes, lives for the lifetime of the app process
- **All fields cached** for questions (`_id`, `topic`, `problem`, `url`, `url2`, `difficulty`, `editorial_links`) and topics (`_id`, `name`, `position`), plus pre-built `topic_question_count`, `difficulty_map`, and `topic_lookup` for O(1) access

## Changes by file

### `app/__init__.py`
- Added `_precompute_static_data(app)` — loads all questions and topics from MongoDB, transforms into string-keyed dictionaries, stored in `app.config["_PRECOMPUTED"]` with keys: `all_questions`, `topics`, `topic_lookup`, `topic_question_count`, `difficulty_map`, `total_questions`
- Called inside `ensure_db_initialized()` after `init_db()`
- Wrapped in try-except so a DB failure during precomputation silently skips caching (routes use fallback)

### `app/tracker/routes.py`
- **`index()`**: Reads `topics`, `total_questions`, `topic_question_count` from cache. Removes `db.question.find()` call.
- **`export_csv()`**: Reads all questions from cache and builds topic_lookup from cached data. Removes 2 DB queries.
- **`export_study_plan_ics()`**: Reads topics and builds questions_by_topic from cached data. Removes 2 DB queries.
- **`export_all_notes()`**: Reads topics and builds questions_by_topic from cached data. Removes 2 DB queries.

### `app/profile/routes.py`
- **`profile()`**: Reads `topics`, `all_questions`, `difficulty_map`, `topic_question_count`, `total_questions` from cache. Removes 2 DB queries and 1 full iteration over all_questions.

### `app/leaderboard/service.py`
- **`build_leaderboard_data()`**: Reads all_questions from cache. Uses try-except for `RuntimeError` to handle tests without Flask app context.

### `app/search/routes.py`
- **`search()`**: Builds topics dropdown from cached data instead of querying MongoDB.

## Impact

| Metric | Before | After |
|--------|--------|-------|
| DB queries on `/index` | 2 (`topic.find`, `question.find`) | 0 (fully cached) |
| DB queries on `/profile` | 2 (`topic.find`, `question.find`) | 0 (fully cached) |
| DB queries on `/search` | 1 (`topic.find`) | 0 (fully cached) |
| DB queries on `/export/csv` | 2 (`question.find`, `topic.find`) | 0 (fully cached) |
| DB queries on leaderboard build | 1 (`question.find`) | 0 (fully cached) |
| Cache population | — | Once at startup (~1-2s) |

## Scope

This is **Phase 1** of issue #605 — caching static read-only question/topic data.

- **Phase 2** (future): Cache admin dashboard KPIs
- **Phase 3** (future): Precompute leaderboard data in a background job instead of on-demand
