### PR TITLE
fix: preserve legacy daily counts after calendar migration

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -228,8 +228,8 @@ def get_merged_daily_counts(user_doc):
     A special ``_legacy`` key stores the old combined totals during the migration period;
     for dates that overlap with real per-platform data the higher of the two values is kept
     (so non-migrated platform contributions are not lost).  Dates from the legacy
-    ``external_daily_counts`` field are used as a second fallback for dates not yet covered
-    by any per-platform data.
+    ``external_daily_counts`` field are merged using ``max()`` so older cumulative history
+    is not lost when per-platform calendars have partial coverage (e.g. limited API windows).
 
     Falls back entirely to ``external_daily_counts`` when no per-platform data exists.
     """
@@ -255,15 +255,11 @@ def get_merged_daily_counts(user_doc):
                 merged[date] = max(merged.get(date, 0), count)
 
         if merged:
-            has_legacy_fallback = bool(legacy_fallback)
             legacy = _get_field(user_doc, "external_daily_counts", {})
             if isinstance(legacy, dict):
                 for date, count in legacy.items():
                     if coerce_non_negative_number(count) > 0:
-                        if has_legacy_fallback:
-                            merged[date] = max(merged.get(date, 0), count)
-                        elif date not in merged:
-                            merged[date] = count
+                        merged[date] = max(merged.get(date, 0), count)
             return merged
     return _get_field(user_doc, "external_daily_counts", {})
 

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -280,8 +280,8 @@ def test_get_merged_daily_counts_uses_max_for_overlapping_legacy_dates():
 
 
 def test_get_merged_daily_counts_no_max_for_legacy_after_full_migration():
-    """Once _legacy is removed, legacy external_daily_counts only fills in
-    missing dates — no max() — so platform_calendars is authoritative."""
+    """Once _legacy is removed, external_daily_counts is still merged using max()
+    so established users don't lose older/higher cumulative history."""
     user = FakeUser(
         platform_calendars={
             "leetcode": {"2026-05-25": 2, "2026-05-26": 1},
@@ -290,8 +290,8 @@ def test_get_merged_daily_counts_no_max_for_legacy_after_full_migration():
         external_daily_counts={"2026-05-25": 99, "2026-05-28": 5},
     )
     merged = get_merged_daily_counts(user)
-    # 2026-05-25: platform sum = 3, legacy = 99 → no max, use 3
-    assert merged["2026-05-25"] == 3
+    # 2026-05-25: platform sum = 3, legacy = 99 → keep max = 99
+    assert merged["2026-05-25"] == 99
     # 2026-05-26, 2026-05-27: from platforms
     assert merged["2026-05-26"] == 1
     assert merged["2026-05-27"] == 3


### PR DESCRIPTION
# Description

Fixes `get_merged_daily_counts()` undercounting active days after migration completion by merging `external_daily_counts` using `max()` for overlapping dates even when `_legacy` is absent. This preserves older/higher cumulative history and prevents consistency scores/heatmaps from regressing after sync. Updated the unit test expectations accordingly.

Fixes #619

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested in Local
  - `python -m pytest -q tests/test_sync_service.py -k get_merged_daily_counts`

## Checklist
- [ ] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs
- Test output: `3 passed` for `get_merged_daily_counts` tests (`tests/test_sync_service.py`)