### PR TITLE
fix: preserve legacy external daily counts with _legacy backfill and request-aware migration cleanup (#603)

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -11,6 +11,7 @@ from flask_login import current_user, login_required
 
 from app.decorators import admin_required
 from app.extensions import db
+from app.utils import get_merged_daily_counts
 
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
@@ -70,7 +71,7 @@ def _compute_system_stats():
     active_users_today = set()
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
-    projection = {"progress": 1, "external_totals": 1, "external_daily_counts": 1}
+    projection = {"progress": 1, "external_totals": 1, "external_daily_counts": 1, "platform_calendars": 1}
     for user in db.user.find({}, projection):
         progress = user.get("progress") or {}
         solved_in_app = 0
@@ -88,7 +89,7 @@ def _compute_system_stats():
             for key in ("LeetCode", "GFG", "Coding Ninjas", "HackerRank")
         )
 
-        daily_counts = user.get("external_daily_counts") or {}
+        daily_counts = get_merged_daily_counts(user)
         if daily_counts.get(today, 0) > 0:
             active_users_today.add(user["_id"])
 

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -114,6 +114,9 @@ class UserWrapper(UserMixin):
             raise AttributeError(name)
         return self._doc.get(name)
 
+    def get(self, name, default=None):
+        return self._doc.get(name, default)
+
     def reload(self):
         self._doc = db.user.find_one({"_id": self._doc["_id"]}) or self._doc
         return self

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -21,6 +21,7 @@ def build_leaderboard_data():
                 "progress": 1,
                 "external_totals": 1,
                 "external_daily_counts": 1,
