### PR TITLE
fix: preserve unmatched progress in replace import

### DIFF
--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -569,8 +569,12 @@ def import_commit():
                 "timestamp": timestamp
             }
     else:
+        # Replace mode should overwrite only the mapped/imported questions while
+        # preserving any existing progress entries that were not present (or not matched)
+        # in the import file.
+        new_progress = dict(current_db_progress)
         for q_id, imp_val in mapped_progress.items():
-            existing = current_db_progress.get(q_id, {})
+            existing = new_progress.get(q_id, {})
             timestamp = existing.get("timestamp")
             if imp_val["done"] and not existing.get("done"):
                 timestamp = utc_now()

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -511,7 +511,7 @@
           </label>
         </div>
         <div style="font-size:0.7rem;color:var(--text-muted);margin-top:4px" id="importModeHelp">
-          Merge will add new progress and combine note differences. Replace will completely overwrite all your sheet progress.
+          Merge will add new progress and combine note differences. Replace will overwrite only the questions found in your import file (unmatched existing progress is preserved).
         </div>
       </div>
       

--- a/tests/test_progress_import.py
+++ b/tests/test_progress_import.py
@@ -193,12 +193,19 @@ def test_import_commit_route_replace(monkeypatch):
         "url": "https://leetcode.com/problems/two-sum/",
         "url2": ""
     }).inserted_id
+    untouched_id = test_db.question.insert_one({
+        "topic": topic_id,
+        "problem": "Best Time to Buy and Sell Stock",
+        "url": "https://leetcode.com/problems/best-time-to-buy-and-sell-stock/",
+        "url2": ""
+    }).inserted_id
 
     # Existing progress
     user_id = test_db.user.insert_one({
         "email": "user@example.com",
         "progress": {
-            str(question_id): {"done": False, "bookmark": True, "notes": "Existing notes"}
+            str(question_id): {"done": False, "bookmark": True, "notes": "Existing notes"},
+            str(untouched_id): {"done": True, "bookmark": False, "notes": "Keep me"}
         },
         "in_sheet_platform_counts": {"LeetCode": 0},
         "is_admin": False
@@ -226,4 +233,10 @@ def test_import_commit_route_replace(monkeypatch):
     assert progress["done"] is True
     assert progress["bookmark"] is False  # Bookmark overwritten to False
     assert progress["notes"] == "Imported notes"  # Notes replaced
-    assert user["in_sheet_platform_counts"]["LeetCode"] == 1
+
+    # Replace mode should not drop unrelated existing entries that were not in the import file.
+    untouched_progress = user["progress"][str(untouched_id)]
+    assert untouched_progress["done"] is True
+    assert untouched_progress["notes"] == "Keep me"
+    # Preserve existing done entries, so counts reflect both solved questions.
+    assert user["in_sheet_platform_counts"]["LeetCode"] == 2


### PR DESCRIPTION
# Description

Fixes progress import `mode=replace` deleting unmatched existing progress entries. Replace mode now overwrites only the questions mapped from the import file and preserves all other existing progress. Updated the import modal help text and added a regression test to ensure unrelated progress isn’t dropped.

Fixes #616

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested in Local
  - `python -m pytest -q tests/test_progress_import.py`

## Checklist
- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs
- Test output: `7 passed` (`tests/test_progress_import.py`)