### PR TITLE
feat: add milestone certificates (#347)

### DIFF
--- a/app/profile/certificate_service.py
+++ b/app/profile/certificate_service.py
@@ -1,0 +1,78 @@
+import io
+from datetime import datetime
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+def _load_fonts():
+    try:
+        return {
+            "title": ImageFont.truetype("arialbd.ttf", 56),
+            "subtitle": ImageFont.truetype("arial.ttf", 28),
+            "name": ImageFont.truetype("arialbd.ttf", 48),
+            "detail": ImageFont.truetype("arial.ttf", 26),
+        }
+    except IOError:
+        try:
+            return {
+                "title": ImageFont.truetype("DejaVuSans-Bold.ttf", 56),
+                "subtitle": ImageFont.truetype("DejaVuSans.ttf", 28),
+                "name": ImageFont.truetype("DejaVuSans-Bold.ttf", 48),
+                "detail": ImageFont.truetype("DejaVuSans.ttf", 26),
+            }
+        except IOError:
+            default = ImageFont.load_default()
+            return {
+                "title": default,
+                "subtitle": default,
+                "name": default,
+                "detail": default,
+            }
+
+
+def _center_text(draw, text, font, y, width, fill):
+    try:
+        bbox = draw.textbbox((0, 0), text, font=font)
+        text_width = bbox[2] - bbox[0]
+    except Exception:
+        text_width = draw.textsize(text, font=font)[0]
+    x = (width - text_width) / 2
+    draw.text((x, y), text, font=font, fill=fill)
+
+
+def generate_milestone_certificate(name, milestone_label, awarded_on=None):
+    width, height = 1200, 850
+    bg_color = (248, 247, 244)
+    border_color = (34, 34, 34)
+    accent = (245, 158, 11)
+    text_color = (20, 20, 20)
+
+    card = Image.new("RGB", (width, height), color=bg_color)
+    draw = ImageDraw.Draw(card)
+    fonts = _load_fonts()
+
+    # Border
+    draw.rectangle([(30, 30), (width - 30, height - 30)], outline=border_color, width=3)
+
+    title = "Certificate of Achievement"
+    subtitle = "Presented to"
+    display_name = (name or "Anonymous").strip() or "Anonymous"
+    if len(display_name) > 30:
+        display_name = display_name[:27] + "..."
+
+    _center_text(draw, title, fonts["title"], 110, width, text_color)
+    _center_text(draw, subtitle, fonts["subtitle"], 220, width, text_color)
+    _center_text(draw, display_name, fonts["name"], 270, width, accent)
+
+    detail = f"For completing the milestone: {milestone_label}"
+    _center_text(draw, detail, fonts["detail"], 370, width, text_color)
+
+    awarded_on = awarded_on or datetime.utcnow().date().isoformat()
+    _center_text(draw, f"Awarded on {awarded_on}", fonts["detail"], 440, width, text_color)
+
+    _center_text(draw, "450 DSA Tracker", fonts["subtitle"], 640, width, text_color)
+
+    img_io = io.BytesIO()
+    card.save(img_io, "PNG")
+    img_io.seek(0)
+    return img_io

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -9,6 +9,7 @@ from app.extensions import cache, db, limiter
 from app.leaderboard.cache import invalidate_leaderboard_cache
 from app.leaderboard.service import build_leaderboard_data, get_user_rank_by_c_score
 from app.profile.card_service import CACHE_TTL, get_public_card_image, warm_public_card_cache
+from app.profile.certificate_service import generate_milestone_certificate
 from app.profile.sync_service import (
     build_sync_platforms_response,
     clear_profile_caches,
@@ -29,6 +30,12 @@ __all__ = ["CACHE_TTL", "build_sync_platforms_response", "get_public_card_image"
 
 UNIVERSITY_SEARCH_TIMEOUT_SECONDS = 5
 HEATMAP_DAYS = 168
+
+MILESTONE_DEFS = {
+  "100-solved": {"label": "100 Problems Solved", "threshold": 100},
+  "250-solved": {"label": "250 Problems Solved", "threshold": 250},
+  "sheet-completed": {"label": "450 DSA Sheet Completed", "threshold": "all"},
+}
 
 
 def filter_heatmap_counts(daily_counts, today=None, days=HEATMAP_DAYS):
@@ -220,7 +227,6 @@ def public_card(user_id):
     except Exception:
         current_app.logger.exception("Failed to generate public progress card")
         return "Unable to generate progress card", 500
-
     try:
         img_io.seek(0)
         response = send_file(img_io, mimetype="image/png")
@@ -233,6 +239,32 @@ def public_card(user_id):
     except Exception:
         current_app.logger.exception("Failed to generate public progress card")
         return "Unable to generate progress card", 500
+
+
+@profile_bp.route("/certificate/<milestone_id>")
+@login_required
+def milestone_certificate(milestone_id):
+    milestone = MILESTONE_DEFS.get(milestone_id)
+    if not milestone:
+        return "Milestone not found", 404
+
+    progress_data = current_user.progress or {}
+    dsa_done = sum(1 for progress_item in progress_data.values() if progress_item.get("done"))
+    total_questions = db.question.count_documents({})
+
+    threshold = milestone["threshold"]
+    if threshold == "all":
+        eligible = total_questions > 0 and dsa_done >= total_questions
+    else:
+        eligible = dsa_done >= int(threshold)
+
+    if not eligible:
+        return "Milestone not reached", 403
+
+    awarded_on = utc_now().date().isoformat()
+    img_io = generate_milestone_certificate(current_user.name, milestone["label"], awarded_on=awarded_on)
+    filename = f"certificate-{milestone_id}.png"
+    return send_file(img_io, mimetype="image/png", as_attachment=True, download_name=filename)
 
 
 @profile_bp.route("/search_universities")

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -68,6 +68,25 @@
     <a class="card-btn ui-btn ui-btn-secondary ui-btn-block" href="{{ url_for('tracker.export_study_plan_ics') }}" aria-label="Export study plan calendar file">
       <i class="bi bi-calendar-event" style="margin-right:6px" aria-hidden="true"></i> Export Study Calendar
     </a>
+    {% set milestone_certs = [
+      {'id': '100-solved', 'label': '100 Solved', 'eligible': dsa_done >= 100},
+      {'id': '250-solved', 'label': '250 Solved', 'eligible': dsa_done >= 250},
+      {'id': 'sheet-completed', 'label': 'Sheet Completed', 'eligible': dsa_done >= total_questions}
+    ] %}
+    <div style="margin-top:12px">
+      <div class="sec-title">Milestone Certificates</div>
+      {% for cert in milestone_certs %}
+        {% if cert.eligible %}
+          <a class="card-btn ui-btn ui-btn-secondary ui-btn-block" href="{{ url_for('profile.milestone_certificate', milestone_id=cert.id) }}" aria-label="Download {{ cert.label }} certificate">
+            <i class="bi bi-download" style="margin-right:6px" aria-hidden="true"></i> {{ cert.label }} Certificate
+          </a>
+        {% else %}
+          <button class="card-btn ui-btn ui-btn-secondary ui-btn-block" disabled aria-disabled="true">
+            <i class="bi bi-lock" style="margin-right:6px" aria-hidden="true"></i> {{ cert.label }} Certificate
+          </button>
+        {% endif %}
+      {% endfor %}
+    </div>
     <div class="prof-bio">{{ user.bio or 'Software Engineer | Problem Solver | DSA Enthusiast' }}</div>
     <div class="social-row">
       {% if user.email %}<a href="mailto:{{ user.email }}" class="social-icon" title="Email" aria-label="Send email to {{ user.email }}"><i class="bi bi-envelope" aria-hidden="true"></i></a>{% endif %}


### PR DESCRIPTION
# Description

This pull request introduces a milestone certificates feature. Users can now view and download custom-generated achievement certificates (PNG format) directly from their profile page upon hitting specific problem-solving thresholds (100 Solved, 250 Solved, and Sheet Completed). 

Closes #347

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Tested in Local: Verified that the `/certificate/<milestone_id>` endpoint correctly authenticates the user, checks eligibility thresholds, generates a pixel-perfect image using PIL, and triggers a clean file attachment download. Also verified that the profile UI updates dynamically to lock or unlock certificates based on the user's progress.

## Checklist

- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs

_None provided._

## Contributor Confirmation

- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors