### PR TITLE
fix: avoid clobbering platform counts on profile load

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -404,12 +404,31 @@ def profile():
     topic_progress = []
 
     ext_platform_totals = user.external_totals or {}
-    if user.in_sheet_platform_counts:
-        platforms = merge_platform_counts(user.in_sheet_platform_counts, ext_platform_totals)
+    cached_in_sheet_counts = (
+        user.in_sheet_platform_counts
+        if isinstance(user.in_sheet_platform_counts, dict)
+        else None
+    )
+    if cached_in_sheet_counts is not None:
+        platforms = merge_platform_counts(cached_in_sheet_counts, ext_platform_totals)
     else:
         in_sheet_counts = compute_in_sheet_platform_counts(solved_items, all_questions)
-        db.user.update_one({"_id": user.id}, {"$set": {"in_sheet_platform_counts": in_sheet_counts}})
-        platforms = merge_platform_counts(in_sheet_counts, ext_platform_totals)
+
+        # Avoid clobbering concurrent $inc updates from /update_question by setting only
+        # if the field is still absent at write time.
+        update_result = db.user.update_one(
+            {"_id": user.id, "in_sheet_platform_counts": {"$exists": False}},
+            {"$set": {"in_sheet_platform_counts": in_sheet_counts}},
+        )
+
+        effective_counts = in_sheet_counts
+        if not getattr(update_result, "modified_count", 0):
+            refreshed = db.user.find_one({"_id": user.id}, {"in_sheet_platform_counts": 1}) or {}
+            refreshed_counts = refreshed.get("in_sheet_platform_counts")
+            if isinstance(refreshed_counts, dict):
+                effective_counts = refreshed_counts
+
+        platforms = merge_platform_counts(effective_counts, ext_platform_totals)
 
     lc_easy = dsa_easy
     lc_medium = dsa_medium

--- a/tests/test_profile_platform_counts_race.py
+++ b/tests/test_profile_platform_counts_race.py
@@ -1,0 +1,54 @@
+from bson import ObjectId
+
+import app.leaderboard.service as leaderboard_service
+import app.profile.routes as profile_routes
+from conftest import build_test_app, login_test_user
+
+
+def test_profile_platform_counts_set_is_conditional(monkeypatch):
+    """When in_sheet_platform_counts is missing, /profile should write it using
+    a conditional $set so it can't clobber a concurrent $inc from /update_question."""
+    flask_app, test_db = build_test_app(
+        monkeypatch,
+        extra_db_targets=(profile_routes, leaderboard_service),
+    )
+
+    topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id
+    question_id = test_db.question.insert_one(
+        {
+            "_id": ObjectId(),
+            "topic": topic_id,
+            "problem": "Two Sum",
+            "url": "https://leetcode.com/problems/two-sum",
+            "difficulty": "Easy",
+        }
+    ).inserted_id
+
+    # Note: intentionally omit in_sheet_platform_counts so /profile computes + caches it.
+    user_id = test_db.user.insert_one(
+        {
+            "name": "User",
+            "email": "user@example.com",
+            "progress": {str(question_id): {"done": True}},
+            "external_totals": {},
+        }
+    ).inserted_id
+
+    original_update_one = test_db.user.update_one
+    seen_filters = []
+
+    def wrapped_update_one(filter_doc, update_doc, *args, **kwargs):
+        seen_filters.append(filter_doc)
+        return original_update_one(filter_doc, update_doc, *args, **kwargs)
+
+    monkeypatch.setattr(test_db.user, "update_one", wrapped_update_one)
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.get("/profile")
+
+    assert response.status_code == 200
+    assert seen_filters, "Expected /profile to attempt caching in_sheet_platform_counts"
+    assert any(
+        f.get("in_sheet_platform_counts") == {"$exists": False} for f in seen_filters
+    ), "Expected conditional $exists filter to avoid clobbering concurrent $inc updates"


### PR DESCRIPTION
# Description

Prevents a race where `/profile` writes `in_sheet_platform_counts` via `$set` and can overwrite a concurrent `$inc` from `/update_question/<id>`. The profile route now uses a conditional write (`$exists: false`) and falls back to the stored value if another request already populated the field. Added a regression test asserting the conditional update is used.

Fixes #617

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested in Local
  - `python -m pytest -q tests/test_profile_platform_counts_race.py`

## Checklist
- [ ] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs
- Test output: `1 passed` (`tests/test_profile_platform_counts_race.py`)