### PR TITLE
fix: empty calendars zero out merged counts

### DIFF
--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -204,9 +204,7 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
             _mark("leetcode", "failed", "No data returned (username may be invalid or rate-limited).")
         else:
             _mark("leetcode", "synced")
-            new_calendar = leetcode_data.get("calendar", {})
-            if new_calendar:
-                platform_calendars["leetcode"] = new_calendar
+            platform_calendars["leetcode"] = leetcode_data.get("calendar", {})
             if leetcode_data.get("total") is not None:
                 platform_totals["LeetCode"] = leetcode_data.get("total")
             if leetcode_data.get("difficulty"):
@@ -239,9 +237,7 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
                 _mark("github", "failed", "GitHub API returned an error. Please try again later.")
         else:
             _mark("github", "synced")
-            new_calendar = github_data.get("calendar", {})
-            if new_calendar:
-                platform_calendars["github"] = new_calendar
+            platform_calendars["github"] = github_data.get("calendar", {})
             if github_data.get("stats"):
                 platform_totals["GitHub_Issues"] = github_data["stats"]["issues"]
                 platform_totals["GitHub_PRs"] = github_data["stats"]["prs"]

--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -204,7 +204,9 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
             _mark("leetcode", "failed", "No data returned (username may be invalid or rate-limited).")
         else:
             _mark("leetcode", "synced")
-            platform_calendars["leetcode"] = leetcode_data.get("calendar", {})
+            new_calendar = leetcode_data.get("calendar", {})
+            if new_calendar:
+                platform_calendars["leetcode"] = new_calendar
             if leetcode_data.get("total") is not None:
                 platform_totals["LeetCode"] = leetcode_data.get("total")
             if leetcode_data.get("difficulty"):
@@ -237,7 +239,9 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
                 _mark("github", "failed", "GitHub API returned an error. Please try again later.")
         else:
             _mark("github", "synced")
-            platform_calendars["github"] = github_data.get("calendar", {})
+            new_calendar = github_data.get("calendar", {})
+            if new_calendar:
+                platform_calendars["github"] = new_calendar
             if github_data.get("stats"):
                 platform_totals["GitHub_Issues"] = github_data["stats"]["issues"]
                 platform_totals["GitHub_PRs"] = github_data["stats"]["prs"]

--- a/app/utils.py
+++ b/app/utils.py
@@ -254,13 +254,15 @@ def get_merged_daily_counts(user_doc):
             if coerce_non_negative_number(count) > 0:
                 merged[date] = max(merged.get(date, 0), count)
 
+        legacy = _get_field(user_doc, "external_daily_counts", {})
+        if isinstance(legacy, dict):
+            for date, count in legacy.items():
+                if coerce_non_negative_number(count) > 0:
+                    merged[date] = max(merged.get(date, 0), count)
+
         if merged:
-            legacy = _get_field(user_doc, "external_daily_counts", {})
-            if isinstance(legacy, dict):
-                for date, count in legacy.items():
-                    if coerce_non_negative_number(count) > 0:
-                        merged[date] = max(merged.get(date, 0), count)
             return merged
+        return legacy if legacy else {}
     return _get_field(user_doc, "external_daily_counts", {})
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -247,18 +247,21 @@ def get_merged_daily_counts(user_doc):
         for _platform, counts in calendars.items():
             if isinstance(counts, dict):
                 for date, count in counts.items():
-                    if coerce_non_negative_number(count) > 0:
-                        merged[date] = merged.get(date, 0) + count
+                    safe = coerce_non_negative_number(count)
+                    if safe > 0:
+                        merged[date] = merged.get(date, 0) + safe
 
         for date, count in legacy_fallback.items():
-            if coerce_non_negative_number(count) > 0:
-                merged[date] = max(merged.get(date, 0), count)
+            safe = coerce_non_negative_number(count)
+            if safe > 0:
+                merged[date] = max(merged.get(date, 0), safe)
 
         legacy = _get_field(user_doc, "external_daily_counts", {})
         if isinstance(legacy, dict):
             for date, count in legacy.items():
-                if coerce_non_negative_number(count) > 0:
-                    merged[date] = max(merged.get(date, 0), count)
+                safe = coerce_non_negative_number(count)
+                if safe > 0:
+                    merged[date] = max(merged.get(date, 0), safe)
 
         if merged:
             return merged

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -310,6 +310,18 @@ def test_get_merged_daily_counts_falls_back_to_legacy():
     assert merged == {"2026-05-25": 3}
 
 
+def test_get_merged_daily_counts_empty_platform_calendars_with_string_legacy():
+    """Empty platform calendars must not prevent merging of string-typed legacy
+    external_daily_counts; the string must be coerced via
+    coerce_non_negative_number before being passed to max()."""
+    user = FakeUser(
+        platform_calendars={"leetcode": {}},
+        external_daily_counts={"2026-05-25": "3", "2026-05-26": 2},
+    )
+    merged = get_merged_daily_counts(user)
+    assert merged == {"2026-05-25": 3, "2026-05-26": 2}
+
+
 def test_sync_clears_stale_totals_when_platform_fails_or_username_cleared(monkeypatch):
     """When a sync is requested for a platform and the sync fails or the username
     is cleared, old external_totals for that platform must be removed so stale


### PR DESCRIPTION
# Description

When LeetCode/GitHub returned an empty calendar, `sync_platform_data` wrote `{}` to the DB, making merged daily counts empty and the profile show zero activity.

Fixes #701

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested in Local

## Checklist
- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [ ] I added or updated tests where useful.

## Screenshots Or Logs
N/A

## Contributor Confirmation

- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

---