### PR TITLE
Feat/353 saved searches

### DIFF
--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -3,7 +3,7 @@ from flask import Blueprint, current_app, jsonify, render_template, request
 from flask_login import current_user
 
 from app.extensions import db, limiter
-from app.utils import json_error, json_success, utc_now
+# Import app utilities lazily inside functions to avoid circular imports
 from app.search.service import search_dsa_questions
 
 
@@ -82,8 +82,10 @@ def search():
 
 @search_bp.route("/api/saved_searches", methods=["POST"])
 def save_search_query():
-    if not current_user.is_authenticated:
-        return json_error("Login required", status_code=401)
+  from app.utils import json_error, json_success, utc_now
+
+  if not current_user.is_authenticated:
+    return json_error("Login required", status_code=401)
 
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
@@ -134,8 +136,10 @@ def save_search_query():
 
 @search_bp.route("/api/saved_searches/<search_id>", methods=["PATCH", "DELETE"])
 def update_saved_search_query(search_id):
-    if not current_user.is_authenticated:
-        return json_error("Login required", status_code=401)
+  from app.utils import json_error, json_success, utc_now
+
+  if not current_user.is_authenticated:
+    return json_error("Login required", status_code=401)
 
     user_doc = db.user.find_one({"_id": current_user.id}) or {}
     saved_searches = list(user_doc.get("saved_searches") or [])

--- a/app/search/routes.py
+++ b/app/search/routes.py
@@ -1,7 +1,9 @@
+from bson import ObjectId
 from flask import Blueprint, current_app, jsonify, render_template, request
 from flask_login import current_user
 
 from app.extensions import db, limiter
+from app.utils import json_error, json_success, utc_now
 from app.search.service import search_dsa_questions
 
 
@@ -9,6 +11,53 @@ search_bp = Blueprint("search", __name__)
 
 DEFAULT_SEARCH_LIMIT = 40
 MAX_SEARCH_LIMIT = 80
+
+
+def normalize_saved_search_text(value):
+    return " ".join((value or "").strip().split())
+
+
+def normalize_saved_search_filters(filters):
+    filters = filters if isinstance(filters, dict) else {}
+    normalized = {}
+    for key in ("topic_id", "difficulty", "platform", "status"):
+        value = normalize_saved_search_text(filters.get(key, ""))
+        normalized[key] = value.lower() if key != "topic_id" else value
+    return normalized
+
+
+def summarize_saved_search(query, filters):
+    parts = []
+    if query:
+        parts.append(query)
+    for label, key in (("Topic", "topic_id"), ("Difficulty", "difficulty"), ("Platform", "platform"), ("Status", "status")):
+        value = filters.get(key)
+        if value:
+            parts.append(f"{label}: {value}")
+    return " · ".join(parts) or "Saved search"
+
+
+def serialize_saved_search(entry):
+    filters = normalize_saved_search_filters(entry.get("filters"))
+    query = normalize_saved_search_text(entry.get("query", ""))
+    name = normalize_saved_search_text(entry.get("name", "")) or summarize_saved_search(query, filters)
+    return {
+        "id": str(entry.get("id", "")),
+        "query": query,
+        "filters": filters,
+        "name": name,
+    }
+
+
+def get_saved_searches(user_doc):
+    return [serialize_saved_search(entry) for entry in (user_doc.get("saved_searches") or []) if isinstance(entry, dict)]
+
+
+def find_saved_search_index(saved_searches, search_id):
+    for index, entry in enumerate(saved_searches):
+        if str(entry.get("id", "")) == search_id:
+            return index
+    return None
 
 
 @search_bp.route("/search")
@@ -22,7 +71,96 @@ def search():
             topics = list(db.topic.find({}, {"name": 1}).sort("position", 1))
         except Exception:
             topics = []
