### PR TITLE
feat: add reset progress by topic (#357)

### DIFF
--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -7,6 +7,7 @@ from app.extensions import db
 from app.leaderboard.cache import invalidate_leaderboard_cache
 from app.profile.card_service import warm_public_card_cache
 from app.utils import (
+    compute_in_sheet_platform_counts,
     json_error,
     json_success,
     platform_from_question_url,
@@ -177,6 +178,40 @@ def export_topic_notes(topic_id):
     response = Response(markdown, mimetype="text/markdown")
     response.headers["Content-Disposition"] = f'attachment; filename={topic_notes_filename(topic_doc["name"])}'
     return response
+
+
+@tracker_bp.route("/topic/<topic_id>/reset-progress", methods=["POST"])
+@login_required
+def reset_topic_progress(topic_id):
+    try:
+        topic_id_obj = ObjectId(topic_id)
+    except InvalidId:
+        return json_error("Topic not found", status_code=404)
+
+    topic_doc = db.topic.find_one({"_id": topic_id_obj})
+    if not topic_doc:
+        return json_error("Topic not found", status_code=404)
+
+    topic_question_ids = [str(question["_id"]) for question in db.question.find({"topic": topic_doc["_id"]}, {"_id": 1})]
+    if topic_question_ids:
+        unset_fields = {}
+        for question_id in topic_question_ids:
+            unset_fields[f"progress.{question_id}.done"] = ""
+            unset_fields[f"progress.{question_id}.skipped"] = ""
+            unset_fields[f"progress.{question_id}.timestamp"] = ""
+
+        db.user.update_one({"_id": current_user.id}, {"$unset": unset_fields})
+        current_user.reload()
+
+        solved_items = {question_id: progress for question_id, progress in current_user.progress.items() if progress.get("done")}
+        all_questions = list(db.question.find({}, {"_id": 1, "url": 1}))
+        in_sheet_platform_counts = compute_in_sheet_platform_counts(solved_items, all_questions)
+        db.user.update_one({"_id": current_user.id}, {"$set": {"in_sheet_platform_counts": in_sheet_platform_counts}})
+        current_user.reload()
+
+    invalidate_leaderboard_cache()
+    warm_public_card_cache(current_user.id, db_handle=db)
+    return json_success(message=f"Reset progress for '{topic_doc.get('name', 'this topic')}'")
 
 
 @tracker_bp.route("/update_question/<question_id>", methods=["POST"])

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -19,6 +19,8 @@
 .topic-header-main { min-width: 0; }
 .export-notes-btn { display: inline-flex; align-items: center; gap: 7px; padding: 8px 14px; border: 1px solid var(--border-color); border-radius: 8px; background: var(--bg-secondary); color: var(--text-secondary); font-size: 0.82rem; font-weight: 700; text-decoration: none; white-space: nowrap; transition: all 0.2s; }
 .export-notes-btn:hover { border-color: var(--accent); color: var(--accent); text-decoration: none; }
+.reset-progress-btn { color: var(--danger); }
+.reset-progress-btn:hover { border-color: var(--danger); color: var(--danger); }
 
 .bookmark-btn { color: var(--text-muted); }
 .bookmark-btn:hover { color: var(--accent); }
@@ -83,9 +85,14 @@
         </div>
     </div>
     {% if current_user.is_authenticated %}
-    <a href="{{ url_for('tracker.export_topic_notes', topic_id=topic._id|string) }}" class="export-notes-btn" aria-label="Export notes for this topic">
-        <i class="bi bi-download" aria-hidden="true"></i> Export Notes
-    </a>
+    <div style="display:flex; gap:10px; flex-wrap:wrap; justify-content:flex-end;">
+        <a href="{{ url_for('tracker.export_topic_notes', topic_id=topic._id|string) }}" class="export-notes-btn" aria-label="Export notes for this topic">
+            <i class="bi bi-download" aria-hidden="true"></i> Export Notes
+        </a>
+        <button type="button" class="export-notes-btn reset-progress-btn" id="resetTopicProgressBtn" aria-label="Reset progress for this topic">
+            <i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i> Reset Progress
+        </button>
+    </div>
     {% endif %}
 </div>
 
@@ -239,6 +246,7 @@
 <script>
 const endpointConfig = {{ {
   "updateQuestionBase": url_for('tracker.update_question', question_id='__QUESTION_ID__'),
+    "resetTopicProgress": url_for('tracker.reset_topic_progress', topic_id=topic._id|string),
 }|tojson }};
 const csrfToken = {{ csrf_token()|tojson }};
 const isAuthenticated = {{ 'true' if current_user.is_authenticated else 'false' }};
@@ -504,6 +512,44 @@ document.querySelectorAll('.filter-btn[data-status]').forEach(btn => {
         emptyRow.style.display = '';
     }
 })();
+
+const resetTopicProgressBtn = document.getElementById('resetTopicProgressBtn');
+if (resetTopicProgressBtn) {
+    resetTopicProgressBtn.addEventListener('click', async function() {
+        if (!isAuthenticated) {
+            window.location.href = "{{ url_for('auth.login') }}";
+            return;
+        }
+
+        if (!window.confirm('Reset all done and skipped progress for this topic?')) {
+            return;
+        }
+
+        const previousLabel = this.innerHTML;
+        this.disabled = true;
+        this.classList.add('btn-busy');
+        this.setAttribute('aria-busy', 'true');
+
+        try {
+            const response = await fetch(endpointConfig.resetTopicProgress, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
+            });
+            const result = await response.json();
+            if (!response.ok || !result.success) {
+                throw new Error(result.error || 'Reset failed');
+            }
+            window.location.reload();
+        } catch (error) {
+            showUpdateError('Unable to reset topic progress. Please try again.');
+        } finally {
+            this.disabled = false;
+            this.classList.remove('btn-busy');
+            this.removeAttribute('aria-busy');
+            this.innerHTML = previousLabel;
+        }
+    });
+}
 
 // Notes Modal with focus trap
 const modal = document.getElementById('notesModal');

