### PR TITLE
fix: preserve per-platform external daily counts on partial sync (#603)

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -11,6 +11,7 @@ from flask_login import current_user, login_required
 
 from app.decorators import admin_required
 from app.extensions import db
+from app.utils import get_merged_daily_counts
 
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
@@ -70,7 +71,7 @@ def _compute_system_stats():
     active_users_today = set()
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
-    projection = {"progress": 1, "external_totals": 1, "external_daily_counts": 1}
+    projection = {"progress": 1, "external_totals": 1, "external_daily_counts": 1, "platform_calendars": 1}
     for user in db.user.find({}, projection):
         progress = user.get("progress") or {}
         solved_in_app = 0
@@ -88,7 +89,7 @@ def _compute_system_stats():
             for key in ("LeetCode", "GFG", "Coding Ninjas", "HackerRank")
         )
 
-        daily_counts = user.get("external_daily_counts") or {}
+        daily_counts = get_merged_daily_counts(user)
         if daily_counts.get(today, 0) > 0:
             active_users_today.add(user["_id"])
 

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -114,6 +114,9 @@ class UserWrapper(UserMixin):
             raise AttributeError(name)
         return self._doc.get(name)
 
+    def get(self, name, default=None):
+        return self._doc.get(name, default)
+
     def reload(self):
         self._doc = db.user.find_one({"_id": self._doc["_id"]}) or self._doc
         return self

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -21,6 +21,7 @@ def build_leaderboard_data():
                 "progress": 1,
                 "external_totals": 1,
                 "external_daily_counts": 1,
+                "platform_calendars": 1,
             },
         )
     )

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -16,6 +16,7 @@ from app.profile.sync_service import (
 )
 from app.utils import (
     compute_in_sheet_platform_counts,
+    get_merged_daily_counts,
     json_error,
     json_success,
     merge_platform_counts,
@@ -383,7 +384,7 @@ def profile():
             day = solved_at.strftime("%Y-%m-%d")
             daily_counts[day] = daily_counts.get(day, 0) + 1
 
-    ext_daily = user.external_daily_counts
+    ext_daily = get_merged_daily_counts(user)
     if ext_daily:
         for day, count in ext_daily.items():
             daily_counts[day] = daily_counts.get(day, 0) + count

--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -142,7 +142,6 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
         codewars_username = data.get("codewars", "").strip()
         update_fields["codewars_username"] = codewars_username
 
-    combined_daily_counts = {}
     platform_totals = {}
     platform_status = {}
 
@@ -151,6 +150,12 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
         if error:
             payload["error"] = error
         platform_status[platform_key] = payload
+
+    # Preserve existing per-platform calendar data across partial syncs
+    existing_calendars = getattr(user, "platform_calendars", {})
+    if not isinstance(existing_calendars, dict):
+        existing_calendars = {}
+    platform_calendars = dict(existing_calendars)
 
     platform_jobs = build_platform_sync_jobs(
         leetcode_username=leetcode_username,
@@ -172,8 +177,7 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
             _mark("leetcode", "failed", "No data returned (username may be invalid or rate-limited).")
         else:
             _mark("leetcode", "synced")
-            for key, value in leetcode_data.get("calendar", {}).items():
-                combined_daily_counts[key] = combined_daily_counts.get(key, 0) + value
+            platform_calendars["leetcode"] = leetcode_data.get("calendar", {})
             if leetcode_data.get("total") is not None:
                 platform_totals["LeetCode"] = leetcode_data.get("total")
             if leetcode_data.get("difficulty"):
@@ -206,8 +210,7 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
                 _mark("github", "failed", "GitHub API returned an error. Please try again later.")
         else:
             _mark("github", "synced")
-            for key, value in github_data.get("calendar", {}).items():
-                combined_daily_counts[key] = combined_daily_counts.get(key, 0) + value
+            platform_calendars["github"] = github_data.get("calendar", {})
             if github_data.get("stats"):
                 platform_totals["GitHub_Issues"] = github_data["stats"]["issues"]
                 platform_totals["GitHub_PRs"] = github_data["stats"]["prs"]
@@ -283,7 +286,7 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
     else:
         _mark("codewars", "skipped")
 
-    update_fields["external_daily_counts"] = combined_daily_counts
+    update_fields["platform_calendars"] = platform_calendars
     update_fields["external_totals"] = platform_totals
     db_handle.user.update_one({"_id": user_id}, {"$set": update_fields})
     user.reload()

--- a/app/utils.py
+++ b/app/utils.py
@@ -207,6 +207,45 @@ def compute_total_solved(progress, external_totals, all_questions=None):
     return max(dsa_done, external_total)
 
 
+def _get_field(user_doc, name, default=None):
+    """Get a field from a raw dict or a ``UserWrapper`` (Flask-Login) object."""
+    if user_doc is None:
+        return default
+    try:
+        return user_doc.get(name, default)
+    except (TypeError, AttributeError):
+        pass
+    try:
+        return getattr(user_doc, name)
+    except AttributeError:
+        return default
+
+
+def get_merged_daily_counts(user_doc):
+    """Return merged flat dict of daily counts, preferring per-platform data with legacy fallback.
+
+    Uses the new ``platform_calendars`` dict (``{platform: {date: count}}``) when available,
+    then fills in any dates from the legacy ``external_daily_counts`` that are not already
+    covered.  Falls back entirely to ``external_daily_counts`` when no per-platform data exists.
+    """
+    platform_calendars = _get_field(user_doc, "platform_calendars", {})
+    if isinstance(platform_calendars, dict) and platform_calendars:
+        merged = {}
+        for _platform, counts in platform_calendars.items():
+            if isinstance(counts, dict):
+                for date, count in counts.items():
+                    if coerce_non_negative_number(count) > 0:
+                        merged[date] = merged.get(date, 0) + count
+        if merged:
+            legacy = _get_field(user_doc, "external_daily_counts", {})
+            if isinstance(legacy, dict):
+                for date, count in legacy.items():
+                    if date not in merged and coerce_non_negative_number(count) > 0:
+                        merged[date] = count
+            return merged
+    return _get_field(user_doc, "external_daily_counts", {})
+
+
 def compute_c_score(user_doc, all_questions=None):
     """Compute composite C-Score (0-999) for a user document."""
     progress = user_doc.get("progress", {})
@@ -230,7 +269,7 @@ def compute_c_score(user_doc, all_questions=None):
         if key in EXTERNAL_SOLVED_TOTAL_KEYS
     )
 
-    ext_daily = user_doc.get("external_daily_counts", {})
+    ext_daily = get_merged_daily_counts(user_doc)
     valid_external_days = count_valid_external_daily_entries(ext_daily)
     ext_daily_keys = valid_external_daily_keys(ext_daily)
     extra_progress_days = set()

--- a/tests/test_sync_platforms.py
+++ b/tests/test_sync_platforms.py
@@ -138,7 +138,7 @@ def test_sync_platforms_runs_selected_platform_jobs_concurrently(monkeypatch):
     assert payload["platforms"]["hackerrank"]["status"] == "synced"
 
     update_fields = captured["db_update"][1]["$set"]
-    assert update_fields["external_daily_counts"] == {"2026-05-25": 5}
+    assert update_fields["platform_calendars"] == {"leetcode": {"2026-05-25": 2}, "github": {"2026-05-25": 3}}
     assert update_fields["external_totals"]["LeetCode"] == 101
     assert update_fields["external_totals"]["GitHub_Commits"] == 9
     assert update_fields["external_totals"]["GFG"] == 77
@@ -254,5 +254,5 @@ def test_sync_platforms_marks_github_rate_limit_payload_failed(monkeypatch):
         "error": "GitHub API rate limit reached. Please try again later.",
     }
     update_fields = captured["db_update"][1]["$set"]