-    return render_template("search.html", initial_query=initial_query, topics=topics)
+    saved_searches = get_saved_searches(current_user._get_current_object()) if current_user.is_authenticated else []
+    return render_template(
+        "search.html",
+        initial_query=initial_query,
+        topics=topics,
+        saved_searches=saved_searches,
+    )
+
+
+@search_bp.route("/api/saved_searches", methods=["POST"])
+def save_search_query():
+    if not current_user.is_authenticated:
+        return json_error("Login required", status_code=401)
+
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return json_error("Request body must be a JSON object", status_code=400)
+
+    query = normalize_saved_search_text(data.get("query", ""))
+    filters = normalize_saved_search_filters(data.get("filters"))
+    name = normalize_saved_search_text(data.get("name", "")) or summarize_saved_search(query, filters)
+    if not query and not any(filters.values()):
+        return json_error("Search query cannot be empty", status_code=400)
+
+    user_doc = db.user.find_one({"_id": current_user.id}) or {}
+    saved_searches = list(user_doc.get("saved_searches") or [])
+    new_key = {"query": query.lower(), "filters": filters}
+    now = utc_now()
+
+    match_index = None
+    for index, entry in enumerate(saved_searches):
+        if not isinstance(entry, dict):
+            continue
+        existing_key = {
+            "query": normalize_saved_search_text(entry.get("query", "")).lower(),
+            "filters": normalize_saved_search_filters(entry.get("filters")),
+        }
+        if existing_key == new_key:
+            match_index = index
+            break
+
+    if match_index is not None:
+        saved_searches[match_index].update({"name": name, "updated_at": now})
+    else:
+        saved_searches.insert(
+            0,
+            {
+                "id": str(ObjectId()),
+                "query": query,
+                "filters": filters,
+                "name": name,
+                "created_at": now,
+                "updated_at": now,
+            },
+        )
+
+    db.user.update_one({"_id": current_user.id}, {"$set": {"saved_searches": saved_searches}})
+    current_user.reload()
+    return json_success(message="Saved search stored", saved_searches=get_saved_searches(current_user._get_current_object()))
+
+
+@search_bp.route("/api/saved_searches/<search_id>", methods=["PATCH", "DELETE"])
+def update_saved_search_query(search_id):
+    if not current_user.is_authenticated:
+        return json_error("Login required", status_code=401)
+
+    user_doc = db.user.find_one({"_id": current_user.id}) or {}
+    saved_searches = list(user_doc.get("saved_searches") or [])
+    index = find_saved_search_index(saved_searches, search_id)
+    if index is None:
+        return json_error("Saved search not found", status_code=404)
+
+    if request.method == "DELETE":
+        saved_searches.pop(index)
+    else:
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return json_error("Request body must be a JSON object", status_code=400)
+        name = normalize_saved_search_text(data.get("name", ""))
+        if not name:
+            return json_error("name is required", status_code=400)
+        saved_searches[index]["name"] = name
+        saved_searches[index]["updated_at"] = utc_now()
+
+    db.user.update_one({"_id": current_user.id}, {"$set": {"saved_searches": saved_searches}})
+    current_user.reload()
+    return json_success(
+        message="Saved searches updated",
+        saved_searches=get_saved_searches(current_user._get_current_object()),
+    )
 
 
 @search_bp.route("/api/search_questions")

--- a/templates/search.html
+++ b/templates/search.html
@@ -100,10 +100,25 @@
   padding-top: 14px;
   border-top: 1px solid var(--border-color);
 }
+.saved-searches {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-color);
+}
 .recent-searches[hidden] {
   display: none;
 }
+.saved-searches[hidden] {
+  display: none;
+}
 .recent-searches-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+.saved-searches-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -117,10 +132,71 @@
   color: var(--text-secondary);
   text-transform: uppercase;
 }
