### PR TITLE
feat: add public compare page for two users (#348)

### DIFF
--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -33,3 +33,66 @@ def public_profile(user_id):
         user=public_user_data,
         stats=stats
     )
+
+
+@public_bp.route("/compare/<user_a_id>/<user_b_id>")
+def public_compare(user_a_id, user_b_id):
+    try:
+        user_doc_a = db.user.find_one({"_id": ObjectId(user_a_id)})
+        user_doc_b = db.user.find_one({"_id": ObjectId(user_b_id)})
+    except InvalidId:
+        return "Invalid User ID", 400
+    except Exception as exc:
+        current_app.logger.exception(f"Failed to load public compare for {user_a_id} vs {user_b_id}: {exc}")
+        return "Server Error", 500
+
+    if not user_doc_a or not user_doc_b:
+        return "User not found", 404
+    # Respect deactivated and explicit privacy flag if present
+    for ud in (user_doc_a, user_doc_b):
+        if ud.get("is_deactivated"):
+            return "User not found", 404
+        if ud.get("public_profile") is False:
+            return "User not found", 404
+
+    stats_a = compute_c_score(user_doc_a)
+    stats_b = compute_c_score(user_doc_b)
+
+    user_a = {
+        "username": user_doc_a.get("name") or user_doc_a.get("username", "Unknown User"),
+        "avatar_url": user_doc_a.get("profile_photo") or user_doc_a.get("avatar_url", ""),
+    }
+    user_b = {
+        "username": user_doc_b.get("name") or user_doc_b.get("username", "Unknown User"),
+        "avatar_url": user_doc_b.get("profile_photo") or user_doc_b.get("avatar_url", ""),
+    }
+
+    # Build simple platform totals mapping from compute_c_score result
+    platforms_a = {
+        "LeetCode": int(stats_a.get("lc_total", 0)),
+        "GFG": int(stats_a.get("gfg_total", 0)),
+        "Coding Ninjas": int(stats_a.get("cn_total", 0)),
+        "HackerRank": int(stats_a.get("hr_total", 0)),
+        "AtCoder": int(stats_a.get("atcoder_total", 0) or 0),
+        "Codewars": int(stats_a.get("cw_total", 0)),
+        "Other": 0,
+    }
+    platforms_b = {
+        "LeetCode": int(stats_b.get("lc_total", 0)),
+        "GFG": int(stats_b.get("gfg_total", 0)),
+        "Coding Ninjas": int(stats_b.get("cn_total", 0)),
+        "HackerRank": int(stats_b.get("hr_total", 0)),
+        "AtCoder": int(stats_b.get("atcoder_total", 0) or 0),
+        "Codewars": int(stats_b.get("cw_total", 0)),
+        "Other": 0,
+    }
+
+    return render_template(
+        "public_compare.html",
+        user_a=user_a,
+        user_b=user_b,
+        stats_a=stats_a,
+        stats_b=stats_b,
+        platforms_a=platforms_a,
+        platforms_b=platforms_b,
+    )

--- a/templates/public_compare.html
+++ b/templates/public_compare.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container py-4">
+  <div class="row mb-3">
+    <div class="col text-center">
+      <h2>Public Comparison</h2>
+      <p class="text-muted">Side-by-side summary of two public users' progress and platform totals.</p>
+    </div>
+  </div>
+
+  <div class="row g-4">
+    <div class="col-md-6">
+      <div class="card">
+        <div class="card-body text-center">
+          <img src="{{ user_a.avatar_url }}" alt="avatar" class="rounded-circle mb-2" width="96" height="96">
+          <h5 class="card-title">{{ user_a.username }}</h5>
+          <p class="mb-1">C-Score: <strong>{{ stats_a.c_score }}</strong></p>
+          <p class="mb-1">DSA Done: <strong>{{ stats_a.dsa_done }}</strong></p>
+          <p class="mb-1">Total Solved: <strong>{{ stats_a.total_solved }}</strong></p>
+          <p class="mb-1">Active Days: <strong>{{ stats_a.active_days }}</strong></p>
+        </div>
+        <ul class="list-group list-group-flush">
+          {% for name, value in platforms_a.items() %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            {{ name }}
+            <span class="badge bg-primary rounded-pill">{{ value }}</span>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+
+    <div class="col-md-6">
+      <div class="card">
+        <div class="card-body text-center">
+          <img src="{{ user_b.avatar_url }}" alt="avatar" class="rounded-circle mb-2" width="96" height="96">
+          <h5 class="card-title">{{ user_b.username }}</h5>
+          <p class="mb-1">C-Score: <strong>{{ stats_b.c_score }}</strong></p>
+          <p class="mb-1">DSA Done: <strong>{{ stats_b.dsa_done }}</strong></p>
+          <p class="mb-1">Total Solved: <strong>{{ stats_b.total_solved }}</strong></p>
+          <p class="mb-1">Active Days: <strong>{{ stats_b.active_days }}</strong></p>
+        </div>
+        <ul class="list-group list-group-flush">
+          {% for name, value in platforms_b.items() %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            {{ name }}
+            <span class="badge bg-primary rounded-pill">{{ value }}</span>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
# Description

This pull request introduces a public comparison page that allows a side-by-side view of progress metrics and platform-specific totals for two public users. It ensures user privacy by respecting deactivated accounts and explicit privacy flags.

Closes #348

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Tested in Local

## Checklist

- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs

_None provided._

## Contributor Confirmation

- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors