### PR TITLE
feat: add interviewbit platform integration (#363)

### DIFF
--- a/app/platforms/fetchers.py
+++ b/app/platforms/fetchers.py
@@ -21,6 +21,7 @@ GFG_PAGE_TIMEOUT_SECONDS = 8
 ATCODER_REQUEST_TIMEOUT_SECONDS = 8
 CODING_NINJAS_REQUEST_TIMEOUT_SECONDS = 8
 CODEWARS_REQUEST_TIMEOUT_SECONDS = 8
+INTERVIEWBIT_REQUEST_TIMEOUT_SECONDS = 8
 
 _session_local = threading.local()
 
@@ -437,4 +438,32 @@ def fetch_codewars(username):
         return {}
     except Exception as exc:
         logger.error(f"Codewars stats fetch failed: {exc}")
+        return {}
+
+
+def fetch_interviewbit(username):
+    """Fetch InterviewBit solved count from the public profile page."""
+    try:
+        response = _get_http_session().get(
+            f"https://www.interviewbit.com/profile/{username}/",
+            timeout=INTERVIEWBIT_REQUEST_TIMEOUT_SECONDS,
+            headers={"User-Agent": "Mozilla/5.0"},
+        )
+        if response.status_code != 200:
+            return {}
+
+        text = response.text or ""
+        patterns = [
+            r"(?is)problems?\s+solved[^\d]{0,40}(\d+)",
+            r"(?is)solved\s+problems[^\d]{0,40}(\d+)",
+            r"(?is)questions?\s+solved[^\d]{0,40}(\d+)",
+            r"(?is)submissions?[^\d]{0,40}(\d+)",
+        ]
+        for pattern in patterns:
+            match = re.search(pattern, text)
+            if match:
+                return {"total": int(match.group(1))}
+        return {"total": 0}
+    except Exception as exc:
+        logger.error(f"InterviewBit stats fetch failed: {exc}")
         return {}

--- a/app/platforms/metadata.py
+++ b/app/platforms/metadata.py
@@ -83,6 +83,18 @@ PLATFORM_META = {
         "profile_url_template": "https://www.codewars.com/users/{username}",
         "search_url": ""
     },
+    "InterviewBit": {
+        "id": "interviewbit",
+        "name": "InterviewBit",
+        "aliases": ("interviewbit", "ib"),
+        "domains": ["interviewbit.com"],
+        "color_class": "warning text-dark",
+        "badge_class": "badge-link",
+        "brand_color": "#f59e0b",
+        "icon_class": "bi-mortarboard",
+        "profile_url_template": "https://www.interviewbit.com/profile/{username}/",
+        "search_url": ""
+    },
     "GitHub": {
         "id": "github",
         "name": "GitHub",

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -77,6 +77,9 @@ def sync_platforms():
             codingninjas:
               type: string
               description: Coding Ninjas profile id or URL.
+            interviewbit:
+              type: string
+              description: InterviewBit username.
     security:
       - SessionAuth: []
     responses:
@@ -376,8 +379,14 @@ def profile():
             dsa_medium += 1
         elif diff == "Hard":
             dsa_hard += 1
-
-    platforms = {"LeetCode": 0, "GFG": 0, "Coding Ninjas": 0, "HackerRank": 0, "Other": 0}
+  platforms = {
+    "LeetCode": 0,
+    "GFG": 0,
+    "Coding Ninjas": 0,
+    "HackerRank": 0,
+    "InterviewBit": 0,
+    "Other": 0,
+  }
     daily_counts = {}
 
     for question in all_questions:

--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -12,6 +12,7 @@ from app.platforms.fetchers import (
     fetch_lc_badges,
     fetch_leetcode,
     fetch_leetcode_rating_history,
+    fetch_interviewbit,
     run_fetch_jobs,
 )
 from app.utils import ensure_utc_datetime, normalize_coding_ninjas_profile_id, utc_now
@@ -49,6 +50,7 @@ def build_platform_sync_jobs(
     hackerrank_username="",
     atcoder_username="",
     codewars_username="",
+    interviewbit_username="",
 ):
     jobs = {}
 
@@ -88,6 +90,9 @@ def build_platform_sync_jobs(
     if codewars_username:
         jobs["codewars"] = lambda: fetch_codewars(codewars_username)
 
+    if interviewbit_username:
+        jobs["interviewbit"] = lambda: fetch_interviewbit(interviewbit_username)
+
     return jobs
 
 
@@ -117,6 +122,7 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
     codingninjas_username = user.codingninjas_username or ""
     atcoder_username = user.atcoder_username or ""
     codewars_username = getattr(user, "codewars_username", "") or ""
+    interviewbit_username = getattr(user, "interviewbit_username", "") or ""
 
     if "leetcode" in data:
         leetcode_username = data.get("leetcode", "").strip()
@@ -139,6 +145,9 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
     if "codewars" in data:
         codewars_username = data.get("codewars", "").strip()
         update_fields["codewars_username"] = codewars_username
+    if "interviewbit" in data:
+        interviewbit_username = data.get("interviewbit", "").strip()
+        update_fields["interviewbit_username"] = interviewbit_username
 
     platform_totals = {}
     platform_status = {}
@@ -163,6 +172,7 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
         hackerrank_username=hackerrank_username,
         atcoder_username=atcoder_username,
         codewars_username=codewars_username,
+        interviewbit_username=interviewbit_username,
     )
     platform_results, platform_errors = run_fetch_jobs(platform_jobs, max_workers=4)
 
@@ -284,30 +294,58 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
     else:
         _mark("codewars", "skipped")
 
+    if interviewbit_username:
+        interviewbit_data = platform_results.get("interviewbit")
+        if platform_errors.get("interviewbit"):
+            _mark("interviewbit", "failed", "Failed to fetch InterviewBit stats.")
+        elif not interviewbit_data:
+            _mark("interviewbit", "failed", "No data returned (username may be invalid or rate-limited).")
+        else:
+            _mark("interviewbit", "synced")
+            if interviewbit_data.get("total") is not None:
+                platform_totals["InterviewBit"] = int(interviewbit_data.get("total", 0))
+    else:
+        _mark("interviewbit", "skipped")
+
     # Backfill or remove ``_legacy`` depending on whether the current sync
-    # covered every platform the user has configured.  During the migration
+    # covered every platform the user has configured. During the migration
     # from the old flat ``external_daily_counts`` format to per-platform
     # calendars, ``_legacy`` preserves dates from platforms not yet re-synced.
-    PLATFORM_KEYS = {"leetcode", "github", "gfg", "hackerrank",
-                     "codingninjas", "atcoder", "codewars"}
+    PLATFORM_KEYS = {
+        "leetcode",
+        "github",
+        "gfg",
+        "hackerrank",
+        "codingninjas",
+        "atcoder",
+        "codewars",
+        "interviewbit",
+    }
     requested_platforms = {k for k in data if k in PLATFORM_KEYS}
     legacy_counts = getattr(user, "external_daily_counts", {})
     has_legacy = isinstance(legacy_counts, dict) and bool(legacy_counts)
 
     if has_legacy:
         user_platforms = set()
-        for attr in ("leetcode_username", "github_username", "gfg_username",
-                     "hackerrank_username", "codingninjas_username",
-                     "atcoder_username", "codewars_username"):
+        for attr in (
+            "leetcode_username",
+            "github_username",
+            "gfg_username",
+            "hackerrank_username",
+            "codingninjas_username",
+            "atcoder_username",
+            "codewars_username",
+            "interviewbit_username",
+        ):
             if getattr(user, attr, ""):
                 platform_name = attr.replace("_username", "")
                 user_platforms.add(platform_name)
 
         if user_platforms and requested_platforms and user_platforms.issubset(requested_platforms):
-            # All user platforms were included in this sync → migration done
+            # All user platforms were included in this sync -> migration done
             platform_calendars.pop("_legacy", None)
         else:
-            # Partial sync — preserve legacy data for platforms not yet re-synced
+            # Partial sync - preserve legacy data for platforms not yet re-synced
             platform_calendars["_legacy"] = dict(legacy_counts)
 
     update_fields["platform_calendars"] = platform_calendars

--- a/app/utils.py
+++ b/app/utils.py
@@ -133,8 +133,8 @@ def search_dsa_questions(raw_query, limit=40):
     return search_service.search_dsa_questions(raw_query, limit=limit, db_handle=db)
 
 
-EXTERNAL_SOLVED_TOTAL_KEYS = ("LeetCode", "GFG", "Coding Ninjas", "HackerRank", "AtCoder", "Codewars")
-PLATFORM_COUNT_KEYS = ("LeetCode", "GFG", "Coding Ninjas", "HackerRank", "AtCoder", "Codewars", "Other")
+EXTERNAL_SOLVED_TOTAL_KEYS = ("LeetCode", "GFG", "Coding Ninjas", "HackerRank", "AtCoder", "Codewars", "InterviewBit")
+PLATFORM_COUNT_KEYS = ("LeetCode", "GFG", "Coding Ninjas", "HackerRank", "AtCoder", "Codewars", "InterviewBit", "Other")
 
 
 def empty_platform_counts():
@@ -154,6 +154,8 @@ def platform_from_question_url(url):
         return "HackerRank"
     if "atcoder.jp" in url:
         return "AtCoder"
+    if "interviewbit.com" in url:
+        return "InterviewBit"
     return "Other"
 
 
@@ -281,6 +283,7 @@ def compute_c_score(user_doc, all_questions=None):
     hr_total = coerce_non_negative_number(ext.get("HackerRank", 0))
     cn_total = coerce_non_negative_number(ext.get("Coding Ninjas", 0))
     cw_total = coerce_non_negative_number(ext.get("Codewars", 0))
+    ib_total = coerce_non_negative_number(ext.get("InterviewBit", 0))
     external_total = sum(
         coerce_non_negative_number(value)
         for key, value in ext.items()
@@ -307,7 +310,7 @@ def compute_c_score(user_doc, all_questions=None):
     s_lc_total = min(lc_total / 500, 1.0) * 200
     s_lc_diff = min((lc_easy * 1 + lc_medium * 3 + lc_hard * 6) / 1500, 1.0) * 150
     s_lc_rating = min(lc_rating / 2500, 1.0) * 200
-    s_other = min((gfg_total + hr_total + cn_total + cw_total) / 300, 1.0) * 100
+    s_other = min((gfg_total + hr_total + cn_total + cw_total + ib_total) / 300, 1.0) * 100
     s_consistency = min(active_days / 365, 1.0) * 100
 
     c_score = int(round(s_dsa + s_lc_total + s_lc_diff + s_lc_rating + s_other + s_consistency))
@@ -367,6 +370,10 @@ def merge_platform_counts(in_sheet_counts, external_totals):
     )
     platforms["AtCoder"] = max(platforms["AtCoder"], coerce_non_negative_number(ext_totals.get("AtCoder", 0)))
     platforms["Codewars"] = max(platforms["Codewars"], coerce_non_negative_number(ext_totals.get("Codewars", 0)))
+    platforms["InterviewBit"] = max(
+        platforms["InterviewBit"],
+        coerce_non_negative_number(ext_totals.get("InterviewBit", 0)),
+    )
 
     return platforms
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -136,6 +136,12 @@
         {% if user.codewars_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="{{ user.codewars_username | platform_url('codewars') }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="Codewars profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect Codewars account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
       </span>
     </div>
+    <div class="platform-row">
+      <span><i class="bi bi-mortarboard" style="color:#f59e0b;margin-right:6px" aria-hidden="true"></i>InterviewBit</span>
+      <span style="display:flex;align-items:center;gap:6px">
+        {% if user.interviewbit_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="{{ user.interviewbit_username | platform_url('interviewbit') }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="InterviewBit profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect InterviewBit account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+      </span>
+    </div>
     <button class="add-btn ui-btn ui-btn-secondary ui-btn-block" onclick="openSyncModal()" aria-label="Add or connect coding platform accounts"><i class="bi bi-plus" aria-hidden="true"></i> Add Platform</button>
     <div class="sec-title" style="margin-top:14px">Development Stats</div>
     <div class="platform-row">
@@ -393,6 +399,8 @@
     <input class="m-inp" id="ac_username" placeholder="e.g. tourist" value="{{ user.atcoder_username or '' }}">
     <label class="m-lbl"><i class="bi bi-fire" style="color:#b1361e;margin-right:4px"></i>Codewars Username</label>
     <input class="m-inp" id="cw_username" placeholder="e.g. g964" value="{{ user.codewars_username or '' }}">
+    <label class="m-lbl"><i class="bi bi-mortarboard" style="color:#f59e0b;margin-right:4px"></i>InterviewBit Username</label>
+    <input class="m-inp" id="ib_username" placeholder="e.g. your-name" value="{{ user.interviewbit_username or '' }}">
     <div class="m-note">GFG and Coding Ninjas sync are experimental and may take a few seconds.</div>
     <div class="m-actions">
       <button class="m-cancel" onclick="closeSyncModal()">Cancel</button>
@@ -598,8 +606,9 @@ window.handleQuickSync = function(btn) {
   const cn = '{{ user.codingninjas_username or "" }}';
   const ac = '{{ user.atcoder_username or "" }}';
   const cw = '{{ user.codewars_username or "" }}';
+  const ib = '{{ user.interviewbit_username or "" }}';
   
-  if(!lc && !gh && !gfg && !hr && !cn && !ac && !cw){
+  if(!lc && !gh && !gfg && !hr && !cn && !ac && !cw && !ib){
     showToast('⚠️ No platforms connected to sync!');
     return;
   }
@@ -611,7 +620,7 @@ window.handleQuickSync = function(btn) {
   fetch(endpointConfig.syncPlatforms, {
     method:'POST',
     headers:{'Content-Type':'application/json','X-CSRFToken':csrfToken},
-    body:JSON.stringify({leetcode:lc,github:gh,gfg:gfg,hackerrank:hr,codingninjas:cn,atcoder:ac,codewars:cw})
+    body:JSON.stringify({leetcode:lc,github:gh,gfg:gfg,hackerrank:hr,codingninjas:cn,atcoder:ac,codewars:cw,interviewbit:ib})
   })
   .then(r => r.json())
   .then(res => {
@@ -640,7 +649,8 @@ window.handleSyncProfile = function(btn){
   const cn=document.getElementById('cn_username').value.trim();
   const ac=document.getElementById('ac_username').value.trim();
   const cw=document.getElementById('cw_username').value.trim();
-  if(!lc && !gh && !gfg && !hr && !cn && !ac && !cw){showToast('\u26a0\ufe0f Enter at least one username');return;}
+  const ib=document.getElementById('ib_username').value.trim();
+  if(!lc && !gh && !gfg && !hr && !cn && !ac && !cw && !ib){showToast('\u26a0\ufe0f Enter at least one username');return;}
 
   // Disable button & show spinner
   window.setButtonBusyState(btn, syncContent, { busy: true, busyLabel: 'Syncing...' });
@@ -658,7 +668,8 @@ window.handleSyncProfile = function(btn){
     {id:'ss_hr', label:'HackerRank', value:hr},
     {id:'ss_cn', label:'Coding Ninjas', value:cn},
     {id:'ss_ac', label:'AtCoder', value:ac},
-    {id:'ss_cw', label:'Codewars', value:cw}
+    {id:'ss_cw', label:'Codewars', value:cw},
+    {id:'ss_ib', label:'InterviewBit', value:ib}
   ];
   const activeSyncPlatforms=syncPlatforms.filter(platform=>platform.value);
   const stepsContainer=document.getElementById('syncSteps');
@@ -686,7 +697,7 @@ window.handleSyncProfile = function(btn){
   fetch(endpointConfig.syncPlatforms,{
     method:'POST',
     headers:{'Content-Type':'application/json','X-CSRFToken':csrfToken},
-    body:JSON.stringify({leetcode:lc,github:gh,gfg:gfg,hackerrank:hr,codingninjas:cn,atcoder:ac,codewars:cw}),
+    body:JSON.stringify({leetcode:lc,github:gh,gfg:gfg,hackerrank:hr,codingninjas:cn,atcoder:ac,codewars:cw,interviewbit:ib}),
     signal:ctrl.signal
   })
   .then(r=>{clearTimeout(timer);return r.json();})
@@ -745,7 +756,7 @@ const cumData = {{ cumulative_data | tojson }};
 const pData = {{ platforms | tojson }};
 const chartShells=['progressChartShell','platformsChartShell','difficultyChartShell'].map(i=>document.getElementById(i)).filter(Boolean);let chartJsPromise;
 function loadChartJs(){return window.Chart?Promise.resolve(window.Chart):chartJsPromise||(chartJsPromise=new Promise((ok,bad)=>{let add=(src,err)=>{let s=document.createElement('script');s.src=src;s.async=true;s.onload=()=>ok(window.Chart);s.onerror=err||bad;document.head.appendChild(s)};add('https://cdn.jsdelivr.net/npm/chart.js',()=>add('https://unpkg.com/chart.js@4/dist/chart.umd.js'))}))}
-function renderProfileCharts(){loadChartJs().then(()=>{let c=document.getElementById('progressChart'),d=ratingHistory.length?ratingHistory:cumData;if(d.length&&c)new Chart(c,{type:'line',data:{labels:d.map(x=>x.x),datasets:[{data:d.map(x=>x.y),borderColor:'#f68b24',backgroundColor:'rgba(246,139,36,.15)',borderWidth:2,fill:true,tension:.4,pointRadius:ratingHistory.length?3:0,pointHoverRadius:5,pointBackgroundColor:'#f68b24'}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}},scales:{x:{grid:{display:false},ticks:{color:'#888',maxTicksLimit:5,font:{size:10}}},y:{grid:{color:'rgba(255,255,255,.05)'},ticks:{color:'#888',font:{size:10}}}}}});else if(c){let x=c.getContext('2d');x.fillStyle='#555';x.font='13px Inter, sans-serif';x.textAlign='center';x.fillText('Sync LeetCode to see rating chart',c.width/2,c.height/2-8)}markChartReady('progressChartShell');[['platformsChart','platformsChartShell',['LeetCode','GFG','Coding Ninjas','HackerRank','Other'],[pData.LeetCode,pData.GFG,pData['Coding Ninjas'],pData.HackerRank,pData.Other],['{{ PLATFORM_META["LeetCode"].brand_color }}','{{ PLATFORM_META["GFG"].brand_color }}','{{ PLATFORM_META["Coding Ninjas"].brand_color }}','{{ PLATFORM_META["HackerRank"].brand_color }}','#6c757d']],['difficultyChart','difficultyChartShell',['Easy','Medium','Hard'],[{{lc_easy}},{{lc_medium}},{{lc_hard}}],['#00b8a3','#ffc01e','#ff375f']]].forEach(a=>{try{new Chart(document.getElementById(a[0]),{type:'doughnut',data:{labels:a[2],datasets:[{data:a[3],backgroundColor:a[4],borderWidth:0,cutout:'78%'}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}}}})}catch(e){}markChartReady(a[1])})}).catch(()=>chartShells.forEach(s=>s.classList.add('is-ready')))}
+function renderProfileCharts(){loadChartJs().then(()=>{let c=document.getElementById('progressChart'),d=ratingHistory.length?ratingHistory:cumData;if(d.length&&c)new Chart(c,{type:'line',data:{labels:d.map(x=>x.x),datasets:[{data:d.map(x=>x.y),borderColor:'#f68b24',backgroundColor:'rgba(246,139,36,.15)',borderWidth:2,fill:true,tension:.4,pointRadius:ratingHistory.length?3:0,pointHoverRadius:5,pointBackgroundColor:'#f68b24'}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}},scales:{x:{grid:{display:false},ticks:{color:'#888',maxTicksLimit:5,font:{size:10}}},y:{grid:{color:'rgba(255,255,255,.05)'},ticks:{color:'#888',font:{size:10}}}}}});else if(c){let x=c.getContext('2d');x.fillStyle='#555';x.font='13px Inter, sans-serif';x.textAlign='center';x.fillText('Sync LeetCode to see rating chart',c.width/2,c.height/2-8)}markChartReady('progressChartShell');[['platformsChart','platformsChartShell',['LeetCode','GFG','Coding Ninjas','HackerRank','InterviewBit','Other'],[pData.LeetCode,pData.GFG,pData['Coding Ninjas'],pData.HackerRank,pData.InterviewBit,pData.Other],['{{ PLATFORM_META["LeetCode"].brand_color }}','{{ PLATFORM_META["GFG"].brand_color }}','{{ PLATFORM_META["Coding Ninjas"].brand_color }}','{{ PLATFORM_META["HackerRank"].brand_color }}','{{ PLATFORM_META["InterviewBit"].brand_color }}','#6c757d']],['difficultyChart','difficultyChartShell',['Easy','Medium','Hard'],[{{lc_easy}},{{lc_medium}},{{lc_hard}}],['#00b8a3','#ffc01e','#ff375f']]].forEach(a=>{try{new Chart(document.getElementById(a[0]),{type:'doughnut',data:{labels:a[2],datasets:[{data:a[3],backgroundColor:a[4],borderWidth:0,cutout:'78%'}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}}}})}catch(e){}markChartReady(a[1])})}).catch(()=>chartShells.forEach(s=>s.classList.add('is-ready')))}
 if('IntersectionObserver'in window&&chartShells.length){const io=new IntersectionObserver((e,o)=>{if(e.some(x=>x.isIntersecting)){o.disconnect();renderProfileCharts()}},{rootMargin:'160px'});chartShells.forEach(s=>io.observe(s))}else renderProfileCharts();
 
 function openSyncModal(){document.getElementById('syncModal').classList.add('open')}

--- a/tests/test_platform_fetcher.py
+++ b/tests/test_platform_fetcher.py
@@ -1,7 +1,7 @@
 import time
 from unittest.mock import MagicMock, patch
 
-from app.platforms.fetchers import clear_platform_http_session, fetch_atcoder, run_fetch_jobs
+from app.platforms.fetchers import clear_platform_http_session, fetch_atcoder, fetch_interviewbit, run_fetch_jobs
 
 
 def setup_function():
@@ -41,6 +41,19 @@ def test_fetch_atcoder_returns_empty_on_exception():
         result = fetch_atcoder('tourist')
 
     assert result == {}
+
+
+def test_fetch_interviewbit_returns_total_on_success():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = '<html><body><div>Problems solved 89</div></body></html>'
+    fake_session = MagicMock()
+    fake_session.get.return_value = mock_response
+
+    with patch('app.platforms.fetchers._get_http_session', return_value=fake_session):
+        result = fetch_interviewbit('example-user')
+
+    assert result == {'total': 89}
 
 
 def test_fetchers_reuse_thread_local_http_session():

--- a/tests/test_sync_overlay_steps.py
+++ b/tests/test_sync_overlay_steps.py
@@ -14,6 +14,7 @@ def test_sync_overlay_includes_all_submitted_platforms():
     assert "{id:'ss_cn', label:'Coding Ninjas', value:cn}" in template
     assert "{id:'ss_ac', label:'AtCoder', value:ac}" in template
     assert "{id:'ss_cw', label:'Codewars', value:cw}" in template
+    assert "{id:'ss_ib', label:'InterviewBit', value:ib}" in template
 
 
 def test_sync_overlay_steps_are_built_from_active_values():
@@ -33,4 +34,6 @@ def test_sync_profile_template_wires_platforms_into_sync_requests():
     assert "const ac = '{{ user.atcoder_username or \"\" }}';" in template
     assert 'id="cw_username"' in template
     assert "const cw = '{{ user.codewars_username or \"\" }}';" in template
-    assert "body:JSON.stringify({leetcode:lc,github:gh,gfg:gfg,hackerrank:hr,codingninjas:cn,atcoder:ac,codewars:cw})" in template
+    assert "body:JSON.stringify({leetcode:lc,github:gh,gfg:gfg,hackerrank:hr,codingninjas:cn,atcoder:ac,codewars:cw,interviewbit:ib})" in template
+    assert 'id="ib_username"' in template
+    assert "const ib = '{{ user.interviewbit_username or \"\" }}';" in template

--- a/tests/test_sync_platforms.py
+++ b/tests/test_sync_platforms.py
@@ -75,6 +75,7 @@ def test_sync_platforms_runs_selected_platform_jobs_concurrently(monkeypatch):
             hackerrank_username="",
             codingninjas_username="",
             atcoder_username="",
+            interviewbit_username="",
             reload=lambda: None,
         ),
     )
@@ -109,6 +110,7 @@ def test_sync_platforms_runs_selected_platform_jobs_concurrently(monkeypatch):
                 "codingninjas": {"total": 12},
                 "hackerrank": ([{"name": "Problem Solving", "stars": 5}], 44),
                 "atcoder": {"total": 8},
+                "interviewbit": {"total": 23},
             },
             {},
         )
@@ -124,13 +126,14 @@ def test_sync_platforms_runs_selected_platform_jobs_concurrently(monkeypatch):
             "codingninjas": "cn-user",
             "hackerrank": "hr-user",
             "atcoder": "ac-user",
+            "interviewbit": "ib-user",
         },
     )
 
     payload = response.get_json()
 
     assert response.status_code == 200
-    assert captured["job_names"] == ["atcoder", "codingninjas", "gfg", "github", "hackerrank", "leetcode"]
+    assert captured["job_names"] == ["atcoder", "codingninjas", "gfg", "github", "hackerrank", "interviewbit", "leetcode"]
     assert captured["max_workers"] == 4
     assert payload["success"] is True
     assert payload["platforms"]["leetcode"]["status"] == "synced"
@@ -145,6 +148,7 @@ def test_sync_platforms_runs_selected_platform_jobs_concurrently(monkeypatch):
     assert update_fields["external_totals"]["Coding Ninjas"] == 12
     assert update_fields["external_totals"]["HackerRank"] == 44
     assert update_fields["external_totals"]["AtCoder"] == 8
+    assert update_fields["external_totals"]["InterviewBit"] == 23
     assert update_fields["rating_history"] == [{"x": "2026-05-25", "y": 1800}]
     assert update_fields["lc_badges_json"] == '[{"name": "Knight"}]'
     assert update_fields["hr_badges_json"] == '[{"name": "Problem Solving", "stars": 5}]'
@@ -167,6 +171,7 @@ def test_sync_platforms_tolerates_missing_cache_extension(monkeypatch):
             hackerrank_username="",
             codingninjas_username="",
             atcoder_username="",
+            interviewbit_username="",
             reload=lambda: None,
         ),
     )
@@ -217,6 +222,7 @@ def test_sync_platforms_marks_github_rate_limit_payload_failed(monkeypatch):
             hackerrank_username="",
             codingninjas_username="",
             atcoder_username="",
+            interviewbit_username="",
             reload=lambda: None,
         ),
     )


### PR DESCRIPTION
# Description

This pull request introduces integration for the InterviewBit coding platform. Users can now link their InterviewBit profiles by providing their username in the sync modal. The application dynamically extracts total problems solved via backend HTML parsing, updates the profile dashboard view, reflects metrics within the platform charts distribution, and accounts for InterviewBit stats when calculating the global consistency C-score.

Fixes #363

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Tested in Local: Verified that the parser correctly extracts the numeric counts from profile pages, account synchronization properly updates `external_totals`, and charts/C-score statistics dynamically include InterviewBit progress.
- [x] Automated Tests Added/Updated:
  - `test_fetch_interviewbit_returns_total_on_success` in `tests/test_platform_fetcher.py` to assert regex parsing metrics evaluate correctly on successful profile scrapes.
  - Wired `ss_ib` checking conditions and verified request payload formatting strings inside `tests/test_sync_overlay_steps.py`.
  - Expanded concurrent execution array mappings inside `tests/test_sync_platforms.py` to confirm the integration behaves safely across parallel thread job runs.

## Checklist

- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs

_None provided._

## Contributor Confirmation

- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors