### PR TITLE
fix: invalidate caches on account delete/deactivate

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -10,7 +10,9 @@ from flask import session
 from flask_login import current_user, login_required
 
 from app.decorators import admin_required
-from app.extensions import db
+from app.extensions import cache, db
+from app.leaderboard.cache import invalidate_leaderboard_cache
+from app.profile.sync_service import clear_profile_caches
 from app.utils import get_merged_daily_counts
 
 
@@ -197,6 +199,9 @@ def delete_user(user_id):
     result = db.user.delete_one({"_id": target_id})
     if result.deleted_count != 1:
         abort(500)
+
+    invalidate_leaderboard_cache()
+    clear_profile_caches(cache, target_id)
 
     display_name = target_user.get("name") or target_user.get("email") or "user"
     flash(f"Deleted account for {display_name}.", "success")

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -5,7 +5,9 @@ from bson import ObjectId
 from flask import Blueprint, abort, current_app, flash, redirect, render_template, request, session, url_for
 from flask_login import UserMixin, current_user, login_required, login_user, logout_user
 
-from app.extensions import bcrypt, db, github, google, limiter, login_manager
+from app.extensions import bcrypt, cache, db, github, google, limiter, login_manager
+from app.leaderboard.cache import invalidate_leaderboard_cache
+from app.profile.sync_service import clear_profile_caches
 from app.utils import utc_now
 
 
@@ -244,6 +246,8 @@ def delete_account():
     user_id = current_user.id
     logout_user()
     db.user.delete_one({"_id": user_id})
+    invalidate_leaderboard_cache()
+    clear_profile_caches(cache, user_id)
     flash("Your account has been permanently deleted.", "info")
     return redirect(url_for("auth.login"))
 
@@ -271,6 +275,8 @@ def deactivate_account():
         {"_id": current_user.id},
         {"$set": {"is_deactivated": True, "deactivated_at": utc_now()}},
     )
+    invalidate_leaderboard_cache()
+    clear_profile_caches(cache, current_user.id)
     logout_user()
     flash("Your account has been deactivated. Log in again anytime to reactivate it.", "info")
     return redirect(url_for("auth.login"))

--- a/tests/test_account_deactivation.py
+++ b/tests/test_account_deactivation.py
@@ -51,6 +51,18 @@ def test_deactivate_account_marks_user_and_logs_out(monkeypatch):
         }
     ).inserted_id
 
+    invalidated = {"leaderboard": 0, "profile": 0}
+    monkeypatch.setattr(
+        auth_routes,
+        "invalidate_leaderboard_cache",
+        lambda: invalidated.__setitem__("leaderboard", invalidated["leaderboard"] + 1),
+    )
+    monkeypatch.setattr(
+        auth_routes,
+        "clear_profile_caches",
+        lambda _cache, _user_id: invalidated.__setitem__("profile", invalidated["profile"] + 1),
+    )
+
     with flask_app.test_client() as client:
         login_as(client, user_id)
         with client.session_transaction() as session:
@@ -66,6 +78,8 @@ def test_deactivate_account_marks_user_and_logs_out(monkeypatch):
     assert "/login" in response.headers["Location"]
     assert user_doc["is_deactivated"] is True
     assert user_doc.get("deactivated_at") is not None
+    assert invalidated["leaderboard"] == 1
+    assert invalidated["profile"] == 1
 
 
 def test_login_reactivates_deactivated_password_user(monkeypatch):

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -242,6 +242,18 @@ def test_admin_can_delete_other_user(monkeypatch):
         }
     ).inserted_id
 
+    invalidated = {"leaderboard": 0, "profile": 0}
+    monkeypatch.setattr(
+        admin_routes,
+        "invalidate_leaderboard_cache",
+        lambda: invalidated.__setitem__("leaderboard", invalidated["leaderboard"] + 1),
+    )
+    monkeypatch.setattr(
+        admin_routes,
+        "clear_profile_caches",
+        lambda _cache, _user_id: invalidated.__setitem__("profile", invalidated["profile"] + 1),
+    )
+
     with flask_app.test_client() as client:
         login_as(client, admin_id)
         csrf_token = set_csrf_token(client)
@@ -254,6 +266,8 @@ def test_admin_can_delete_other_user(monkeypatch):
     assert response.status_code == 200
     assert test_db.user.find_one({"_id": victim_id}) is None
     assert "Deleted account for Spam Bot." in response.data.decode("utf-8")
+    assert invalidated["leaderboard"] == 1
+    assert invalidated["profile"] == 1
 
 
 def test_admin_delete_rejects_missing_csrf(monkeypatch):

--- a/tests/test_csrf_protection.py
+++ b/tests/test_csrf_protection.py
@@ -1,5 +1,6 @@
 from bson import ObjectId
 
+import app.auth.routes as auth_routes
 import app.tracker.routes as tracker_routes
 from conftest import build_test_app, login_test_user
 
@@ -24,6 +25,10 @@ def test_delete_account_accepts_one_time_delete_csrf_token(monkeypatch):
         {"email": "oauth@example.com", "progress": {}, "is_admin": False}
     ).inserted_id
 
+    invalidated = {"leaderboard": 0, "profile": 0}
+    monkeypatch.setattr(auth_routes, "invalidate_leaderboard_cache", lambda: invalidated.__setitem__("leaderboard", invalidated["leaderboard"] + 1))
+    monkeypatch.setattr(auth_routes, "clear_profile_caches", lambda _cache, _user_id: invalidated.__setitem__("profile", invalidated["profile"] + 1))
+
     with flask_app.test_client() as client:
         login_test_user(client, user_id)
         with client.session_transaction() as session:
@@ -34,6 +39,8 @@ def test_delete_account_accepts_one_time_delete_csrf_token(monkeypatch):
     assert response.status_code == 302
     assert response.headers["Location"] == "/login"
     assert test_db.user.find_one({"_id": user_id}) is None
+    assert invalidated["leaderboard"] == 1
+    assert invalidated["profile"] == 1
 
 
 def test_delete_account_rejects_missing_csrf_token(monkeypatch):


### PR DESCRIPTION
# Description

Adds missing cache invalidation for irreversible user state changes (self-delete, deactivate, admin delete). After deletion/deactivation, the leaderboard cache is invalidated and the user’s profile/card caches are cleared so stale leaderboard entries and cached card images are not served.

Fixes #618

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- [x] Tested in Local
  - `python -m pytest -q tests/test_csrf_protection.py tests/test_account_deactivation.py tests/test_admin_routes.py`

## Checklist
- [ ] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs
- Test output: `17 passed` (targeted auth/admin/cache tests)