+.saved-searches-title {
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
 .recent-searches-list {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+}
+.saved-searches-list {
+  display: grid;
+  gap: 8px;
+}
+.saved-search-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.saved-search-chip-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  max-width: 100%;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  padding: 7px 12px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.2s;
+}
+.saved-search-chip-main:hover,
+.saved-search-chip-main:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.saved-search-chip-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.saved-search-chip-action {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+.saved-search-chip-action:hover,
+.saved-search-chip-action:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 .recent-search-chip {
   display: inline-flex;
@@ -314,6 +390,15 @@
       </select>
       {% endif %}
     </div>
+    {% if current_user.is_authenticated %}
+    <div id="savedSearches" class="saved-searches" hidden>
+      <div class="saved-searches-head">
+        <div class="saved-searches-title">Saved searches</div>
+        <button id="saveSearchBtn" class="recent-search-clear" type="button" aria-label="Save the current search">Save current</button>
+      </div>
+      <div id="savedSearchesList" class="saved-searches-list" role="list" aria-label="Saved searches"></div>
+    </div>
+    {% endif %}
     <div id="recentSearches" class="recent-searches" hidden>
       <div class="recent-searches-head">
         <div class="recent-searches-title">Recent searches</div>
@@ -334,11 +419,15 @@
 <script>
 const endpointConfig = {{ {
   "searchQuestions": url_for('search.api_search_questions'),
+  "savedSearches": url_for('search.save_search_query'),
 }|tojson }};
 const input = document.getElementById('searchInput');
 const results = document.getElementById('results');
 const meta = document.getElementById('searchMeta');
 const clearBtn = document.getElementById('clearSearch');
+const saveSearchBtn = document.getElementById('saveSearchBtn');
+const savedSearchesPanel = document.getElementById('savedSearches');
+const savedSearchesList = document.getElementById('savedSearchesList');
 const recentSearchesPanel = document.getElementById('recentSearches');
 const recentSearchesList = document.getElementById('recentSearchesList');
 const clearRecentSearchesBtn = document.getElementById('clearRecentSearches');
@@ -352,6 +441,8 @@ let debounceTimer = null;
 let controller = null;
 const RECENT_SEARCHES_KEY = 'dsa_recent_searches_v1';
 const MAX_RECENT_SEARCHES = 5;
+const initialSavedSearches = {{ saved_searches|default([])|tojson }};
+let savedSearches = Array.isArray(initialSavedSearches) ? initialSavedSearches : [];
 const platformLabels = {
   leetcode: 'LeetCode',
   gfg: 'GFG',
@@ -424,6 +515,26 @@ function currentQuery() {
   return [activeToken, text].filter(Boolean).join(' ');
 }
 
+function currentSearchState() {
+  return {
+    query: input.value.trim(),
+    filters: getFilters()
+  };
+}
+
+function summarizeSavedSearch(state) {
+  const parts = [];
+  if (state.query) {
+    parts.push(state.query);
+  }
+  const filters = state.filters || {};
+  if (filters.topic_id) parts.push(`Topic: ${filters.topic_id}`);
+  if (filters.difficulty) parts.push(`Difficulty: ${filters.difficulty}`);
+  if (filters.platform) parts.push(`Platform: ${filters.platform}`);
+  if (filters.status) parts.push(`Status: ${filters.status}`);
+  return parts.length ? parts.join(' · ') : 'Saved search';
+}
+
 function normalizeRecentSearchText(value) {
   return String(value || '').replace(/\s+/g, ' ').trim();
 }
@@ -465,6 +576,110 @@ function renderRecentSearches() {
       </button>
     `;
   }).join('');
+}
+
+function renderSavedSearches() {
+  if (!savedSearchesPanel || !savedSearchesList) {
+    return;
+  }
+
+  savedSearchesPanel.hidden = savedSearches.length === 0;
+  if (!savedSearches.length) {
+    savedSearchesList.innerHTML = '';
+    return;
+  }
+
+  savedSearchesList.innerHTML = savedSearches.map(entry => {
+    const label = escapeHtml(entry.name || summarizeSavedSearch(entry));
+    return `
+      <div class="saved-search-item" role="listitem" data-id="${escapeHtml(entry.id || '')}">
+        <button class="saved-search-chip-main" type="button" data-saved-search-action="apply" data-id="${escapeHtml(entry.id || '')}" aria-label="Apply saved search ${label}">
+          <i class="bi bi-bookmark-star" aria-hidden="true"></i>
+          <span class="recent-search-chip-text">${label}</span>
+        </button>
+        <div class="saved-search-chip-actions" aria-label="Saved search actions">
+          <button class="saved-search-chip-action" type="button" data-saved-search-action="rename" data-id="${escapeHtml(entry.id || '')}" aria-label="Rename saved search ${label}">
+            <i class="bi bi-pencil" aria-hidden="true"></i>
+          </button>
+          <button class="saved-search-chip-action" type="button" data-saved-search-action="delete" data-id="${escapeHtml(entry.id || '')}" aria-label="Delete saved search ${label}">
+            <i class="bi bi-trash" aria-hidden="true"></i>
+          </button>
+        </div>
+      </div>
+    `;
+  }).join('');
+}
+
+function applySavedSearch(entry) {
+  if (!entry) return;
+  input.value = entry.query || '';
+  const filters = entry.filters || {};
+  if (filterTopic) filterTopic.value = filters.topic_id || '';
+  if (filterDifficulty) filterDifficulty.value = filters.difficulty || '';
+  if (filterPlatform) filterPlatform.value = filters.platform || '';
+  if (filterStatus) filterStatus.value = filters.status || '';
+  setFilterActiveStates();
+  setActiveChip('');
+  runSearch();
+}
+
+async function persistSavedSearch(method, payload, searchId) {
+  const url = searchId ? `${endpointConfig.savedSearches}/${encodeURIComponent(searchId)}` : endpointConfig.savedSearches;
+  const response = await fetch(url, {
+    method,
+    headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
+    body: payload ? JSON.stringify(payload) : undefined,
+  });
+  const result = await response.json();
+  if (!response.ok || !result.success) {
+    throw new Error(result.error || 'Saved search update failed');
+  }
+  savedSearches = Array.isArray(result.saved_searches) ? result.saved_searches : savedSearches;
+  renderSavedSearches();
+  return result;
+}
+
+async function saveCurrentSearch() {
+  const state = currentSearchState();
+  if (!state.query && !Object.values(state.filters).some(Boolean)) {
+    showUpdateError('Enter a query or filter before saving.');
+    return;
+  }
+  const defaultName = summarizeSavedSearch(state);
+  const name = window.prompt('Name this saved search', defaultName);
+  if (name === null) return;
+  try {
+    await persistSavedSearch('POST', {...state, name});
+    showUpdateError('Saved search updated.');
+  } catch (error) {
+    showUpdateError(error.message || 'Unable to save search. Please try again.');
+  }
+}
+
+async function renameSavedSearch(entry) {
+  const currentName = entry.name || summarizeSavedSearch(entry);
+  const nextName = window.prompt('Rename saved search', currentName);
+  if (nextName === null) return;
+  if (!nextName.trim()) {
+    showUpdateError('Saved search name cannot be empty.');
+    return;
+  }
+  try {
+    await persistSavedSearch('PATCH', {name: nextName.trim()}, entry.id);
+  } catch (error) {
+    showUpdateError(error.message || 'Unable to rename saved search.');
+  }
+}
+
+async function deleteSavedSearch(entry) {
+  if (!window.confirm(`Delete saved search "${entry.name || summarizeSavedSearch(entry)}"?`)) {
+    return;
+  }
+  try {
+    await persistSavedSearch('DELETE', null, entry.id);
+  } catch (error) {
+    showUpdateError(error.message || 'Unable to delete saved search.');
+  }
 }
 
 function rememberRecentSearch(text, token) {
@@ -618,6 +833,9 @@ clearBtn.addEventListener('click', () => {
   input.focus();
   scheduleSearch();
 });
+if (saveSearchBtn) {
+  saveSearchBtn.addEventListener('click', saveCurrentSearch);
+}
 recentSearchesList.addEventListener('click', (event) => {
   const chip = event.target.closest('.recent-search-chip');
   if (!chip) return;
@@ -627,6 +845,22 @@ clearRecentSearchesBtn.addEventListener('click', () => {
   saveRecentSearches([]);
   renderRecentSearches();
 });
+if (savedSearchesList) {
+  savedSearchesList.addEventListener('click', event => {
+    const button = event.target.closest('button[data-saved-search-action]');
+    if (!button) return;
+    const entry = savedSearches.find(item => String(item.id) === String(button.dataset.id));
+    if (!entry) return;
+    const action = button.dataset.savedSearchAction;
+    if (action === 'apply') {
+      applySavedSearch(entry);
+    } else if (action === 'rename') {
+      renameSavedSearch(entry);
+    } else if (action === 'delete') {
+      deleteSavedSearch(entry);
+    }
+  });
+}
 chips.forEach(chip => {
   chip.addEventListener('click', () => {
     setActiveChip(chip.dataset.token);
@@ -644,6 +878,7 @@ chips.forEach(chip => {
 
 restoreStateFromUrl();
 setActiveChip('');
+renderSavedSearches();
 renderRecentSearches();
 runSearch();
 </script>


### PR DESCRIPTION
# Description

This pull request introduces a "Saved Searches" feature for authenticated users on the search page. Users can now persist their active query strings and applied filter configurations (topic, difficulty, platform, status) directly to their account profile. The feature supports custom names or automatically generated dynamic summaries, real-time list rendering, updating/renaming saved parameters, and clean deletions.

Fixes #353

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Tested in Local: Verified that authenticated users can successfully save search states via the `/api/saved_searches` POST endpoint, edit names with PATCH actions, and drop items using DELETE verbs. Confirmed that unauthenticated visitors are safely restricted and that the frontend updates its state handling synchronously without breaking lazy utility definitions or triggering circular imports.

## Checklist

- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs

_None provided._

## Contributor Confirmation

- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors