### PR TITLE
feat: add bulk actions for topic questions (#358)

### DIFF
--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -7,6 +7,7 @@ from app.extensions import db
 from app.leaderboard.cache import invalidate_leaderboard_cache
 from app.profile.card_service import warm_public_card_cache
 from app.utils import (
+    compute_in_sheet_platform_counts,
     json_error,
     json_success,
     platform_from_question_url,
@@ -57,6 +58,7 @@ CSV_EXPORT_QUESTION_PROJECTION = {
     "url2": 1,
 }
 ALL_NOTES_QUESTION_PROJECTION = {"problem": 1, "topic": 1}
+BULK_QUESTION_PROJECTION = {"url": 1}
 
 @tracker_bp.route("/")
 def index():
@@ -311,6 +313,79 @@ def update_question(question_id):
         return json_success(message=message)
 
     return json_success(message="No changes made")
+
+
+@tracker_bp.route("/update_questions", methods=["POST"])
+@login_required
+def update_questions():
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return json_error("Request body must be a JSON object", status_code=400)
+
+    question_ids = data.get("question_ids")
+    action = (data.get("action") or "").strip().lower()
+    allowed_actions = {"done", "skipped", "bookmark", "unbookmark", "clear"}
+
+    if not isinstance(question_ids, list) or not question_ids:
+        return json_error("question_ids must be a non-empty list", status_code=400)
+    if action not in allowed_actions:
+        return json_error("Invalid bulk action", status_code=400)
+
+    valid_question_ids = []
+    for question_id in question_ids:
+        if not isinstance(question_id, str):
+            continue
+        try:
+            ObjectId(question_id)
+        except InvalidId:
+            continue
+        valid_question_ids.append(question_id)
+
+    if not valid_question_ids:
+        return json_error("No valid question ids provided", status_code=400)
+
+    progress = dict(current_user.progress or {})
+    now = utc_now()
+    modified_count = 0
+
+    for question_id in valid_question_ids:
+        existing = dict(progress.get(question_id, {}))
+        if action == "done":
+            if not existing.get("done"):
+                existing["timestamp"] = now
+            existing["done"] = True
+            existing["skipped"] = False
+        elif action == "skipped":
+            existing["done"] = False
+            existing["skipped"] = True
+        elif action == "bookmark":
+            existing["bookmark"] = True
+        elif action == "unbookmark":
+            existing["bookmark"] = False
+        elif action == "clear":
+            existing["done"] = False
+            existing["skipped"] = False
+        progress[question_id] = existing
+        modified_count += 1
+
+    solved_items = {question_id: item for question_id, item in progress.items() if item.get("done")}
+    question_docs = list(db.question.find({}, BULK_QUESTION_PROJECTION))
+    in_sheet_counts = compute_in_sheet_platform_counts(solved_items, question_docs)
+
+    db.user.update_one(
+        {"_id": current_user.id},
+        {
+            "$set": {
+                "progress": progress,
+                "in_sheet_platform_counts": in_sheet_counts,
+            }
+        },
+    )
+    current_user.reload()
+    invalidate_leaderboard_cache()
+    warm_public_card_cache(current_user.id, db_handle=db)
+
+    return json_success(message=f"Updated {modified_count} questions")
 
 
 @tracker_bp.route("/bookmarks")

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -34,12 +34,19 @@
     font-weight: 600;
 }
 .topic-status:empty { display: none; }
+.bulk-toolbar { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-bottom: 14px; }
+.bulk-toolbar .bulk-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+.bulk-toolbar .bulk-action-btn { padding: 6px 14px; border-radius: 8px; border: 1px solid var(--border-color); background: var(--bg-secondary); color: var(--text-secondary); font-size: 0.8rem; font-weight: 700; cursor: pointer; transition: all 0.2s; font-family: inherit; }
+.bulk-toolbar .bulk-action-btn:hover { border-color: var(--accent); color: var(--accent); }
+.bulk-toolbar .bulk-action-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.bulk-select-all { display: inline-flex; align-items: center; gap: 8px; font-size: 0.82rem; color: var(--text-secondary); font-weight: 600; }
 .topic-skeleton-shell { grid-template-columns: 1fr; }
 .topic-skeleton-toolbar { display: grid; grid-template-columns: repeat(4, minmax(90px, 1fr)); gap: 10px; }
 .topic-skeleton-card { min-height: 420px; }
 .btn-busy { pointer-events: none; opacity: 0.75; }
 .btn-busy::before { content: ""; width: 12px; height: 12px; border-radius: 50%; border: 2px solid currentColor; border-right-color: transparent; display: inline-block; animation: topic-spin 0.7s linear infinite; }
 .row-updating { opacity: 0.55; }
+.row-selected { background: rgba(255, 184, 0, 0.08); }
 
 @keyframes topic-spin {
     to { transform: rotate(360deg); }
@@ -126,6 +133,21 @@
     </button>
 </div>
 
+<div class="bulk-toolbar" id="bulkToolbar" aria-label="Bulk actions for selected questions">
+    <label class="bulk-select-all">
+        <input type="checkbox" id="bulkSelectAll" aria-label="Select all questions on this page">
+        Select all
+    </label>
+    <div class="bulk-actions">
+        <button type="button" class="bulk-action-btn" data-bulk-action="done">Mark Done</button>
+        <button type="button" class="bulk-action-btn" data-bulk-action="skipped">Mark Skipped</button>
+        <button type="button" class="bulk-action-btn" data-bulk-action="bookmark">Bookmark</button>
+        <button type="button" class="bulk-action-btn" data-bulk-action="unbookmark">Unbookmark</button>
+        <button type="button" class="bulk-action-btn" data-bulk-action="clear">Clear Progress</button>
+    </div>
+    <div class="topic-subtitle" id="bulkSelectionCount" style="margin:0">0 selected</div>
+</div>
+
 <div class="topic-status" id="topicStatus" role="status" aria-live="polite"></div>
 
 <div class="questions-table-wrap">
@@ -133,6 +155,9 @@
         <caption class="visually-hidden">Questions for {{ topic.name }} topic - {{ total_count }} total questions</caption>
         <thead>
             <tr>
+                <th scope="col">
+                    <input type="checkbox" id="bulkSelectAllHeader" aria-label="Select all questions on this page">
+                </th>
                 <th scope="col">#</th>
                 <th scope="col">Status</th>
                 <th scope="col">Problem</th>
@@ -147,6 +172,9 @@
             {% set p = progress_dict.get(q_id_str) %}
             {% set difficulty = q.get('difficulty', 'Medium') %}
             <tr class="{% if p and p.done %}row-done{% endif %}" id="row-{{ q_id_str }}" data-difficulty="{{ difficulty }}">
+                <td>
+                    <input type="checkbox" class="bulk-select-checkbox" data-id="{{ q_id_str }}" aria-label="Select '{{ q.problem }}' for bulk actions">
+                </td>
                 <td class="q-num">{{ loop.index }}</td>
                 <td>
                     <input type="checkbox" class="q-checkbox status-checkbox"
@@ -217,7 +245,7 @@
             </tr>
             {% endfor %}
             <tr id="empty-state-row" style="display:none;">
-                <td colspan="6" class="text-center" style="padding: 2rem;">
+                <td colspan="7" class="text-center" style="padding: 2rem;">
                     <p style="margin-bottom: 0.75rem; color: var(--text-muted, #888);">
                         No questions match the selected difficulty.
                     </p>
@@ -239,6 +267,7 @@
 <script>
 const endpointConfig = {{ {
   "updateQuestionBase": url_for('tracker.update_question', question_id='__QUESTION_ID__'),
+    "bulkUpdateQuestions": url_for('tracker.update_questions'),
 }|tojson }};
 const csrfToken = {{ csrf_token()|tojson }};
 const isAuthenticated = {{ 'true' if current_user.is_authenticated else 'false' }};
@@ -250,6 +279,42 @@ function showUpdateError(message = 'Unable to save your change. Please try again
     topicStatus._hideTimer = window.setTimeout(() => {
         topicStatus.textContent = '';
     }, 5000);
+}
+
+function getBulkSelectedIds() {
+    return Array.from(document.querySelectorAll('.bulk-select-checkbox:checked')).map(cb => cb.dataset.id);
+}
+
+function syncBulkSelectionState() {
+    const selectedIds = getBulkSelectedIds();
+    const countLabel = document.getElementById('bulkSelectionCount');
+    const bulkButtons = document.querySelectorAll('[data-bulk-action]');
+    const headerCheckboxes = [document.getElementById('bulkSelectAll'), document.getElementById('bulkSelectAllHeader')].filter(Boolean);
+    const allCheckboxes = Array.from(document.querySelectorAll('.bulk-select-checkbox'));
+    const allSelected = allCheckboxes.length > 0 && selectedIds.length === allCheckboxes.length;
+    const someSelected = selectedIds.length > 0 && !allSelected;
+
+    if (countLabel) {
+        countLabel.textContent = `${selectedIds.length} selected`;
+    }
+    bulkButtons.forEach(btn => {
+        btn.disabled = selectedIds.length === 0;
+    });
+    headerCheckboxes.forEach(checkbox => {
+        checkbox.checked = allSelected;
+        checkbox.indeterminate = someSelected;
+    });
+}
+
+function setBulkBusy(isBusy) {
+    document.querySelectorAll('[data-bulk-action]').forEach(btn => {
+        btn.disabled = isBusy || getBulkSelectedIds().length === 0;
+        btn.classList.toggle('btn-busy', isBusy);
+        btn.setAttribute('aria-busy', isBusy ? 'true' : 'false');
+    });
+    [document.getElementById('bulkSelectAll'), document.getElementById('bulkSelectAllHeader')].filter(Boolean).forEach(checkbox => {
+        checkbox.disabled = isBusy;
+    });
 }
 
 function setBookmarkState(btn, isBookmarked) {
@@ -409,6 +474,22 @@ document.querySelectorAll('.status-checkbox').forEach(cb => {
     });
 });
 
+    document.querySelectorAll('.bulk-select-checkbox').forEach(cb => {
+        cb.addEventListener('change', syncBulkSelectionState);
+    });
+
+    [document.getElementById('bulkSelectAll'), document.getElementById('bulkSelectAllHeader')].filter(Boolean).forEach(checkbox => {
+        checkbox.addEventListener('change', function() {
+            const checked = this.checked;
+            document.querySelectorAll('.bulk-select-checkbox').forEach(item => {
+                item.checked = checked;
+            });
+            syncBulkSelectionState();
+        });
+    });
+
+    syncBulkSelectionState();
+
 function setSkippedState(btn, isSkipped) {
     const icon = btn.querySelector('i');
     btn.dataset.skipped = isSkipped ? 'true' : 'false';
@@ -471,6 +552,48 @@ document.querySelectorAll('.skip-btn').forEach(btn => {
                 checkbox.disabled = false;
                 row.classList.remove('row-updating');
             });
+    });
+});
+
+document.querySelectorAll('[data-bulk-action]').forEach(btn => {
+    btn.addEventListener('click', function() {
+        if (!isAuthenticated) {
+            window.location.href = "{{ url_for('auth.login') }}";
+            return;
+        }
+
+        const questionIds = getBulkSelectedIds();
+        if (!questionIds.length) {
+            showUpdateError('Select at least one question first.');
+            return;
+        }
+
+        const action = this.dataset.bulkAction;
+        const originalLabel = this.textContent;
+        setBulkBusy(true);
+        this.textContent = 'Applying...';
+        topicStatus.textContent = 'Applying bulk action...';
+
+        fetch(endpointConfig.bulkUpdateQuestions, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
+            body: JSON.stringify({question_ids: questionIds, action: action})
+        })
+        .then(r => {
+            if (!r.ok) throw new Error('Request failed');
+            return r.json();
+        })
+        .then(res => {
+            if (!res.success) throw new Error(res.error || 'Bulk update failed');
+            window.location.reload();
+        })
+        .catch(() => {
+            showUpdateError();
+        })
+        .finally(() => {
+            this.textContent = originalLabel;
+            setBulkBusy(false);
+        });
     });
 });
 

--- a/tests/test_tracker_routes.py
+++ b/tests/test_tracker_routes.py
@@ -86,6 +86,22 @@ def test_topic_page_all_and_filtered_counts(monkeypatch):
     assert "Hard Prob 1" not in html
 
 
+def test_topic_page_exposes_bulk_actions_toolbar(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id
+    test_db.question.insert_one({"topic": topic_id, "problem": "Two Sum", "difficulty": "Easy"})
+
+    with flask_app.test_client() as client:
+        response = client.get(f"/topic/{topic_id}")
+
+    html = response.data.decode("utf-8")
+    assert response.status_code == 200
+    assert 'id="bulkToolbar"' in html
+    assert 'id="bulkSelectAll"' in html
+    assert 'data-bulk-action="done"' in html
+    assert 'data-bulk-action="clear"' in html
+
+
 def test_topic_page_status_filters_include_skipped_counts(monkeypatch):
     flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
     topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id
@@ -190,6 +206,31 @@ def test_update_question_rejects_non_boolean_skipped(monkeypatch):
 
     assert response.status_code == 400
     assert response.get_json() == {"success": False, "error": "skipped must be a boolean"}
+
+
+def test_update_questions_bulk_updates_multiple_items(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_ids = test_db.question.insert_many([
+        {"problem": "Two Sum", "url": "https://leetcode.com/problems/two-sum/"},
+        {"problem": "Array Practice", "url": "https://www.geeksforgeeks.org/problems/array-practice/"},
+    ]).inserted_ids
+    user_id = test_db.user.insert_one({"email": "user@example.com", "progress": {}, "is_admin": False}).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.post(
+            "/update_questions",
+            json={"question_ids": [str(question_ids[0]), str(question_ids[1])], "action": "done"},
+            headers=csrf_headers(client),
+        )
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    user = test_db.user.find_one({"_id": user_id})
+    assert user["progress"][str(question_ids[0])]["done"] is True
+    assert user["progress"][str(question_ids[1])]["done"] is True
+    assert user["in_sheet_platform_counts"]["LeetCode"] == 1
+    assert user["in_sheet_platform_counts"]["GFG"] == 1
 
 
 def test_topic_page_accepts_lowercase_difficulty_filter(monkeypatch):


### PR DESCRIPTION
# Description

This pull request introduces a bulk actions feature for topic questions. Users can now select multiple questions simultaneously on a topic page to update their progress status or bookmarks in a single request, significantly improving user experience.

Fixes #358

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] **Local Manual Testing:** Verified UI interactions, bulk selection mechanics, indeterminate checkbox states, and backend database state mutations locally.
- [x] **Automated Tests Added:** - `test_topic_page_exposes_bulk_actions_toolbar` to ensure the HTML toolbar components render correctly.
  - `test_update_questions_bulk_updates_multiple_items` to verify database status mutations and platform cache calculation correctness via the `/update_questions` route.

## Checklist

- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Contributor Confirmation

- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors