### PR TITLE
feat: add public profile privacy controls

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -47,15 +47,16 @@ def resolve_oauth_user(provider_field, provider_id, name, email=None):
         return user_doc, "linked"
 
     result = db.user.insert_one(
-        {
-            "name": name,
-            "email": email,
-            provider_field: provider_id,
-            "progress": {},
-            "is_admin": False,
-            "created_at": utc_now(),
-        }
-    )
+    {
+        "name": name,
+        "email": email,
+        provider_field: provider_id,
+        "progress": {},
+        "profile_visibility": "public",
+        "is_admin": False,
+        "created_at": utc_now(),
+    }
+)
     user_doc = db.user.find_one({"_id": result.inserted_id})
     return user_doc, "created"
 
@@ -194,15 +195,16 @@ def register():
         hashed_password = bcrypt.generate_password_hash(password).decode("utf-8")
         try:
             db.user.insert_one(
-                {
-                    "name": name,
-                    "email": email,
-                    "password": hashed_password,
-                    "progress": {},
-                    "is_admin": False,
-                    "created_at": utc_now(),
-                }
-            )
+    {
+        "name": name,
+        "email": email,
+        "password": hashed_password,
+        "progress": {},
+        "profile_visibility": "public",
+        "is_admin": False,
+        "created_at": utc_now(),
+    }
+)
             flash("Your account has been created! You can now log in.", "success")
             return redirect(url_for("auth.login"))
         except Exception:

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -203,18 +203,32 @@ def edit_profile():
 @profile_bp.route("/u/<user_id>/card.png")
 def public_card(user_id):
     from bson.objectid import ObjectId
+
     try:
         object_id = ObjectId(user_id)
     except Exception:
         return "Invalid User ID", 400
 
     try:
-        user_doc = db.user.find_one({"_id": object_id}, {"is_deactivated": 1})
+        user_doc = db.user.find_one(
+            {"_id": object_id},
+            {"is_deactivated": 1, "profile_visibility": 1},
+        )
     except TypeError:
         # Some lightweight test doubles implement a simpler find_one(query) API.
         user_doc = db.user.find_one({"_id": object_id})
+
     if not user_doc or user_doc.get("is_deactivated"):
         return "User not found", 404
+
+    visibility = user_doc.get("profile_visibility", "public")
+    viewer_is_owner = (
+        current_user.is_authenticated
+        and str(current_user.id) == str(object_id)
+    )
+
+    if visibility == "private" and not viewer_is_owner:
+        return "Profile is private", 403
 
     try:
         img_io, etag, last_modified = get_public_card_image(user_id, object_id, db_handle=db)
@@ -236,8 +250,6 @@ def public_card(user_id):
     except Exception:
         current_app.logger.exception("Failed to generate public progress card")
         return "Unable to generate progress card", 500
