### PR TITLE
Add head-to-head compare action from leaderboard rows

### DIFF
--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, jsonify, render_template, request
-from flask_login import current_user
+from flask_login import current_user, login_required
 
 from app.extensions import limiter, cache
 from app.leaderboard.cache import LEADERBOARD_CACHE_TIMEOUT, api_leaderboard_cache_key, leaderboard_page_cache_key
@@ -172,3 +172,22 @@ def api_leaderboard():
         "total_pages": (total + per_page - 1) // per_page,
         "current_user_rank": current_user_rank
     })
+
+
+@leaderboard_bp.route("/leaderboard/compare/<user_id>")
+@login_required
+def compare(user_id):
+    """Show a head-to-head comparison between the current user and another public user."""
+    entries = build_leaderboard_data()
+    other = next((e for e in entries if e.get("user_id") == user_id), None)
+    current_user_id = str(current_user.id) if current_user.is_authenticated else None
+    current_entry = next((e for e in entries if e.get("user_id") == current_user_id), None)
+
+    status_code = 404 if other is None else 200
+    return render_template(
+        "leaderboard_compare.html",
+        other=other,
+        current_entry=current_entry,
+        other_user_id=user_id,
+        current_user_id=current_user_id,
+    ), status_code

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -270,6 +270,7 @@
 const CURRENT_USER_ID = {{ current_user_id | tojson }};
 const endpointConfig = {{ {
   "publicProfileBase": url_for('public.public_profile', user_id='__USER_ID__'),
+  "compareBase": url_for('leaderboard.compare', user_id='__USER_ID__'),
 }|tojson }};
 let activeMode = 'cscore';
 let currentPage = 1;
@@ -403,6 +404,10 @@ function renderTable(entries, mode) {
     
     const dsaHTML = `<span class="stat-badge dsa">${e.dsa_done} / 450</span>`;
     
+    const compareHTML = (CURRENT_USER_ID && !isMe && e.user_id)
+      ? `<a class="pagination-btn" style="margin-left:8px" href="${endpointConfig.compareBase.replace('__USER_ID__', encodeURIComponent(e.user_id))}" aria-label="Compare with ${escapeHTML(e.name)}">Compare</a>`
+      : '';
+
     const platformHTML = isCollegeMode
       ? `<span class="stat-badge lc">Solved ${e.total_solved}</span>`
       : `${e.lc_total ? `<span class="stat-badge lc" aria-label="LeetCode: ${e.lc_total} solved">LC ${e.lc_total}</span> ` : ''}
@@ -424,7 +429,7 @@ function renderTable(entries, mode) {
         </td>
         <td class="score-cell ${getScoreClass(mode)}" aria-label="${getScoreLabel(mode)}: ${score}">${score}</td>
         <td>${dsaHTML}</td>
-        <td>${platformHTML}</td>
+        <td>${platformHTML} ${compareHTML}</td>
       </tr>`;
   });
   

--- a/templates/leaderboard_compare.html
+++ b/templates/leaderboard_compare.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="lb-header">
+  <h1><i class="bi bi-filter-square-fill" style="color:var(--accent)" aria-hidden="true"></i> Compare Users</h1>
+  <p>Head-to-head comparison between you and the selected user.</p>
+</div>
+
+<div style="display:flex;gap:20px;flex-wrap:wrap;margin-top:18px;">
+  <div style="flex:1;min-width:280px;border:1px solid var(--border-color);border-radius:12px;padding:16px;background:var(--bg-card)">
+    <h3>Your stats</h3>
+    {% if current_entry %}
+      <p><strong>{{ current_entry.name or 'You' }}</strong></p>
+      <p>C-Score: {{ current_entry.c_score }}</p>
+      <p>Solved: {{ current_entry.total_solved }}</p>
+      <p>LeetCode Rating: {{ current_entry.lc_rating or '—' }}</p>
+    {% else %}
+      <p>You don't have leaderboard data yet.</p>
+    {% endif %}
+  </div>
+
+  <div style="flex:1;min-width:280px;border:1px solid var(--border-color);border-radius:12px;padding:16px;background:var(--bg-card)">
+    <h3>Other user</h3>
+    {% if other %}
+      <p><strong>{{ other.name }}</strong></p>
+      <p>C-Score: {{ other.c_score }}</p>
+      <p>Solved: {{ other.total_solved }}</p>
+      <p>LeetCode Rating: {{ other.lc_rating or '—' }}</p>
+    {% else %}
+      <p>User not found on the leaderboard.</p>
+    {% endif %}
+  </div>
+</div>
+
+<div style="margin-top:18px;">
+  <a href="{{ url_for('leaderboard.leaderboard') }}" class="pagination-btn">← Back to leaderboard</a>
+</div>
+
+{% endblock %}