+                "platform_calendars": 1,
             },
         )
     )

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -16,6 +16,7 @@ from app.profile.sync_service import (
 )
 from app.utils import (
     compute_in_sheet_platform_counts,
+    get_merged_daily_counts,
     json_error,
     json_success,
     merge_platform_counts,
@@ -383,7 +384,7 @@ def profile():
             day = solved_at.strftime("%Y-%m-%d")
             daily_counts[day] = daily_counts.get(day, 0) + 1
 
-    ext_daily = user.external_daily_counts
+    ext_daily = get_merged_daily_counts(user)
     if ext_daily:
         for day, count in ext_daily.items():
             daily_counts[day] = daily_counts.get(day, 0) + count

--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -157,14 +157,6 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
         existing_calendars = {}
     platform_calendars = dict(existing_calendars)
 
-    # Backfill from legacy external_daily_counts during migration from the old
-    # combined flat-dict format to the new per-platform calendar storage.
-    # The ``_legacy`` entry preserves dates from platforms not yet re-synced.
-    if not any(k for k in platform_calendars if k != "_legacy"):
-        legacy_counts = getattr(user, "external_daily_counts", {})
-        if isinstance(legacy_counts, dict) and legacy_counts:
-            platform_calendars["_legacy"] = dict(legacy_counts)
-
     platform_jobs = build_platform_sync_jobs(
         leetcode_username=leetcode_username,
         github_username=github_username,
@@ -294,9 +286,17 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
     else:
         _mark("codewars", "skipped")
 
-    # Once every platform the user has registered has been synced at least once,
-    # the ``_legacy`` migration entry is no longer needed.
-    if "_legacy" in platform_calendars:
+    # Backfill or remove ``_legacy`` depending on whether the current sync
+    # covered every platform the user has configured.  During the migration
+    # from the old flat ``external_daily_counts`` format to per-platform
+    # calendars, ``_legacy`` preserves dates from platforms not yet re-synced.
+    PLATFORM_KEYS = {"leetcode", "github", "gfg", "hackerrank",
+                     "codingninjas", "atcoder", "codewars"}
+    requested_platforms = {k for k in data if k in PLATFORM_KEYS}
+    legacy_counts = getattr(user, "external_daily_counts", {})
+    has_legacy = isinstance(legacy_counts, dict) and bool(legacy_counts)
+
+    if has_legacy:
         user_platforms = set()
         for attr in ("leetcode_username", "github_username", "gfg_username",
                      "hackerrank_username", "codingninjas_username",
@@ -304,9 +304,13 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
             if getattr(user, attr, ""):
                 platform_name = attr.replace("_username", "")
                 user_platforms.add(platform_name)
-        synced_platforms = {k for k in platform_calendars if k != "_legacy"}
-        if user_platforms and synced_platforms and user_platforms == synced_platforms:
+
+        if user_platforms and requested_platforms and user_platforms.issubset(requested_platforms):
+            # All user platforms were included in this sync → migration done
             platform_calendars.pop("_legacy", None)
+        else:
+            # Partial sync — preserve legacy data for platforms not yet re-synced
+            platform_calendars["_legacy"] = dict(legacy_counts)
 
     update_fields["platform_calendars"] = platform_calendars
     update_fields["external_totals"] = platform_totals

--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -157,6 +157,14 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
         existing_calendars = {}
     platform_calendars = dict(existing_calendars)
 
+    # Backfill from legacy external_daily_counts during migration from the old
+    # combined flat-dict format to the new per-platform calendar storage.
+    # The ``_legacy`` entry preserves dates from platforms not yet re-synced.
+    if not any(k for k in platform_calendars if k != "_legacy"):
+        legacy_counts = getattr(user, "external_daily_counts", {})
+        if isinstance(legacy_counts, dict) and legacy_counts:
+            platform_calendars["_legacy"] = dict(legacy_counts)
+
     platform_jobs = build_platform_sync_jobs(
         leetcode_username=leetcode_username,
         github_username=github_username,
@@ -285,6 +293,20 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
                 platform_totals["Codewars"] = int(codewars_data.get("total", 0))
     else:
         _mark("codewars", "skipped")
+
+    # Once every platform the user has registered has been synced at least once,
+    # the ``_legacy`` migration entry is no longer needed.
+    if "_legacy" in platform_calendars:
+        user_platforms = set()
+        for attr in ("leetcode_username", "github_username", "gfg_username",
+                     "hackerrank_username", "codingninjas_username",
+                     "atcoder_username", "codewars_username"):
+            if getattr(user, attr, ""):
+                platform_name = attr.replace("_username", "")
+                user_platforms.add(platform_name)
+        synced_platforms = {k for k in platform_calendars if k != "_legacy"}
+        if user_platforms and synced_platforms and user_platforms == synced_platforms:
+            platform_calendars.pop("_legacy", None)
 
     update_fields["platform_calendars"] = platform_calendars
     update_fields["external_totals"] = platform_totals

--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -142,7 +142,6 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
         codewars_username = data.get("codewars", "").strip()
         update_fields["codewars_username"] = codewars_username
 
-    combined_daily_counts = {}
     platform_totals = {}
     platform_status = {}
 
@@ -151,6 +150,12 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
         if error:
             payload["error"] = error
         platform_status[platform_key] = payload
+
+    # Preserve existing per-platform calendar data across partial syncs
+    existing_calendars = getattr(user, "platform_calendars", {})
+    if not isinstance(existing_calendars, dict):
+        existing_calendars = {}
+    platform_calendars = dict(existing_calendars)
 
     platform_jobs = build_platform_sync_jobs(
         leetcode_username=leetcode_username,
@@ -172,8 +177,7 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
             _mark("leetcode", "failed", "No data returned (username may be invalid or rate-limited).")
         else:
             _mark("leetcode", "synced")
-            for key, value in leetcode_data.get("calendar", {}).items():
-                combined_daily_counts[key] = combined_daily_counts.get(key, 0) + value
+            platform_calendars["leetcode"] = leetcode_data.get("calendar", {})
             if leetcode_data.get("total") is not None:
                 platform_totals["LeetCode"] = leetcode_data.get("total")
             if leetcode_data.get("difficulty"):
@@ -206,8 +210,7 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
                 _mark("github", "failed", "GitHub API returned an error. Please try again later.")
         else:
             _mark("github", "synced")
-            for key, value in github_data.get("calendar", {}).items():
-                combined_daily_counts[key] = combined_daily_counts.get(key, 0) + value
+            platform_calendars["github"] = github_data.get("calendar", {})
             if github_data.get("stats"):
                 platform_totals["GitHub_Issues"] = github_data["stats"]["issues"]
                 platform_totals["GitHub_PRs"] = github_data["stats"]["prs"]
@@ -283,7 +286,7 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
     else:
         _mark("codewars", "skipped")
 
-    update_fields["external_daily_counts"] = combined_daily_counts
+    update_fields["platform_calendars"] = platform_calendars
     update_fields["external_totals"] = platform_totals
     db_handle.user.update_one({"_id": user_id}, {"$set": update_fields})
     user.reload()

--- a/app/utils.py
+++ b/app/utils.py
@@ -224,24 +224,46 @@ def _get_field(user_doc, name, default=None):
 def get_merged_daily_counts(user_doc):
     """Return merged flat dict of daily counts, preferring per-platform data with legacy fallback.
 
-    Uses the new ``platform_calendars`` dict (``{platform: {date: count}}``) when available,
-    then fills in any dates from the legacy ``external_daily_counts`` that are not already
-    covered.  Falls back entirely to ``external_daily_counts`` when no per-platform data exists.
+    Uses the new ``platform_calendars`` dict (``{platform: {date: count}}``) when available.
+    A special ``_legacy`` key stores the old combined totals during the migration period;
+    for dates that overlap with real per-platform data the higher of the two values is kept
+    (so non-migrated platform contributions are not lost).  Dates from the legacy
+    ``external_daily_counts`` field are used as a second fallback for dates not yet covered
+    by any per-platform data.
+
+    Falls back entirely to ``external_daily_counts`` when no per-platform data exists.
     """
     platform_calendars = _get_field(user_doc, "platform_calendars", {})
     if isinstance(platform_calendars, dict) and platform_calendars:
+        legacy_fallback = {}
+        calendars = {}
+        for key, value in platform_calendars.items():
+            if key == "_legacy" and isinstance(value, dict):
+                legacy_fallback = value
+            else:
+                calendars[key] = value
+
         merged = {}
-        for _platform, counts in platform_calendars.items():
+        for _platform, counts in calendars.items():
             if isinstance(counts, dict):
                 for date, count in counts.items():
                     if coerce_non_negative_number(count) > 0:
                         merged[date] = merged.get(date, 0) + count
+
+        for date, count in legacy_fallback.items():
+            if coerce_non_negative_number(count) > 0:
+                merged[date] = max(merged.get(date, 0), count)
+
         if merged:
+            has_legacy_fallback = bool(legacy_fallback)
             legacy = _get_field(user_doc, "external_daily_counts", {})
             if isinstance(legacy, dict):
                 for date, count in legacy.items():
-                    if date not in merged and coerce_non_negative_number(count) > 0:
-                        merged[date] = count
+                    if coerce_non_negative_number(count) > 0:
+                        if has_legacy_fallback:
+                            merged[date] = max(merged.get(date, 0), count)
+                        elif date not in merged:
+                            merged[date] = count
             return merged
     return _get_field(user_doc, "external_daily_counts", {})
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -207,6 +207,45 @@ def compute_total_solved(progress, external_totals, all_questions=None):
     return max(dsa_done, external_total)
 
 
+def _get_field(user_doc, name, default=None):
+    """Get a field from a raw dict or a ``UserWrapper`` (Flask-Login) object."""
+    if user_doc is None:
+        return default
+    try:
+        return user_doc.get(name, default)
+    except (TypeError, AttributeError):
+        pass
+    try:
+        return getattr(user_doc, name)
+    except AttributeError:
+        return default
+
+
+def get_merged_daily_counts(user_doc):
+    """Return merged flat dict of daily counts, preferring per-platform data with legacy fallback.
+
+    Uses the new ``platform_calendars`` dict (``{platform: {date: count}}``) when available,
+    then fills in any dates from the legacy ``external_daily_counts`` that are not already
+    covered.  Falls back entirely to ``external_daily_counts`` when no per-platform data exists.
+    """
+    platform_calendars = _get_field(user_doc, "platform_calendars", {})
+    if isinstance(platform_calendars, dict) and platform_calendars:
+        merged = {}
+        for _platform, counts in platform_calendars.items():
+            if isinstance(counts, dict):
+                for date, count in counts.items():
+                    if coerce_non_negative_number(count) > 0:
+                        merged[date] = merged.get(date, 0) + count
+        if merged:
+            legacy = _get_field(user_doc, "external_daily_counts", {})
+            if isinstance(legacy, dict):
+                for date, count in legacy.items():
+                    if date not in merged and coerce_non_negative_number(count) > 0:
+                        merged[date] = count
+            return merged
+    return _get_field(user_doc, "external_daily_counts", {})
+
+
 def compute_c_score(user_doc, all_questions=None):
     """Compute composite C-Score (0-999) for a user document."""
     progress = user_doc.get("progress", {})
@@ -230,7 +269,7 @@ def compute_c_score(user_doc, all_questions=None):
         if key in EXTERNAL_SOLVED_TOTAL_KEYS
     )
 
-    ext_daily = user_doc.get("external_daily_counts", {})
+    ext_daily = get_merged_daily_counts(user_doc)
     valid_external_days = count_valid_external_daily_entries(ext_daily)
     ext_daily_keys = valid_external_daily_keys(ext_daily)
     extra_progress_days = set()

--- a/tests/test_sync_platforms.py
+++ b/tests/test_sync_platforms.py
@@ -138,7 +138,7 @@ def test_sync_platforms_runs_selected_platform_jobs_concurrently(monkeypatch):
     assert payload["platforms"]["hackerrank"]["status"] == "synced"
 
     update_fields = captured["db_update"][1]["$set"]
-    assert update_fields["external_daily_counts"] == {"2026-05-25": 5}
+    assert update_fields["platform_calendars"] == {"leetcode": {"2026-05-25": 2}, "github": {"2026-05-25": 3}}
     assert update_fields["external_totals"]["LeetCode"] == 101
     assert update_fields["external_totals"]["GitHub_Commits"] == 9
     assert update_fields["external_totals"]["GFG"] == 77
@@ -254,5 +254,5 @@ def test_sync_platforms_marks_github_rate_limit_payload_failed(monkeypatch):
         "error": "GitHub API rate limit reached. Please try again later.",
     }
     update_fields = captured["db_update"][1]["$set"]
-    assert update_fields["external_daily_counts"] == {}
+    assert update_fields["platform_calendars"] == {}
     assert "GitHub_Commits" not in update_fields["external_totals"]

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 from app.profile.sync_service import build_sync_platforms_response, sync_user_platforms
+from app.utils import get_merged_daily_counts
 
 
 class FakeUser:
@@ -14,6 +15,7 @@ class FakeUser:
         self.codingninjas_username = kwargs.get("codingninjas_username", "")
         self.atcoder_username = kwargs.get("atcoder_username", "")
         self.platform_calendars = kwargs.get("platform_calendars", {})
+        self.external_daily_counts = kwargs.get("external_daily_counts", {})
         self.reload_calls = 0
 
     def reload(self):
@@ -163,6 +165,149 @@ def test_sync_user_platforms_partial_sync_preserves_other_platforms(monkeypatch)
         "github": {"2026-05-24": 2},
         "leetcode": {"2026-05-24": 3, "2026-05-25": 1},
     }
+
+
+def test_sync_backfills_legacy_external_daily_counts_into_platform_calendars(monkeypatch):
+    """On first partial sync after deployment, legacy external_daily_counts are
+    backfilled into platform_calendars._legacy so that dates from platforms
+    not yet re-synced are preserved. _legacy stays until the user's *other*
+    configured platforms (github) are also synced."""
+    now = datetime.now(timezone.utc)
+    user = FakeUser(
+        leetcode_username="alice",
+        github_username="octocat",
+        external_daily_counts={"2026-05-25": 3, "2026-05-26": 1},
+    )
+    db = FakeDB()
+    cache = FakeCache()
+
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_leetcode",
+        lambda username: {
+            "calendar": {"2026-05-25": 2},
+            "total": 10,
+            "difficulty": {"Easy": 5, "Medium": 4, "Hard": 1},
+            "contest": {"attendedContestsCount": 1, "rating": 1500, "globalRanking": 500},
+        },
+    )
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_leetcode_rating_history",
+        lambda username: [],
+    )
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_lc_badges",
+        lambda username: [],
+    )
+    monkeypatch.setattr("app.profile.sync_service.invalidate_leaderboard_cache", lambda: None)
+
+    payload, status_code = sync_user_platforms(
+        user,
+        {"leetcode": "alice"},
+        db,
+        cache,
+        now=now,
+    )
+
+    assert status_code == 200
+    assert payload["success"] is True
+
+    update_doc = db.user.updates[0][1]
+    calendars = update_doc["$set"]["platform_calendars"]
+    assert "leetcode" in calendars
+    assert calendars["leetcode"] == {"2026-05-25": 2}
+    assert "_legacy" in calendars
+    assert calendars["_legacy"] == {"2026-05-25": 3, "2026-05-26": 1}
+
+
+def test_sync_removes_legacy_once_all_platforms_synced(monkeypatch):
+    """Once every platform the user has configured has been synced into
+    platform_calendars, the _legacy entry is removed."""
+    now = datetime.now(timezone.utc)
+    user = FakeUser(
+        leetcode_username="alice",
+        external_daily_counts={"2026-05-25": 3},
+    )
+    db = FakeDB()
+    cache = FakeCache()
+
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_leetcode",
+        lambda username: {
+            "calendar": {"2026-05-25": 4},
+            "total": 10,
+            "difficulty": {"Easy": 5, "Medium": 4, "Hard": 1},
+            "contest": {"attendedContestsCount": 1, "rating": 1500, "globalRanking": 500},
+        },
+    )
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_leetcode_rating_history",
+        lambda username: [],
+    )
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_lc_badges",
+        lambda username: [],
+    )
+    monkeypatch.setattr("app.profile.sync_service.invalidate_leaderboard_cache", lambda: None)
+
+    payload, status_code = sync_user_platforms(
+        user,
+        {"leetcode": "alice"},
+        db,
+        cache,
+        now=now,
+    )
+
+    assert status_code == 200
+    assert payload["success"] is True
+
+    update_doc = db.user.updates[0][1]
+    calendars = update_doc["$set"]["platform_calendars"]
+    assert "leetcode" in calendars
+    assert "_legacy" not in calendars
+
+
+def test_get_merged_daily_counts_uses_max_for_overlapping_legacy_dates():
+    """get_merged_daily_counts preserves legacy counts for dates where
+    platform_calendars only covers a subset of platforms."""
+    user = FakeUser(
+        platform_calendars={
+            "leetcode": {"2026-05-25": 2},
+            "_legacy": {"2026-05-25": 3, "2026-05-26": 1},
+        },
+    )
+    merged = get_merged_daily_counts(user)
+    assert merged == {"2026-05-25": 3, "2026-05-26": 1}
+    assert merged["2026-05-25"] == 3
+
+
+def test_get_merged_daily_counts_no_max_for_legacy_after_full_migration():
+    """Once _legacy is removed, legacy external_daily_counts only fills in
+    missing dates — no max() — so platform_calendars is authoritative."""
+    user = FakeUser(
+        platform_calendars={
+            "leetcode": {"2026-05-25": 2, "2026-05-26": 1},
+            "github": {"2026-05-25": 1, "2026-05-27": 3},
+        },
+        external_daily_counts={"2026-05-25": 99, "2026-05-28": 5},
+    )
+    merged = get_merged_daily_counts(user)
+    # 2026-05-25: platform sum = 3, legacy = 99 → no max, use 3
+    assert merged["2026-05-25"] == 3
+    # 2026-05-26, 2026-05-27: from platforms
+    assert merged["2026-05-26"] == 1
+    assert merged["2026-05-27"] == 3
+    # 2026-05-28: missing from platforms, filled from legacy
+    assert merged["2026-05-28"] == 5
+
+
+def test_get_merged_daily_counts_falls_back_to_legacy():
+    """When platform_calendars is completely empty (no migration done),
+    get_merged_daily_counts falls back to external_daily_counts."""
+    user = FakeUser(
+        external_daily_counts={"2026-05-25": 3},
+    )
+    merged = get_merged_daily_counts(user)
+    assert merged == {"2026-05-25": 3}
 
 
 def test_build_sync_platforms_response_all_failed():

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -13,6 +13,7 @@ class FakeUser:
         self.hackerrank_username = kwargs.get("hackerrank_username", "")
         self.codingninjas_username = kwargs.get("codingninjas_username", "")
         self.atcoder_username = kwargs.get("atcoder_username", "")