-
-
 @profile_bp.route("/search_universities")
 def search_universities():
     """Return matching universities for an autocomplete query.

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -239,6 +239,9 @@ def public_card(user_id):
     if visibility == "private" and not viewer_is_owner:
         return "Profile is private", 403
 
+    if visibility == "stats_only" and not viewer_is_owner:
+        return "Profile card is unavailable for stats-only profiles", 403
+
     try:
         img_io, etag, last_modified = get_public_card_image(user_id, object_id, db_handle=db)
     except LookupError:

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -1,10 +1,12 @@
 from flask import Blueprint, render_template, current_app
+from flask_login import current_user
 from bson import ObjectId
 from bson.errors import InvalidId
 from app.extensions import db
 from app.utils import compute_c_score
 
 public_bp = Blueprint("public", __name__)
+
 
 @public_bp.route("/u/<user_id>")
 def public_profile(user_id):
@@ -18,18 +20,51 @@ def public_profile(user_id):
 
     if not user_doc:
         return "User not found", 404
+
     if user_doc.get("is_deactivated"):
         return "User not found", 404
+
+    visibility = user_doc.get("profile_visibility", "public")
+    viewer_is_owner = (
+        current_user.is_authenticated
+        and str(current_user.id) == str(user_doc.get("_id"))
+    )
+
+    stats = compute_c_score(user_doc)
+
+    if visibility == "private" and not viewer_is_owner:
+        return render_template(
+            "public_profile.html",
+            user={
+                "username": "Private Profile",
+                "avatar_url": "",
+            },
+            stats={},
+            is_private=True,
+            is_stats_only=False,
+        )
+
+    if visibility == "stats_only" and not viewer_is_owner:
+        return render_template(
+            "public_profile.html",
+            user={
+                "username": "Stats Only Profile",
+                "avatar_url": "",
+            },
+            stats=stats,
+            is_private=False,
+            is_stats_only=True,
+        )
 
     public_user_data = {
         "username": user_doc.get("name") or user_doc.get("username", "Unknown User"),
         "avatar_url": user_doc.get("profile_photo") or user_doc.get("avatar_url", ""),
     }
 
-    stats = compute_c_score(user_doc)
-
     return render_template(
         "public_profile.html",
         user=public_user_data,
-        stats=stats
+        stats=stats,
+        is_private=False,
+        is_stats_only=False,
     )

--- a/profile_validation.py
+++ b/profile_validation.py
@@ -12,11 +12,15 @@ PROFILE_FIELD_LIMITS = {
     'website_url': 300,
     'resume_url': 300,
 }
+
 PROFILE_URL_FIELDS = {'linkedin_url', 'twitter_url', 'website_url', 'resume_url'}
+
+PROFILE_VISIBILITY_OPTIONS = {'public', 'private', 'stats_only'}
 
 
 def build_profile_updates(data):
     update_fields = {}
+
     for field, max_length in PROFILE_FIELD_LIMITS.items():
         if field not in data:
             continue
@@ -25,18 +29,22 @@ def build_profile_updates(data):
         if value is None:
             update_fields[field] = ''
             continue
+
         if not isinstance(value, str):
             return None, f'{field} must be text'
 
         value = value.strip()
+
         if field == 'name' and not value:
             return None, 'name is required'
+
         if len(value) > max_length:
             return None, f'{field} must be at most {max_length} characters'
 
         if field in PROFILE_URL_FIELDS and value:
             url_val = value.strip()
             parsed_raw = urlparse(url_val)
+
             if parsed_raw.scheme:
                 if parsed_raw.scheme not in {'http', 'https'}:
                     return None, f'Invalid URL for {field}'
@@ -45,11 +53,27 @@ def build_profile_updates(data):
                     url_val = 'https:' + url_val if url_val.startswith('//') else 'https://' + url_val.split('//', 1)[1]
                 else:
                     url_val = 'https://' + url_val
-            
+
             parsed = urlparse(url_val)
+
             if parsed.scheme not in {'http', 'https'} or not parsed.netloc:
                 return None, f'Invalid URL for {field}'
+
             value = url_val
 
         update_fields[field] = value
+
+    if 'profile_visibility' in data:
+        visibility = data['profile_visibility']
+
+        if not isinstance(visibility, str):
+            return None, 'profile_visibility must be text'
+
+        visibility = visibility.strip().lower()
+
+        if visibility not in PROFILE_VISIBILITY_OPTIONS:
+            return None, 'profile_visibility must be one of: public, private, stats_only'
+
+        update_fields['profile_visibility'] = visibility
+
     return update_fields, None

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -452,7 +452,18 @@
     <div style="margin-bottom:10px"><label class="m-lbl"><i class="bi bi-twitter-x"></i> Twitter / X URL</label><input class="m-inp" id="ep_twitter" placeholder="https://twitter.com/username" value="{{ user.twitter_url or '' }}"></div>
     <div style="margin-bottom:10px"><label class="m-lbl"><i class="bi bi-globe" style="color:var(--info)"></i> Website / Portfolio</label><input class="m-inp" id="ep_website" placeholder="https://yoursite.com" value="{{ user.website_url or '' }}"></div>
     <div style="margin-bottom:16px"><label class="m-lbl"><i class="bi bi-file-earmark-person" style="color:var(--accent)"></i> Resume URL</label><input class="m-inp" id="ep_resume" placeholder="https://drive.google.com/... or LinkedIn resume link" value="{{ user.resume_url or '' }}"><div style="font-size:.7rem;color:var(--text-muted);margin-top:3px">Paste a Google Drive, Dropbox, or any public resume link</div></div>
-    </div><!-- end scrollable body -->
+    <div style="margin-bottom:16px">
+  <label class="m-lbl"><i class="bi bi-shield-lock" style="color:var(--accent)"></i> Profile Visibility</label>
+  <select class="m-inp" id="ep_profile_visibility">
+    <option value="public" {% if (user.profile_visibility or 'public') == 'public' %}selected{% endif %}>Public - show full profile</option>
+    <option value="private" {% if user.profile_visibility == 'private' %}selected{% endif %}>Private - hide public profile</option>
+    <option value="stats_only" {% if user.profile_visibility == 'stats_only' %}selected{% endif %}>Stats Only - show only progress stats</option>
+  </select>
+  <div style="font-size:.7rem;color:var(--text-muted);margin-top:3px">
+    Control what other users can see on your public profile page.
+  </div>
+</div>
+  </div><!-- end scrollable body -->
     <div style="flex-shrink:0;display:flex;justify-content:flex-end;gap:10px;padding:14px 24px;border-top:1px solid var(--border-color)">
       <button class="m-cancel" onclick="closeEditProfile()">Cancel</button>
       <button class="m-save" id="btnSaveProfile" onclick="handleSaveProfile(this)"><span id="saveProfileContent" style="display:inline-flex;align-items:center;gap:6px"><i class="bi bi-check2-circle"></i> Save Profile</span></button>
@@ -559,16 +570,17 @@ const csrfToken = {{ csrf_token()|tojson }};
 window.handleSaveProfile = function(btn){
   const contentEl=document.getElementById('saveProfileContent');
   const payload={
-    name: document.getElementById('ep_name').value,
-    bio: document.getElementById('ep_bio').value,
-    headline: document.getElementById('ep_headline').value,
-    location: document.getElementById('ep_location').value,
-    college: document.getElementById('ep_college').value,
-    linkedin_url: document.getElementById('ep_linkedin').value,
-    twitter_url: document.getElementById('ep_twitter').value,
-    website_url: document.getElementById('ep_website').value,
-    resume_url: document.getElementById('ep_resume').value,
-  };
+  name: document.getElementById('ep_name').value,
+  bio: document.getElementById('ep_bio').value,
+  headline: document.getElementById('ep_headline').value,
+  location: document.getElementById('ep_location').value,
+  college: document.getElementById('ep_college').value,
+  linkedin_url: document.getElementById('ep_linkedin').value,
+  twitter_url: document.getElementById('ep_twitter').value,
+  website_url: document.getElementById('ep_website').value,
+  resume_url: document.getElementById('ep_resume').value,
+  profile_visibility: document.getElementById('ep_profile_visibility').value,
+};
   window.setButtonBusyState(btn, contentEl, { busy: true, busyLabel: 'Saving...' });
   fetch(endpointConfig.editProfile,{method:'POST',headers:{'Content-Type':'application/json','X-CSRFToken':csrfToken},body:JSON.stringify(payload)})
     .then(r=>r.json())

--- a/templates/public_profile.html
+++ b/templates/public_profile.html
@@ -1,13 +1,25 @@
 {% extends "base.html" %}
+
 {% block head %}
+{% if is_private %}
+<meta property="og:title" content="Private Profile | 450 DSA" />
+<meta property="og:description" content="This user has chosen to keep their profile private." />
+<title>Private Profile | 450 DSA</title>
+{% elif is_stats_only %}
+<meta property="og:title" content="Stats Only Profile | 450 DSA" />
+<meta property="og:description"
+      content="This user shares progress statistics only with a C-Score of {{ stats.c_score or 0 }}." />
+<title>Stats Only Profile | 450 DSA</title>
+{% else %}
 <meta property="og:title"
       content="{{ user.username }}'s DSA Profile 450 DSA Tracker" />
 <meta property="og:description"
-      content="{{ user.username }} has solved {{ stats.dsa_done }} DSA problems
-               with a C-Score of {{ stats.c_score }}. Check their full stats!" />
+      content="{{ user.username }} has solved {{ stats.dsa_done or 0 }} DSA problems
+               with a C-Score of {{ stats.c_score or 0 }}. Check their full stats!" />
+<title>{{ user.username }}'s Profile | 450 DSA</title>
+{% endif %}
 <meta property="og:type" content="profile" />
 <meta property="og:url" content="{{ request.url }}" />
-<title>{{ user.username }}'s Profile | 450 DSA</title>
 {% endblock %}
 
 {% block content %}
@@ -25,12 +37,24 @@
 .stat-card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:16px;color:var(--text-primary)}
 .stat-num{font-size:2.4rem;font-weight:900;line-height:1;margin-top:4px;color:var(--text-primary)}
 .stat-lbl{font-size:0.75rem;color:var(--text-secondary);font-weight:600}
+.private-message{max-width:720px;margin:0 auto;text-align:center;padding:34px}
+.private-icon{font-size:3rem;margin-bottom:14px}
+.private-title{font-size:1.8rem;font-weight:900;margin-bottom:10px}
+.private-text{color:var(--text-secondary);font-size:.95rem}
 @media(max-width:520px){.stat-row{grid-template-columns:1fr}}
 </style>
 
 <div class="prof-layout">
+  {% if is_private %}
+    <div class="card private-message">
+      <div class="private-icon">🔒</div>
+      <div class="private-title">Private Profile</div>
+      <p class="private-text">This user has chosen to keep their public profile private.</p>
+    </div>
+  {% else %}
   <div class="prof-main">
     <div class="card" style="text-align:center">
+      {% if not is_stats_only %}
       <div class="avatar-ring" style="margin-bottom:16px">
         {% if user.avatar_url %}
         <img src="{{ user.avatar_url }}" width="90" height="90" loading="eager" fetchpriority="high" decoding="async" style="width:100%;height:100%;object-fit:cover;border-radius:50%" alt="{{ user.username }}">
@@ -40,6 +64,12 @@
       </div>
       <div class="prof-name">{{ user.username }}</div>
       <div class="prof-handle">Public DSA Profile</div>
+      {% else %}
+      <div class="private-icon">📊</div>
+      <div class="prof-name">Stats Only Profile</div>
+      <div class="prof-handle">This user shares progress statistics only</div>
+      {% endif %}
+
       <div class="sec-title" style="margin-top:18px">C-Score</div>
       <div class="big-num" style="color:var(--accent)">{{ stats.c_score or 0 }}</div>
       <div class="sub-label">Composite public score</div>
@@ -108,9 +138,14 @@
     </div>
 
     <div class="card" style="text-align:center;color:var(--text-secondary);font-size:.82rem">
-      This is a public profile page.
+      {% if is_stats_only %}
+        This profile is limited to public progress statistics.
+      {% else %}
+        This is a public profile page.
+      {% endif %}
     </div>
   </div>
+  {% endif %}
 </div>
 {% endblock %}
 

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -42,3 +42,22 @@ def test_profile_updates_reject_non_text_values():
 
     assert updates is None
     assert error == 'headline must be text'
+def test_profile_updates_accept_valid_profile_visibility():
+    updates, error = build_profile_updates({"profile_visibility": "stats_only"})
+
+    assert error is None
+    assert updates == {"profile_visibility": "stats_only"}
+
+
+def test_profile_updates_normalize_profile_visibility():
+    updates, error = build_profile_updates({"profile_visibility": "  PRIVATE  "})
+
+    assert error is None
+    assert updates == {"profile_visibility": "private"}
+
+
+def test_profile_updates_reject_invalid_profile_visibility():
+    updates, error = build_profile_updates({"profile_visibility": "friends_only"})
+
+    assert updates is None
+    assert error == "profile_visibility must be one of: public, private, stats_only"

--- a/tests/test_progress_card.py
+++ b/tests/test_progress_card.py
@@ -127,23 +127,25 @@ def test_public_card_valid_user(client, app):
             "GFG": 5,
         }
     }
-    
-    app.mock_db.question.data = {
-        "q1": {"_id": "q1", "url": "https://leetcode.com/"},
-        "q2": {"_id": "q2", "url": "https://geeksforgeeks.org/"},
-        "q3": {"_id": "q3", "url": ""},
-        "q4": {"_id": "q4", "url": ""}
+def test_public_card_private_profile_returns_403(client, app):
+    """Test that private profiles block public progress card access."""
+    user_id = ObjectId()
+    user_data = {
+        "_id": user_id,
+        "name": "Private User",
+        "profile_visibility": "private",
+        "progress": {},
+        "external_totals": {},
     }
-    
-    app.mock_db.user.data[str(user_id)] = user_data
-    
-    with patch('app.profile.routes.db', app.mock_db):
-        response = client.get(f"/u/{user_id}/card.png")
-        
-        assert response.status_code == 200
-        assert response.content_type == "image/png"
-        assert len(response.data) > 0
 
+    app.mock_db.user.data[str(user_id)] = user_data
+
+    with patch("app.profile.routes.db", app.mock_db):
+        response = client.get(f"/u/{user_id}/card.png")
+
+    assert response.status_code == 403
+    assert b"Profile is private" in response.data
+    
 
 def test_public_card_invalid_user_id(client, app):
     """Test that /u/<invalid_id>/card.png returns 400."""

--- a/tests/test_progress_card.py
+++ b/tests/test_progress_card.py
@@ -114,19 +114,38 @@ def test_public_card_valid_user(client, app):
     """Test that /u/<user_id>/card.png returns 200 with valid user."""
     user_id = ObjectId()
     from datetime import datetime, timedelta, timezone
+
     now = datetime.now(timezone.utc)
     user_data = {
         "_id": user_id,
         "name": "Test User",
         "progress": {
             "q1": {"done": True, "timestamp": now},
-            "q2": {"done": True, "timestamp": now - timedelta(days=1)}
+            "q2": {"done": True, "timestamp": now - timedelta(days=1)},
         },
         "external_totals": {
             "LeetCode": 10,
             "GFG": 5,
-        }
+        },
     }
+
+    app.mock_db.question.data = {
+        "q1": {"_id": "q1", "url": "https://leetcode.com/"},
+        "q2": {"_id": "q2", "url": "https://geeksforgeeks.org/"},
+        "q3": {"_id": "q3", "url": ""},
+        "q4": {"_id": "q4", "url": ""},
+    }
+
+    app.mock_db.user.data[str(user_id)] = user_data
+
+    with patch("app.profile.routes.db", app.mock_db):
+        response = client.get(f"/u/{user_id}/card.png")
+
+    assert response.status_code == 200
+    assert response.content_type == "image/png"
+    assert len(response.data) > 0
+
+
 def test_public_card_private_profile_returns_403(client, app):
     """Test that private profiles block public progress card access."""
     user_id = ObjectId()
@@ -146,7 +165,6 @@ def test_public_card_private_profile_returns_403(client, app):
     assert response.status_code == 403
     assert b"Profile is private" in response.data
     
-
 def test_public_card_invalid_user_id(client, app):
     """Test that /u/<invalid_id>/card.png returns 400."""
     with patch('app.profile.routes.db', app.mock_db):

--- a/tests/test_progress_card.py
+++ b/tests/test_progress_card.py
@@ -77,7 +77,7 @@ def app(mock_db):
         from app import create_app
         app = create_app()
         app.config['TESTING'] = True
-        
+
         # Keep the mock in place for the app context
         app.mock_db = mock_db
         yield app
@@ -92,7 +92,7 @@ def client(app):
 def test_card_generator_returns_bytesio():
     """Test that generate_progress_card returns a BytesIO object."""
     from card_generator import generate_progress_card
-    
+
     result = generate_progress_card(
         name="Test User",
         c_score=100,
@@ -100,10 +100,10 @@ def test_card_generator_returns_bytesio():
         current_streak=10,
         platforms={"LeetCode": 50}
     )
-    
+
     # Verify it's a BytesIO object
     assert isinstance(result, io.BytesIO)
-    
+
     # Verify it contains PNG data
     result.seek(0)
     png_header = result.read(8)
@@ -164,7 +164,27 @@ def test_public_card_private_profile_returns_403(client, app):
 
     assert response.status_code == 403
     assert b"Profile is private" in response.data
-    
+
+
+def test_public_card_stats_only_profile_returns_403(client, app):
+    """Test that stats-only profiles block public progress card access to avoid identity leaks."""
+    user_id = ObjectId()
+    user_data = {
+        "_id": user_id,
+        "name": "Stats Only User",
+        "profile_visibility": "stats_only",
+        "progress": {},
+        "external_totals": {"LeetCode": 12},
+    }
+
+    app.mock_db.user.data[str(user_id)] = user_data
+
+    with patch("app.profile.routes.db", app.mock_db):
+        response = client.get(f"/u/{user_id}/card.png")
+
+    assert response.status_code == 403
+    assert b"Profile card is unavailable for stats-only profiles" in response.data
+
 def test_public_card_invalid_user_id(client, app):
     """Test that /u/<invalid_id>/card.png returns 400."""
     with patch('app.profile.routes.db', app.mock_db):
@@ -176,10 +196,10 @@ def test_public_card_invalid_user_id(client, app):
 def test_public_card_missing_user(client, app):
     """Test that /u/<nonexistent_user_id>/card.png returns 404."""
     user_id = ObjectId()
-    
+
     with patch('app.profile.routes.db', app.mock_db):
         response = client.get(f"/u/{user_id}/card.png")
-        
+
         assert response.status_code == 404
         assert b"User not found" in response.data
 
@@ -193,16 +213,16 @@ def test_public_card_with_minimal_data(client, app):
         "progress": {},
         "external_totals": {}
     }
-    
+
     app.mock_db.question.data = {
         "q1": {"_id": "q1"}
     }
-    
+
     app.mock_db.user.data[str(user_id)] = user_data
-    
+
     with patch('app.profile.routes.db', app.mock_db):
         response = client.get(f"/u/{user_id}/card.png")
-        
+
         assert response.status_code == 200
         assert response.content_type == "image/png"
 
@@ -215,16 +235,16 @@ def test_public_card_with_anonymous_name(client, app):
         "progress": {"q1": {"done": True, "timestamp": datetime.now(timezone.utc)}},
         "external_totals": {}
     }
-    
+
     app.mock_db.question.data = {
         "q1": {"_id": "q1"}
     }
-    
+
     app.mock_db.user.data[str(user_id)] = user_data
-    
+
     with patch('app.profile.routes.db', app.mock_db):
         response = client.get(f"/u/{user_id}/card.png")
-        
+
         assert response.status_code == 200
         assert response.content_type == "image/png"
 
@@ -238,24 +258,24 @@ def test_public_card_caching(client, app):
         "progress": {"q1": {"done": True, "timestamp": datetime.now(timezone.utc)}},
         "external_totals": {"LeetCode": 20}
     }
-    
+
     app.mock_db.question.data = {
         "q1": {"_id": "q1"}
     }
-    
+
     app.mock_db.user.data[str(user_id)] = user_data
-    
+
     with patch('app.profile.routes.db', app.mock_db):
         # First request - should generate card
         response1 = client.get(f"/u/{user_id}/card.png")
         assert response1.status_code == 200
         data1 = response1.data
-        
+
         # Second request - should use cache
         response2 = client.get(f"/u/{user_id}/card.png")
         assert response2.status_code == 200
         data2 = response2.data
-        
+
         # Both should return the same PNG data
         assert data1 == data2
 
@@ -312,15 +332,15 @@ def test_public_card_exception_handling(client, app):
         "progress": {},
         "external_totals": {}
     }
-    
+
     app.mock_db.question.data = {}
-    
+
     app.mock_db.user.data[str(user_id)] = user_data
-    
+
     with patch('app.profile.routes.db', app.mock_db), \
          patch('card_generator.generate_progress_card', side_effect=Exception("Secret path leak")):
         response = client.get(f"/u/{user_id}/card.png")
-        
+
         assert response.status_code == 500
         assert b"Unable to generate progress card" in response.data
         assert b"Secret path leak" not in response.data
@@ -336,14 +356,14 @@ def test_card_generator_with_long_name(client, app):
         "progress": {},
         "external_totals": {"LeetCode": 100, "GFG": 50, "Coding Ninjas": 30, "HackerRank": 20}
     }
-    
+
     app.mock_db.question.data = {}
-    
+
     app.mock_db.user.data[str(user_id)] = user_data
-    
+
     with patch('app.profile.routes.db', app.mock_db):
         response = client.get(f"/u/{user_id}/card.png")
-        
+
         assert response.status_code == 200
         assert response.content_type == "image/png"
         assert len(response.data) > 0
@@ -363,14 +383,14 @@ def test_card_generator_with_all_platforms(client, app):
             "HackerRank": 150
         }
     }
-    
+
     app.mock_db.question.data = {}
-    
+
     app.mock_db.user.data[str(user_id)] = user_data
-    
+
     with patch('app.profile.routes.db', app.mock_db):
         response = client.get(f"/u/{user_id}/card.png")
-        
+
         assert response.status_code == 200
         assert response.content_type == "image/png"
         assert len(response.data) > 0
@@ -385,14 +405,14 @@ def test_card_generator_with_zero_values(client, app):
         "progress": {},
         "external_totals": {}
     }
-    
+
     app.mock_db.question.data = {}
-    
+
     app.mock_db.user.data[str(user_id)] = user_data
-    
+
     with patch('app.profile.routes.db', app.mock_db):
         response = client.get(f"/u/{user_id}/card.png")
-        
+
         assert response.status_code == 200
         assert response.content_type == "image/png"
         assert len(response.data) > 0
@@ -401,7 +421,7 @@ def test_card_generator_with_zero_values(client, app):
 def test_card_generator_png_format():
     """Test that generated card is valid PNG format."""
     from card_generator import generate_progress_card
-    
+
     result = generate_progress_card(
         name="PNG Format Test",
         c_score=50,
@@ -409,12 +429,12 @@ def test_card_generator_png_format():
         current_streak=5,
         platforms={"LeetCode": 25}
     )
-    
+
     # Check PNG signature
     result.seek(0)
     signature = result.read(8)
     assert signature == b'\x89PNG\r\n\x1a\n'
-    
+
     # Check that we can seek and read multiple times
     result.seek(0)
     data1 = result.read()
@@ -427,7 +447,7 @@ def test_card_generator_png_format():
 def test_card_generator_empty_platforms():
     """Test card generation with empty platforms dict."""
     from card_generator import generate_progress_card
-    
+
     result = generate_progress_card(
         name="No Platforms",
         c_score=10,
@@ -435,7 +455,7 @@ def test_card_generator_empty_platforms():
         current_streak=1,
         platforms={}
     )
-    
+
     assert isinstance(result, io.BytesIO)
     result.seek(0)
     assert result.read(8) == b'\x89PNG\r\n\x1a\n'
@@ -444,7 +464,7 @@ def test_card_generator_empty_platforms():
 def test_card_generator_single_platform():
     """Test card generation with single platform."""
     from card_generator import generate_progress_card
-    
+
     result = generate_progress_card(
         name="Single Platform",
         c_score=25,
@@ -452,7 +472,7 @@ def test_card_generator_single_platform():
         current_streak=2,
         platforms={"LeetCode": 50}
     )
-    
+
     assert isinstance(result, io.BytesIO)
     result.seek(0)
     assert result.read(8) == b'\x89PNG\r\n\x1a\n'
@@ -461,7 +481,7 @@ def test_card_generator_single_platform():
 def test_card_generator_multiple_platforms():
     """Test card generation with multiple platforms."""
     from card_generator import generate_progress_card
-    
+
     result = generate_progress_card(
         name="Multi Platform",
         c_score=100,
@@ -474,7 +494,7 @@ def test_card_generator_multiple_platforms():
             "HackerRank": 20
         }
     )
-    
+
     assert isinstance(result, io.BytesIO)
     result.seek(0)
     assert result.read(8) == b'\x89PNG\r\n\x1a\n'
@@ -483,7 +503,7 @@ def test_card_generator_multiple_platforms():
 def test_card_generator_high_values():
     """Test card generation with high metric values."""
     from card_generator import generate_progress_card
-    
+
     result = generate_progress_card(
         name="High Achiever",
         c_score=9999,
@@ -496,7 +516,7 @@ def test_card_generator_high_values():
             "HackerRank": 300
         }
     )
-    
+
     assert isinstance(result, io.BytesIO)
     result.seek(0)
     assert result.read(8) == b'\x89PNG\r\n\x1a\n'
@@ -505,7 +525,7 @@ def test_card_generator_high_values():
 def test_card_generator_special_characters_in_name():
     """Test card generation with special characters in name."""
     from card_generator import generate_progress_card
-    
+
     result = generate_progress_card(
         name="User@#$%^&*()",
         c_score=50,
@@ -513,7 +533,7 @@ def test_card_generator_special_characters_in_name():
         current_streak=5,
         platforms={"LeetCode": 25}
     )
-    
+
     assert isinstance(result, io.BytesIO)
     result.seek(0)
     assert result.read(8) == b'\x89PNG\r\n\x1a\n'
@@ -522,7 +542,7 @@ def test_card_generator_special_characters_in_name():
 def test_card_generator_unicode_name():
     """Test card generation with unicode characters in name."""
     from card_generator import generate_progress_card
-    
+
     result = generate_progress_card(
         name="用户名 🚀",
         c_score=50,
@@ -530,7 +550,7 @@ def test_card_generator_unicode_name():
         current_streak=5,
         platforms={"LeetCode": 25}
     )
-    
+
     assert isinstance(result, io.BytesIO)
     result.seek(0)
     assert result.read(8) == b'\x89PNG\r\n\x1a\n'
@@ -546,12 +566,12 @@ def test_public_card_response_headers(client, app):
         "external_totals": {}
     }
     app.mock_db.question.data = {}
-    
+
     app.mock_db.user.data[str(user_id)] = user_data
-    
+
     with patch('app.profile.routes.db', app.mock_db):
         response = client.get(f"/u/{user_id}/card.png")
-        
+
         assert response.status_code == 200
         assert response.content_type == "image/png"
         assert "Content-Length" in response.headers or len(response.data) > 0

--- a/tests/test_public_profile.py
+++ b/tests/test_public_profile.py
@@ -59,3 +59,63 @@ def test_public_profile_missing_user_returns_404(monkeypatch):
         response = client.get("/u/64b64c3f8f1d2b3c4d5e6f70")
 
     assert response.status_code == 404
+
+def test_private_public_profile_hides_profile_from_public_viewer(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(public_routes,))
+    user_id = test_db.user.insert_one(
+        {
+            "name": "Hidden User",
+            "email": "hidden@example.com",
+            "profile_visibility": "private",
+            "profile_photo": "https://example.com/avatar.png",
+            "progress": {},
+            "external_totals": {
+                "LeetCode": 12,
+            },
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        response = client.get(f"/u/{user_id}")
+
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert "Private Profile" in html
+    assert "This user has chosen to keep their public profile private." in html
+    assert "Hidden User" not in html
+    assert "hidden@example.com" not in html
+    assert "https://example.com/avatar.png" not in html
+
+
+def test_stats_only_public_profile_shows_stats_without_identity(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(public_routes,))
+    user_id = test_db.user.insert_one(
+        {
+            "name": "Stats User",
+            "email": "stats@example.com",
+            "profile_visibility": "stats_only",
+            "profile_photo": "https://example.com/stats-avatar.png",
+            "progress": {},
+            "external_totals": {
+                "LeetCode": 12,
+                "LeetCode_Easy": 3,
+                "LeetCode_Medium": 6,
+                "LeetCode_Hard": 3,
+                "GFG": 4,
+                "HackerRank": 2,
+                "Coding Ninjas": 1,
+            },
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        response = client.get(f"/u/{user_id}")
+
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert "Stats Only Profile" in html
+    assert "This profile is limited to public progress statistics." in html
+    assert "LeetCode" in html
+    assert "Stats User" not in html
+    assert "stats@example.com" not in html
+    assert "https://example.com/stats-avatar.png" not in html    

--- a/tests/test_public_profile.py
+++ b/tests/test_public_profile.py
@@ -118,4 +118,4 @@ def test_stats_only_public_profile_shows_stats_without_identity(monkeypatch):
     assert "LeetCode" in html
     assert "Stats User" not in html
     assert "stats@example.com" not in html
-    assert "https://example.com/stats-avatar.png" not in html    
+    assert "https://example.com/stats-avatar.png" not in html


### PR DESCRIPTION
## Summary

This PR adds public profile privacy controls for users.

## Changes Made

* Added `profile_visibility` support with three options:

  * `public`
  * `private`
  * `stats_only`
* Added validation for `profile_visibility` in profile update logic.
* Added default `profile_visibility: public` for newly registered users.
* Added default visibility for OAuth-created users.
* Updated public profile route to respect user visibility settings.
* Updated public progress card route to block access for private profiles.
* Added profile visibility dropdown in the edit profile modal.
* Updated public profile template to support private and stats-only views.
* Added tests for profile validation, public profile visibility, and private card access.

## Tests Run

```bash
python -m pytest tests\test_profile_validation.py tests\test_public_profile.py tests\test_progress_card.py
```

Result:

```bash
37 passed, 1 warning
```

Fixes #281