--- a/tests/test_leaderboard_compare.py
+++ b/tests/test_leaderboard_compare.py
@@ -1,0 +1,74 @@
+from bson import ObjectId
+
+import app.leaderboard.service as leaderboard_service
+from tests.conftest import build_test_app, login_test_user
+
+
+def test_compare_requires_authentication(monkeypatch):
+    app, _ = build_test_app(monkeypatch, extra_db_targets=(leaderboard_service,))
+
+    with app.test_client() as client:
+        response = client.get(f"/leaderboard/compare/{ObjectId()}")
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_compare_renders_current_and_other_user(monkeypatch):
+    app, test_db = build_test_app(monkeypatch, extra_db_targets=(leaderboard_service,))
+
+    current_user_id = test_db.user.insert_one(
+        {
+            "name": "Current User",
+            "email": "current@example.com",
+            "progress": {},
+            "is_admin": False,
+            "is_deactivated": False,
+            "external_totals": {},
+            "external_daily_counts": {},
+        }
+    ).inserted_id
+    other_user_id = test_db.user.insert_one(
+        {
+            "name": "Other User",
+            "email": "other@example.com",
+            "progress": {},
+            "is_admin": False,
+            "is_deactivated": False,
+            "external_totals": {},
+            "external_daily_counts": {},
+        }
+    ).inserted_id
+
+    with app.test_client() as client:
+        login_test_user(client, current_user_id)
+        response = client.get(f"/leaderboard/compare/{other_user_id}")
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Head-to-head comparison" in html
+    assert "Current User" in html
+    assert "Other User" in html
+
+
+def test_compare_returns_404_for_unknown_user(monkeypatch):
+    app, test_db = build_test_app(monkeypatch, extra_db_targets=(leaderboard_service,))
+
+    current_user_id = test_db.user.insert_one(
+        {
+            "name": "Current User",
+            "email": "current@example.com",
+            "progress": {},
+            "is_admin": False,
+            "is_deactivated": False,
+            "external_totals": {},
+            "external_daily_counts": {},
+        }
+    ).inserted_id
+
+    with app.test_client() as client:
+        login_test_user(client, current_user_id)
+        response = client.get(f"/leaderboard/compare/{ObjectId()}")
+
+    assert response.status_code == 404
+    assert "User not found on the leaderboard." in response.get_data(as_text=True)


### PR DESCRIPTION
## Summary
Implements issue #349 by adding a head-to-head compare flow from leaderboard rows.

### What changed
- Added `Compare` action on leaderboard rows for authenticated users (excluding self rows).
- Added new route: `/leaderboard/compare/<user_id>`.
- Added comparison page template to show current user vs selected user stats.
- Hardened compare route behavior:
  - Requires authentication.
  - Returns `404` when the selected user is not found on leaderboard data.
- Replaced hardcoded compare URL in frontend JS with route-generated URL template.
- Added tests for compare flow.

### Tests
- Added `tests/test_leaderboard_compare.py`:
  - redirect to login for unauthenticated access
  - successful render for current user + selected user
  - `404` for unknown selected user
- Full suite run locally: `268 passed`.

Closes #349