+        self.platform_calendars = kwargs.get("platform_calendars", {})
         self.reload_calls = 0
 
     def reload(self):
@@ -103,7 +104,7 @@ def test_sync_user_platforms_updates_totals_and_clears_cache(monkeypatch):
                     "leetcode_username": "alice",
                     "rating_history": [{"rating": 1700}],
                     "lc_badges_json": '[{"name": "100 Days"}]',
-                    "external_daily_counts": {"2026-05-24": 3},
+                    "platform_calendars": {"leetcode": {"2026-05-24": 3}},
                     "external_totals": {
                         "LeetCode": 25,
                         "LeetCode_Easy": 10,
@@ -119,6 +120,49 @@ def test_sync_user_platforms_updates_totals_and_clears_cache(monkeypatch):
     ]
     assert cache.deleted_keys == ["card_user-1"]
     assert user.reload_calls == 1
+
+
+def test_sync_user_platforms_partial_sync_preserves_other_platforms(monkeypatch):
+    now = datetime.now(timezone.utc)
+    user = FakeUser(platform_calendars={"github": {"2026-05-24": 2}})
+    db = FakeDB()
+    cache = FakeCache()
+
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_leetcode",
+        lambda username: {
+            "calendar": {"2026-05-24": 3, "2026-05-25": 1},
+            "total": 10,
+            "difficulty": {"Easy": 5, "Medium": 4, "Hard": 1},
+            "contest": {"attendedContestsCount": 1, "rating": 1500, "globalRanking": 500},
+        },
+    )
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_leetcode_rating_history",
+        lambda username: [],
+    )
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_lc_badges",
+        lambda username: [],
+    )
+    monkeypatch.setattr("app.profile.sync_service.invalidate_leaderboard_cache", lambda: None)
+
+    payload, status_code = sync_user_platforms(
+        user,
+        {"leetcode": "alice"},
+        db,
+        cache,
+        now=now,
+    )
+
+    assert status_code == 200
+    assert payload["success"] is True
+
+    update_doc = db.user.updates[0][1]
+    assert update_doc["$set"]["platform_calendars"] == {
+        "github": {"2026-05-24": 2},
+        "leetcode": {"2026-05-24": 3, "2026-05-25": 1},
+    }
 
 
 def test_build_sync_platforms_response_all_failed():