--- a/tests/test_tracker_routes.py
+++ b/tests/test_tracker_routes.py
@@ -248,6 +248,66 @@ def test_update_question_accepts_valid_boolean_update(monkeypatch):
     assert user["in_sheet_platform_counts"]["LeetCode"] == 1
 
 
+def test_topic_page_exposes_reset_progress_button(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id
+    test_db.question.insert_one({"topic": topic_id, "problem": "Two Sum", "url": "https://leetcode.com/problems/two-sum/"})
+    user_id = test_db.user.insert_one({"email": "user@example.com", "progress": {}, "is_admin": False}).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.get(f"/topic/{topic_id}")
+
+    assert response.status_code == 200
+    html = response.data.decode("utf-8")
+    assert "Reset Progress" in html
+
+
+def test_reset_topic_progress_clears_topic_question_status(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id
+    topic_question_id = test_db.question.insert_one(
+        {"topic": topic_id, "problem": "Two Sum", "url": "https://leetcode.com/problems/two-sum/"}
+    ).inserted_id
+    other_topic_id = test_db.topic.insert_one({"name": "Graphs", "position": 2}).inserted_id
+    other_question_id = test_db.question.insert_one(
+        {"topic": other_topic_id, "problem": "Flood Fill", "url": "https://www.geeksforgeeks.org/flood-fill-algorithm/"}
+    ).inserted_id
+    user_id = test_db.user.insert_one(
+        {
+            "email": "user@example.com",
+            "progress": {
+                str(topic_question_id): {"done": True, "skipped": True},
+                str(other_question_id): {"done": True},
+            },
+            "is_admin": False,
+            "in_sheet_platform_counts": {
+                "LeetCode": 1,
+                "GFG": 1,
+                "Coding Ninjas": 0,
+                "HackerRank": 0,
+                "AtCoder": 0,
+                "Codewars": 0,
+            },
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.post(f"/topic/{topic_id}/reset-progress", headers=csrf_headers(client))
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+
+    user = test_db.user.find_one({"_id": user_id})
+    topic_progress = user["progress"][str(topic_question_id)]
+    assert topic_progress.get("done") is None
+    assert topic_progress.get("skipped") is None
+    assert user["progress"][str(other_question_id)]["done"] is True
+    assert user["in_sheet_platform_counts"]["LeetCode"] == 0
+    assert user["in_sheet_platform_counts"]["GFG"] == 1
+
+
 def test_update_question_sets_skipped_and_clears_done(monkeypatch):
     flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
     question_id = test_db.question.insert_one(


### PR DESCRIPTION
# Description

This pull request introduces the ability for users to reset all their "done" and "skipped" progress for a specific topic directly from the topic page. Upon resetting, the platform status tracking metrics (e.g., LeetCode, GFG counts) are automatically recalculated and the global leaderboard cache is invalidated to keep stats consistent.

Fixes #357

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] **Local Manual Testing:** Verified that clicking the "Reset Progress" button prompts a confirmation dialog, clears progress on the current topic without affecting other topics, correctly decrements the platform specific counts, and reloads the page.
- [x] **Automated Tests Added:** - `test_topic_page_exposes_reset_progress_button` to verify that the "Reset Progress" button renders on the frontend for authenticated users.
  - `test_reset_topic_progress_clears_topic_question_status` to ensure database status fields are properly unset, other topics remain untouched, and user platform statistics sync correctly.

## Checklist

- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Contributor Confirmation

- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors