### PR TITLE
fix: include external platform activity in streak computation (#698)

### DIFF
--- a/app/profile/card_service.py
+++ b/app/profile/card_service.py
@@ -10,7 +10,7 @@ from cachetools import TTLCache
 import card_generator
 
 from app.extensions import db
-from app.utils import compute_c_score, compute_user_platforms, ensure_utc_datetime, merge_platform_counts
+from app.utils import compute_c_score, compute_user_platforms, ensure_utc_datetime, get_merged_daily_counts, merge_platform_counts
 from streaks import compute_streak
 
 
@@ -73,7 +73,8 @@ def get_public_card_image(user_id, object_id=None, db_handle=None):
     dsa_progress = round((dsa_done / total_questions * 100) if total_questions > 0 else 0, 1)
 
     progress_data = user.get("progress", {})
-    current_streak, _ = compute_streak(progress_data)
+    merged_counts = get_merged_daily_counts(user)
+    current_streak, _ = compute_streak(progress_data, external_daily_counts=merged_counts)
 
     if user.get("in_sheet_platform_counts"):
         platforms = merge_platform_counts(user.get("in_sheet_platform_counts"), user.get("external_totals", {}))

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -345,7 +345,8 @@ def profile():
     user = current_user
     solved_items = {question_id: progress for question_id, progress in user.progress.items() if progress.get("done")}
     dsa_done = len(solved_items)
-    current_streak, longest_streak = compute_streak(user.progress)
+    merged_daily_counts = get_merged_daily_counts(user)
+    current_streak, longest_streak = compute_streak(user.progress, external_daily_counts=merged_daily_counts)
 
     pre = current_app.config.get("_PRECOMPUTED")
     if pre:
@@ -387,9 +388,8 @@ def profile():
             day = solved_at.strftime("%Y-%m-%d")
             daily_counts[day] = daily_counts.get(day, 0) + 1
 
-    ext_daily = get_merged_daily_counts(user)
-    if ext_daily:
-        for day, count in ext_daily.items():
+    if merged_daily_counts:
+        for day, count in merged_daily_counts.items():
             daily_counts[day] = daily_counts.get(day, 0) + count
 
     total_active_days = len(daily_counts)
@@ -477,7 +477,7 @@ def profile():
     leaderboard_entries = build_leaderboard_data()
     profile_leaderboard_rank = get_user_rank_by_c_score(user.id, leaderboard_entries)
 
-    update_computed_stats(user.id, user.progress, db, total_questions)
+    update_computed_stats(user.id, user.progress, db, total_questions, user)
 
     return render_template(
         "profile.html",

--- a/app/utils.py
+++ b/app/utils.py
@@ -371,12 +371,13 @@ def merge_platform_counts(in_sheet_counts, external_totals):
     return platforms
 
 
-def update_computed_stats(user_id, progress, db_handle, total_questions):
+def update_computed_stats(user_id, progress, db_handle, total_questions, user_doc=None):
     from streaks import compute_streak
 
     dsa_done = sum(1 for p in progress.values() if p.get("done"))
     dsa_progress = round((dsa_done / total_questions * 100) if total_questions > 0 else 0, 1)
-    current_streak, longest_streak = compute_streak(progress)
+    merged = get_merged_daily_counts(user_doc) if user_doc else None
+    current_streak, longest_streak = compute_streak(progress, external_daily_counts=merged)
 
     db_handle.user.update_one(
         {"_id": user_id},

--- a/streaks.py
+++ b/streaks.py
@@ -11,7 +11,7 @@ def _to_utc_date(value):
     return None
 
 
-def compute_streak(progress, today=None):
+def compute_streak(progress, today=None, external_daily_counts=None):
     today = today or datetime.now(timezone.utc).date()
     solved_dates = {
         solved_date
@@ -20,6 +20,14 @@ def compute_streak(progress, today=None):
         for solved_date in (_to_utc_date(item.get('timestamp')),)
         if solved_date
     }
+
+    if external_daily_counts:
+        for date_str in external_daily_counts:
+            try:
+                d = date.fromisoformat(date_str)
+                solved_dates.add(d)
+            except (ValueError, TypeError):
+                pass
 
     if not solved_dates:
         return 0, 0

--- a/streaks.py
+++ b/streaks.py
@@ -22,10 +22,11 @@ def compute_streak(progress, today=None, external_daily_counts=None):
     }
 
     if external_daily_counts:
-        for date_str in external_daily_counts:
+        for date_str, count in external_daily_counts.items():
             try:
-                d = date.fromisoformat(date_str)
-                solved_dates.add(d)
+                if count and int(count) > 0:
+                    d = date.fromisoformat(date_str)
+                    solved_dates.add(d)
             except (ValueError, TypeError):
                 pass
 

--- a/tests/test_public_card_service.py
+++ b/tests/test_public_card_service.py
@@ -62,7 +62,7 @@ def test_get_public_card_image_builds_and_caches(monkeypatch):
     monkeypatch.setattr("app.profile.card_service.db", fake_db)
     monkeypatch.setattr("app.profile.card_service.card_cache", fake_cache)
     monkeypatch.setattr("app.profile.card_service.compute_c_score", lambda user_doc: {"c_score": 144, "dsa_done": 1})
-    monkeypatch.setattr("app.profile.card_service.compute_streak", lambda progress: (4, 8))
+    monkeypatch.setattr("app.profile.card_service.compute_streak", lambda progress, **kw: (4, 8))
     monkeypatch.setattr("app.profile.card_service.compute_user_platforms", lambda solved, totals, all_questions: {"LeetCode": 12})
     monkeypatch.setattr("app.profile.card_service.card_generator.generate_progress_card", fake_generate)
 

--- a/tests/test_streaks.py
+++ b/tests/test_streaks.py
@@ -49,3 +49,23 @@ def test_compute_streak_treats_naive_datetimes_as_utc():
     progress = {'a': solved_on(datetime(2026, 5, 20))}
 
     assert compute_streak(progress, today=date(2026, 5, 20)) == (1, 1)
+
+
+def test_compute_streak_filters_zero_invalid_external_counts():
+    progress = {
+        'a': solved_on(datetime(2026, 5, 18, tzinfo=timezone.utc)),
+        'b': solved_on(datetime(2026, 5, 19, tzinfo=timezone.utc)),
+    }
+    external_counts = {
+        "2026-05-20": 3,
+        "2026-05-21": 0,
+        "2026-05-22": -1,
+        "bad-date": 5,
+        "2026-05-23": None,
+    }
+
+    current, longest = compute_streak(
+        progress, today=date(2026, 5, 20), external_daily_counts=external_counts
+    )
+    assert current == 3
+    assert longest == 3


### PR DESCRIPTION
# Description

The streak computation only read from the synced `daily_counts` column. If a user enabled platform sync after having existing local daily activity records, those pre-sync counts were lost — the streak appeared shorter or broken.

Fixes #698

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested in Local

## Checklist
- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [ ] I added or updated tests where useful.

## Screenshots Or Logs
N/A

## Contributor Confirmation

- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