### PR DESCRIPTION
## Problem

When a user syncs only a subset of their coding platforms (e.g., only LeetCode), the `external_daily_counts` field on their user document gets completely replaced, silently dropping daily count data from platforms that were **not** included in the current sync request. This causes the profile heatmap to lose historical activity from those platforms.

### Root cause

The sync flow in `app/profile/sync_service.py`:
1. Fetches fresh daily counts from the **requested** platforms
2. Stores them as per-platform calendars (`platform_calendars`)
3. Previously, `external_daily_counts` was replaced entirely — no existing data from skipped platforms was preserved

### Additional issue found during review

During the migration from the old flat `external_daily_counts` format to the new per-platform `platform_calendars` format, overlapping dates would lose contributions from non-migrated platforms. Example:
- Legacy `external_daily_counts`: `{"2026-05-25": 3}` (2 LeetCode + 1 GitHub)
- After partial sync (LeetCode only): `platform_calendars` = `{"leetcode": {"2026-05-25": 2}}`
- Merged result: `{"2026-05-25": 2}` — GitHub's 1 contribution was silently dropped

## Solution

### 1. Backfill legacy data into `platform_calendars._legacy` (`sync_service.py`)
On the first sync after deployment, if `platform_calendars` is empty but `external_daily_counts` has data, the legacy data is copied into `platform_calendars["_legacy"]`. This ensures dates from platforms not yet re-synced are preserved.

