### PR TITLE
fix: hide photo upload UI and return 501 when Cloudinary not configured

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -336,7 +336,7 @@ def upload_photo():
               type: string
               example: Photo upload disabled (Cloudinary not configured)
     """
-    return json_error("Photo upload disabled (Cloudinary not configured)", status_code=500)
+    return json_error("Photo upload disabled (Cloudinary not configured)", status_code=501)
 
 
 @profile_bp.route("/profile")

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -425,6 +425,7 @@
         <div id="editAvatarPreview" style="width:80px;height:80px;border-radius:50%;background:linear-gradient(135deg,var(--accent),#ff375f);display:flex;align-items:center;justify-content:center;font-size:1.8rem;font-weight:900;color:#fff;overflow:hidden;margin:0 auto 8px;border:3px solid var(--border-color)">
           {% if user.profile_photo %}<img src="{{ user.profile_photo }}" width="80" height="80" loading="lazy" decoding="async" style="width:100%;height:100%;object-fit:cover" alt="{{ user.name }} profile preview">{% else %}{{ user.name[0]|upper }}{% endif %}
         </div>
+        {% if false %}{# Photo upload hidden: Cloudinary not configured #}
         <label for="photoInput" style="display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border:1px solid var(--border-color);border-radius:8px;cursor:pointer;font-size:.8rem;color:var(--text-secondary);transition:all .2s" onmouseover="this.style.borderColor='var(--accent)';this.style.color='var(--accent)'" onmouseout="this.style.borderColor='var(--border-color)';this.style.color='var(--text-secondary)'">
           <i class="bi bi-camera"></i> Upload Photo
         </label>
@@ -432,6 +433,7 @@
       </div>
       <div style="font-size:.7rem;color:var(--text-muted);margin-top:4px">Max 2MB • PNG, JPG, GIF, WebP</div>
     </div>
+    {% endif %}
     <!-- Basic Info -->
     <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:12px">
       <div><label class="m-lbl">Full Name</label><input class="m-inp" id="ep_name" value="{{ user.name or '' }}"></div>


### PR DESCRIPTION
Fixes #197

### Changes made:
- Hid the profile photo upload UI in `templates/profile.html` using `{% if false %}` when Cloudinary is not configured
- Updated `app/profile/routes.py` to return `501` (Not Implemented) instead of `500` for the upload_photo endpoint

### Why:
The upload UI was visible but broken for every user since Cloudinary is not configured. This fix hides the UI gracefully and returns a proper status code.