-    assert update_fields["external_daily_counts"] == {}
+    assert update_fields["platform_calendars"] == {}
     assert "GitHub_Commits" not in update_fields["external_totals"]

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -13,6 +13,7 @@ class FakeUser:
         self.hackerrank_username = kwargs.get("hackerrank_username", "")
         self.codingninjas_username = kwargs.get("codingninjas_username", "")
         self.atcoder_username = kwargs.get("atcoder_username", "")
+        self.platform_calendars = kwargs.get("platform_calendars", {})
         self.reload_calls = 0
 
     def reload(self):
@@ -103,7 +104,7 @@ def test_sync_user_platforms_updates_totals_and_clears_cache(monkeypatch):
                     "leetcode_username": "alice",
                     "rating_history": [{"rating": 1700}],
                     "lc_badges_json": '[{"name": "100 Days"}]',
-                    "external_daily_counts": {"2026-05-24": 3},
+                    "platform_calendars": {"leetcode": {"2026-05-24": 3}},
                     "external_totals": {
                         "LeetCode": 25,
                         "LeetCode_Easy": 10,
@@ -119,6 +120,49 @@ def test_sync_user_platforms_updates_totals_and_clears_cache(monkeypatch):
     ]
     assert cache.deleted_keys == ["card_user-1"]
     assert user.reload_calls == 1
+
+
+def test_sync_user_platforms_partial_sync_preserves_other_platforms(monkeypatch):
+    now = datetime.now(timezone.utc)
+    user = FakeUser(platform_calendars={"github": {"2026-05-24": 2}})
+    db = FakeDB()
+    cache = FakeCache()
+
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_leetcode",
+        lambda username: {
+            "calendar": {"2026-05-24": 3, "2026-05-25": 1},
+            "total": 10,
+            "difficulty": {"Easy": 5, "Medium": 4, "Hard": 1},
+            "contest": {"attendedContestsCount": 1, "rating": 1500, "globalRanking": 500},
+        },
+    )
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_leetcode_rating_history",
+        lambda username: [],
+    )
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_lc_badges",
+        lambda username: [],
+    )
+    monkeypatch.setattr("app.profile.sync_service.invalidate_leaderboard_cache", lambda: None)
+
+    payload, status_code = sync_user_platforms(
+        user,
+        {"leetcode": "alice"},
+        db,
+        cache,
+        now=now,
+    )
+
+    assert status_code == 200
+    assert payload["success"] is True
+
+    update_doc = db.user.updates[0][1]
+    assert update_doc["$set"]["platform_calendars"] == {
+        "github": {"2026-05-24": 2},
+        "leetcode": {"2026-05-24": 3, "2026-05-25": 1},
+    }
 
 
 def test_build_sync_platforms_response_all_failed():


### PR DESCRIPTION
## Problem

When a user syncs only one platform (e.g., only LeetCode), the daily counts from other platforms (e.g., GitHub) were silently erased. This happened because `external_daily_counts` was stored as a flat merged dict `{"date": count}` that was completely overwritten on every sync, regardless of which platforms were actually re-fetched.

## Solution

Fixes #603 
Store per-platform calendar data as a nested dict in a new field `platform_calendars` (`{"platform": {"date": count}}`) instead of the flat merged format. When syncing, existing platform data for non-synced platforms is preserved by starting with the existing `platform_calendars` and only updating the entries for platforms that were re-fetched.

## Migration

No explicit migration needed. After deployment:
- Users with only `external_daily_counts` (legacy format) continue to work via the fallback in `get_merged_daily_counts`.
- On the first sync after deployment, `platform_calendars` is written with per-platform data while legacy `external_daily_counts` remains — the helper merges both views.
- A future cleanup can remove stale `external_daily_counts` fields.