### 2. `max()` fallback for overlapping dates (`app/utils.py`)
In `get_merged_daily_counts()`:
- **During migration** (`_legacy` exists): for dates that appear in both per-platform calendars and `_legacy`, the **higher** of the two values is kept via `max()`. This preserves contributions from non-migrated platforms.
- **After migration** (`_legacy` removed): legacy `external_daily_counts` only fills in dates **not already covered** by per-platform calendars — no `max()` is applied, so per-platform data is authoritative.

### 3. Request-aware `_legacy` backfill/cleanup (`sync_service.py`)
After each sync, the code checks which platforms the user has configured (by username) vs. which platforms were **included in the sync request body**. If the request covers all configured platforms, migration is complete and `_legacy` is removed. Otherwise, legacy `external_daily_counts` is backfilled into `_legacy` to preserve data from platforms not yet re-synced.

This approach is robust against `run_fetch_jobs` processing platforms that weren't explicitly requested — only the sync request data determines what counts as "synced."

## Migration path

| State | `platform_calendars` | `_legacy` | `get_merged_daily_counts` behavior |
|---|---|---|---|
| Pre-deployment (old data) | `{}` | — | Falls back to `external_daily_counts` |
| First partial sync | `{"leetcode": {...}, "_legacy": {...}}` | Full copy of legacy | Per-platform sum + `max()` for `_legacy` overlap |
| All platforms synced | `{"leetcode": {...}, "github": {...}}` | Removed | Per-platform sum; legacy fills only missing dates |

## Testing
- `test_sync_backfills_legacy_external_daily_counts_into_platform_calendars` — verifies backfill and that `_legacy` persists when the user has other configured platforms not yet synced
- `test_sync_removes_legacy_once_all_platforms_synced` — verifies `_legacy` is removed when all user platforms are synced
- `test_get_merged_daily_counts_uses_max_for_overlapping_legacy_dates` — verifies `max()` preservation during migration
- `test_get_merged_daily_counts_no_max_for_legacy_after_full_migration` — verifies no `max()` after migration, per-platform data is authoritative
- `test_get_merged_daily_counts_falls_back_to_legacy` — verifies fallback when no `platform_calendars` exist
- Existing partial-sync tests continue to pass

Fixes #603
