### PR TITLE
fix: preserve existing external_totals during partial platform sync

### DIFF
--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -140,7 +140,10 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
         codewars_username = data.get("codewars", "").strip()
         update_fields["codewars_username"] = codewars_username
 
-    platform_totals = {}
+    existing_totals = getattr(user, "external_totals", {}) or {}
+    if not isinstance(existing_totals, dict):
+        existing_totals = {}
+    platform_totals = dict(existing_totals)
     platform_status = {}
 
     def _mark(platform_key: str, status: str, error: str = None):

--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -21,6 +21,20 @@ logger = logging.getLogger("flask.app")
 
 SYNC_COOLDOWN_SECONDS = 600
 
+PLATFORM_KEYS = {"leetcode", "github", "gfg", "hackerrank",
+                 "codingninjas", "atcoder", "codewars"}
+
+PLATFORM_TOTAL_KEYS = {
+    "leetcode": {"LeetCode", "LeetCode_Easy", "LeetCode_Medium", "LeetCode_Hard",
+                 "LeetCode_Contests", "LeetCode_Rating", "LeetCode_GlobalRank"},
+    "github": {"GitHub_Issues", "GitHub_PRs", "GitHub_Merged_PRs", "GitHub_Commits"},
+    "gfg": {"GFG"},
+    "codingninjas": {"Coding Ninjas"},
+    "hackerrank": {"HackerRank"},
+    "atcoder": {"AtCoder"},
+    "codewars": {"Codewars"},
+}
+
 
 def build_sync_platforms_response(platform_status: dict):
     attempted = sum(1 for value in platform_status.values() if value.get("status") != "skipped")
@@ -144,6 +158,14 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
     if not isinstance(existing_totals, dict):
         existing_totals = {}
     platform_totals = dict(existing_totals)
+
+    # Clear totals for platforms included in this sync so stale data
+    # does not persist when a sync fails or a username is cleared.
+    for platform_key in data:
+        if platform_key in PLATFORM_TOTAL_KEYS:
+            for total_key in PLATFORM_TOTAL_KEYS[platform_key]:
+                platform_totals.pop(total_key, None)
+
     platform_status = {}
 
     def _mark(platform_key: str, status: str, error: str = None):
@@ -291,8 +313,6 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
     # covered every platform the user has configured.  During the migration
     # from the old flat ``external_daily_counts`` format to per-platform
     # calendars, ``_legacy`` preserves dates from platforms not yet re-synced.
-    PLATFORM_KEYS = {"leetcode", "github", "gfg", "hackerrank",
-                     "codingninjas", "atcoder", "codewars"}
     requested_platforms = {k for k in data if k in PLATFORM_KEYS}
     legacy_counts = getattr(user, "external_daily_counts", {})
     has_legacy = isinstance(legacy_counts, dict) and bool(legacy_counts)

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -16,6 +16,7 @@ class FakeUser:
         self.atcoder_username = kwargs.get("atcoder_username", "")
         self.platform_calendars = kwargs.get("platform_calendars", {})
         self.external_daily_counts = kwargs.get("external_daily_counts", {})
+        self.external_totals = kwargs.get("external_totals", {})
         self.reload_calls = 0
 
     def reload(self):
@@ -307,6 +308,82 @@ def test_get_merged_daily_counts_falls_back_to_legacy():
     )
     merged = get_merged_daily_counts(user)
     assert merged == {"2026-05-25": 3}
+
+
+def test_sync_clears_stale_totals_when_platform_fails_or_username_cleared(monkeypatch):
+    """When a sync is requested for a platform and the sync fails or the username
+    is cleared, old external_totals for that platform must be removed so stale
+    stats do not persist. Totals for platforms not part of this sync are preserved."""
+    now = datetime.now(timezone.utc)
+    user = FakeUser(
+        leetcode_username="alice",
+        github_username="octocat",
+        external_totals={
+            "LeetCode": 25,
+            "LeetCode_Easy": 10,
+            "LeetCode_Medium": 12,
+            "LeetCode_Hard": 3,
+            "LeetCode_Contests": 4,
+            "LeetCode_Rating": 1725,
+            "LeetCode_GlobalRank": 3210,
+            "GitHub_Issues": 5,
+            "GitHub_PRs": 3,
+            "GitHub_Merged_PRs": 2,
+            "GitHub_Commits": 100,
+        },
+    )
+    db = FakeDB()
+    cache = FakeCache()
+
+    # Sync both platforms — the fetch will return data for leetcode but fail for
+    # github (simulated by not adding a github entry to platform_results).
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_leetcode",
+        lambda username: {
+            "calendar": {"2026-05-24": 3},
+            "total": 30,
+            "difficulty": {"Easy": 15, "Medium": 12, "Hard": 3},
+            "contest": {"attendedContestsCount": 5, "rating": 1800, "globalRanking": 2500},
+        },
+    )
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_leetcode_rating_history",
+        lambda username: [],
+    )
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_lc_badges",
+        lambda username: [],
+    )
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_github",
+        lambda username: None,
+    )
+    monkeypatch.setattr("app.profile.sync_service.invalidate_leaderboard_cache", lambda: None)
+
+    payload, status_code = sync_user_platforms(
+        user,
+        {"leetcode": "alice", "github": "octocat"},
+        db,
+        cache,
+        now=now,
+    )
+
+    assert status_code == 200
+    # leetcode succeeds, github returns None → fails
+    assert payload["platforms"]["leetcode"]["status"] == "synced"
+    assert payload["platforms"]["github"]["status"] == "failed"
+
+    update_doc = db.user.updates[0][1]
+    totals = update_doc["$set"]["external_totals"]
+
+    # LeetCode totals should be updated with new sync values
+    assert totals["LeetCode"] == 30
+
+    # GitHub totals must be gone because the sync failed
+    assert "GitHub_Issues" not in totals
+    assert "GitHub_PRs" not in totals
+    assert "GitHub_Merged_PRs" not in totals
+    assert "GitHub_Commits" not in totals
 
 
 def test_build_sync_platforms_response_all_failed():


### PR DESCRIPTION
# Description

When `sync_platform_data` writes to `platform_totals`, it overwrote any existing totals from manual entry or previous syncs, losing unsynced problem-solving statistics.

Fixes #699

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested in Local

## Checklist
- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [ ] I added or updated tests where useful.

## Screenshots Or Logs
N/A

## Contributor Confirmation

- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

---