### PR TITLE
fix: compute and persist streak/dsa_progress on profile load and after progress toggle (#602)

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -19,9 +19,11 @@ from app.utils import (
     json_error,
     json_success,
     merge_platform_counts,
+    update_computed_stats,
     utc_now,
 )
 from profile_validation import build_profile_updates
+from streaks import compute_streak
 
 profile_bp = Blueprint("profile", __name__)
 
@@ -342,6 +344,7 @@ def profile():
     user = current_user
     solved_items = {question_id: progress for question_id, progress in user.progress.items() if progress.get("done")}
     dsa_done = len(solved_items)
+    current_streak, longest_streak = compute_streak(user.progress)
 
     pre = current_app.config.get("_PRECOMPUTED")
     if pre:
@@ -454,6 +457,8 @@ def profile():
     leaderboard_entries = build_leaderboard_data()
     profile_leaderboard_rank = get_user_rank_by_c_score(user.id, leaderboard_entries)
 
+    update_computed_stats(user.id, user.progress, db, total_questions)
+
     return render_template(
         "profile.html",
         user=user,
@@ -480,4 +485,6 @@ def profile():
         lc_badges=lc_badges,
         hr_badges=hr_badges,
         profile_leaderboard_rank=profile_leaderboard_rank,
+        current_streak=current_streak,
+        longest_streak=longest_streak,
     )

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -12,6 +12,7 @@ from app.utils import (
     json_success,
     platform_from_question_url,
     question_editorial_links,
+    update_computed_stats,
     utc_now,
 )
 from calendar_export import build_study_plan_ics
@@ -313,6 +314,10 @@ def update_question(question_id):
             update_doc["$inc"] = inc_fields
         db.user.update_one({"_id": user_id}, update_doc)
         current_user.reload()
+        pre = current_app.config.get("_PRECOMPUTED")
+        total_questions = (pre["total_questions"] if pre
+                           else db.question.count_documents({}))
+        update_computed_stats(user_id, current_user.progress, db, total_questions)
         invalidate_leaderboard_cache()
         warm_public_card_cache(user_id, db_handle=db)
         return json_success(message=message)

--- a/app/utils.py
+++ b/app/utils.py
@@ -312,3 +312,20 @@ def merge_platform_counts(in_sheet_counts, external_totals):
     platforms["Codewars"] = max(platforms["Codewars"], coerce_non_negative_number(ext_totals.get("Codewars", 0)))
 
     return platforms
+
+
+def update_computed_stats(user_id, progress, db_handle, total_questions):
+    from streaks import compute_streak
+
+    dsa_done = sum(1 for p in progress.values() if p.get("done"))
+    dsa_progress = round((dsa_done / total_questions * 100) if total_questions > 0 else 0, 1)
+    current_streak, longest_streak = compute_streak(progress)
+
+    db_handle.user.update_one(
+        {"_id": user_id},
+        {"$set": {
+            "dsa_progress": dsa_progress,
+            "current_streak": current_streak,
+            "longest_streak": longest_streak,
+        }}
+    )


### PR DESCRIPTION
## Problem

The profile page and progress card have three related bugs:

### Bug 1: Streak display blank on profile page
`compute_streak()` (defined in `streaks.py`) is never called in the profile route. The profile template (`templates/profile.html`) expects `{{ current_streak }}` and `{{ longest_streak }}` variables (lines 179-180), but these are never passed to `render_template()`, so the streak stat cards render empty.

### Bug 2: Progress card shows 0% DSA progress
`dsa_progress` is never computed and persisted to the user document. The `card_service.py` computes it dynamically from `compute_c_score()`, but the field is never stored in MongoDB, so any code path that reads `user.get("dsa_progress", 0)` falls back to 0.

### Bug 3: No recomputation after progress toggle
`update_question()` in `app/tracker/routes.py` toggles `progress[qid].done` and calls `warm_public_card_cache()`, but never recomputes `dsa_progress`, `current_streak`, or `longest_streak`. Derived stats only update on full profile page load, not after marking a question as done/incomplete.

## Solution

### 1. Shared helper — `update_computed_stats()` (`app/utils.py`)
Added a reusable function that:
- Counts solved questions from `progress` dict
- Computes `dsa_progress` as `(solved / total) * 100`
- Calls `compute_streak(progress)` to get `(current_streak, longest_streak)`
- Persists all three fields to the user document with a single `$set`

### 2. Profile route fix (`app/profile/routes.py`)
- Imports `compute_streak` from `streaks` and `update_computed_stats` from `app.utils`
- Calls `compute_streak(user.progress)` early in the route
- Persists computed stats via `update_computed_stats()` before rendering
- Passes `current_streak` and `longest_streak` to the template

### 3. Tracker route fix (`app/tracker/routes.py`)
- Imports `update_computed_stats` from `app.utils`
- After `current_user.reload()` in `update_question()`, determines `total_questions` from precomputed config (or DB fallback) and calls `update_computed_stats()` to persist fresh values

## Testing
- `compute_streak()` is already unit-tested in `tests/test_streaks.py`
- The profile route now correctly passes streak values to the template (verified by inspection)
- `update_question()` persists recomputed stats after every progress toggle (verified by inspection)

Fixes #602
