### PR TITLE
fix: call update_computed_stats after progress import commit (#708)

### DIFF
--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -613,4 +613,9 @@ def import_commit():
     invalidate_leaderboard_cache()
     warm_public_card_cache(user_id, db_handle=db)
 
+    pre = current_app.config.get("_PRECOMPUTED")
+    total_questions = (pre["total_questions"] if pre
+                       else db.question.count_documents({}))
+    update_computed_stats(user_id, new_progress, db, total_questions)
+
     return jsonify({"success": True, "message": "Progress imported successfully!"})

--- a/issue_descriptions/issue-delete-account-cache-stale.md
+++ b/issue_descriptions/issue-delete-account-cache-stale.md
@@ -1,8 +1,8 @@
 # Account deletion and deactivation leave stale data in leaderboard and card caches
 
-**Severity:** High  
-**Type:** Bug — Data Privacy / Cache Staleness  
-**Filed:** No  
+**Severity:** High
+**Type:** Bug — Data Privacy / Cache Staleness
+**Filed:** No
 
 ---
 

--- a/issue_descriptions/issue-delete-account-cache-stale.md
+++ b/issue_descriptions/issue-delete-account-cache-stale.md
@@ -1,0 +1,104 @@
+# Account deletion and deactivation leave stale data in leaderboard and card caches
+
+**Severity:** High  
+**Type:** Bug — Data Privacy / Cache Staleness  
+**Filed:** No  
+
+---
+
+## Description
+
+When a user deletes or deactivates their account (or an admin deletes a user), the user document is removed or flagged from MongoDB, but **no cache invalidation** is performed. The in-memory leaderboard cache (TTL: 300s) continues to serve the deleted/deactivated user's C-Score, total solved, and ranking. The public progress card cache (TTL: 3600s) still stores the user's card image. For irreversible account deletion, this means deleted user data remains publicly accessible for up to **1 hour**.
+
+## Root Cause
+
+**User self-delete** — `app/auth/routes.py:244-246`:
+```python
+user_id = current_user.id
+logout_user()
+db.user.delete_one({"_id": user_id})
+flash("Your account has been permanently deleted.", "info")
+return redirect(url_for("auth.login"))
+```
+No cache invalidation. Compare with `sync_user_platforms` at `sync_service.py:320-321` which correctly calls both:
+```python
+invalidate_leaderboard_cache()
+clear_profile_caches(cache_backend, user_id)
+```
+
+**User deactivation** — `app/auth/routes.py:270-274`:
+```python
+db.user.update_one(
+    {"_id": current_user.id},
+    {"$set": {"is_deactivated": True, "deactivated_at": utc_now()}},
+)
+logout_user()
+```
+No cache invalidation.
+
+**Admin user delete** — `app/admin/routes.py:197-200`:
+```python
+result = db.user.delete_one({"_id": target_id})
+if result.deleted_count != 1:
+    abort(500)
+flash(f"Deleted account for {display_name}.", "success")
+```
+No cache invalidation.
+
+## Impact
+
+| Scenario | Problem | Duration |
+|----------|---------|----------|
+| User deletes account → user's data on leaderboard | Deleted user still ranked | Up to 5 min |
+| User deletes account → user's public card served | Deleted user's progress image served to anyone with the URL | Up to 60 min |
+| User deactivates account → expected immediate hide | User still visible on leaderboard | Up to 5 min |
+| Admin deletes user | Same as self-delete | Up to 5 min |
+
+For **irreversible account deletion**, this is a privacy concern: the user's data should be immediately inaccessible after deletion. The card endpoint at `/u/<user_id>/card.png` does check `find_one` before returning data, but if the card is **warm in cache**, `get_public_card_image` returns the cached bytes directly (line 82-86 of `card_service.py`), avoiding the `find_one` check that happens **after** the cache bypass:
+
+Looking at `app/profile/routes.py:209-218`:
+```python
+user_doc = db.user.find_one({"_id": object_id}, {"is_deactivated": 1})
+...
+if not user_doc or user_doc.get("is_deactivated"):
+    return "User not found", 404
+
+img_io, etag, last_modified = get_public_card_image(user_id, object_id, db_handle=db)
+```
+
+The `find_one` check happens **before** the cache lookup inside `get_public_card_image`. So for fresh requests the deleted user gets 404. However, the cache entry `card_{user_id}` is never invalidated, wasting memory.
+
+The leaderboard cache (`build_leaderboard_data`) stores computed entries as a list. Deleted users remain in this cached list until eviction.
+
+## Suggested Fix
+
+Add cache invalidation to all three deletion/deactivation paths:
+
+**For `auth/routes.py` `delete_account()`:**
+```python
+from app.leaderboard.cache import invalidate_leaderboard_cache
+from app.profile.sync_service import clear_profile_caches
+from app.extensions import cache
+
+user_id = current_user.id
+logout_user()
+db.user.delete_one({"_id": user_id})
+invalidate_leaderboard_cache()
+clear_profile_caches(cache, user_id)
+cache.delete(f"card_{user_id}")
+```
+
+**For `auth/routes.py` `deactivate_account()`:**
+Same invalidation calls.
+
+**For `admin/routes.py` `delete_user()`:**
+Add invalidation calls before or after the `delete_one`.
+
+## Files Involved
+
+- `app/auth/routes.py:244-246` — Self-delete missing cache invalidation
+- `app/auth/routes.py:270-274` — Deactivation missing cache invalidation
+- `app/admin/routes.py:197-200` — Admin delete missing cache invalidation
+- `app/leaderboard/cache.py` — Contains `invalidate_leaderboard_cache()`
+- `app/profile/sync_service.py:39-43` — Contains `clear_profile_caches()`
+- `app/profile/card_service.py:82-86` — Card cache bypass path

--- a/issue_descriptions/issue-import-replace-data-loss.md
+++ b/issue_descriptions/issue-import-replace-data-loss.md
@@ -1,0 +1,92 @@
+# Progress import replace mode silently deletes all unmatched question progress
+
+**Severity:** Critical  
+**Type:** Bug — Data Loss  
+**Filed:** No  
+
+---
+
+## Description
+
+The progress import's "replace" mode (`mode=replace`) in `import_commit()` overwrites the user's entire `progress` document with only the items that were present in the uploaded backup file. Any existing question progress that is not matched by a record in the backup file is **permanently and silently deleted**.
+
+## Root Cause
+
+In `app/tracker/routes.py`, `import_commit()` at line 566-593:
+
+```python
+else:  # replace mode
+    for q_id, imp_val in mapped_progress.items():
+        existing = current_db_progress.get(q_id, {})
+        timestamp = existing.get("timestamp")
+        if imp_val["done"] and not existing.get("done"):
+            timestamp = utc_now()
+        elif not timestamp:
+            timestamp = utc_now()
+
+        new_progress[q_id] = {
+            "done": imp_val["done"],
+            "bookmark": imp_val["bookmark"],
+            "skipped": imp_val["skipped"] if not imp_val["done"] else False,
+            "notes": imp_val["notes"],
+            "timestamp": timestamp
+        }
+```
+
+`mapped_progress` only contains question IDs that **both** existed in the import file **and** were matched to a DB question. All existing progress entries NOT in this set are absent from `new_progress`. Then at line 586-594:
+
+```python
+db.user.update_one(
+    {"_id": user_id},
+    {"$set": {
+        "progress": new_progress,
+        "in_sheet_platform_counts": in_sheet_counts
+    }}
+)
+```
+
+The `$set` replaces the entire `progress` document, dropping every entry not in `new_progress`.
+
+In contrast, "merge" mode (`mode=merge`) at line 536-565 correctly preserves existing entries:
+```python
+new_progress = dict(current_db_progress)  # Start with ALL existing progress
+for q_id, imp_val in mapped_progress.items():
+    existing = new_progress.get(q_id, {})
+    # ... merge each imported entry
+```
+
+## Impact
+
+A user who exports a progress CSV/JSON (containing, say, 20 questions), then re-imports that same file in replace mode will lose progress on every other question they had marked (e.g., the other 430+ questions). The operation is instant and irreversible — there is no undo.
+
+## Steps to Reproduce
+
+1. Mark 50 questions as done on the tracker
+2. Export progress as JSON → this file contains all 50 entries
+3. Delete 40 entries from the exported JSON file
+4. Import the edited file using "Replace (Overwrite)" mode
+5. Observe: only 10 questions remain marked. The other 40 are gone permanently.
+
+## Suggested Fix
+
+The replace mode should preserve entries not present in the import file, similar to merge mode:
+
+```python
+else:  # replace mode
+    new_progress = {}
+    # First, copy over existing entries that are NOT in the import
+    for q_id, existing in current_db_progress.items():
+        if q_id not in mapped_progress:
+            new_progress[q_id] = dict(existing)
+    # Then apply imported changes
+    for q_id, imp_val in mapped_progress.items():
+        ...
+```
+
+Alternatively, the dry-run preview (`import_preview`) should show a count of entries that **would be dropped** by replace mode and reject the import if this count is non-zero unless the user explicitly confirms.
+
+## Files Involved
+
+- `app/tracker/routes.py:566-594` — Replace mode builds `new_progress` from only `mapped_progress`
+- `app/tracker/routes.py:536-565` — Merge mode (correct) for comparison
+- `templates/profile.html:503-516` — UI radio button selects mode, but no warning shown

--- a/issue_descriptions/issue-import-replace-data-loss.md
+++ b/issue_descriptions/issue-import-replace-data-loss.md
@@ -1,8 +1,8 @@
 # Progress import replace mode silently deletes all unmatched question progress
 
-**Severity:** Critical  
-**Type:** Bug — Data Loss  
-**Filed:** No  
+**Severity:** Critical
+**Type:** Bug — Data Loss
+**Filed:** No
 
 ---
 

--- a/issue_descriptions/issue-merged-daily-counts-undercount.md
+++ b/issue_descriptions/issue-merged-daily-counts-undercount.md
@@ -1,0 +1,104 @@
+# `get_merged_daily_counts` undercounts active days after `_legacy` migration completes
+
+**Severity:** High  
+**Type:** Bug — Data Integrity / C-Score Regression  
+**Filed:** No  
+
+---
+
+## Description
+
+`get_merged_daily_counts()` is the authoritative function for computing a user's total daily submission activity. After the per-platform calendar migration completes (signalled by the removal of the `_legacy` key), overlapping dates between per-platform calendars and the original `external_daily_counts` field use the **per-platform value only**, discarding the (potentially higher) legacy cumulative count. This causes C-Score consistency scores to **decrease** for established users immediately after their first full post-migration sync.
+
+## Root Cause
+
+In `app/utils.py:236-268`:
+
+```python
+def get_merged_daily_counts(user_doc):
+    platform_calendars = _get_field(user_doc, "platform_calendars", {})
+    if isinstance(platform_calendars, dict) and platform_calendars:
+        legacy_fallback = {}
+        calendars = {}
+        for key, value in platform_calendars.items():
+            if key == "_legacy" and isinstance(value, dict):
+                legacy_fallback = value          # ← _legacy data captured here
+            else:
+                calendars[key] = value           # ← per-platform calendars
+
+        merged = {}
+        for _platform, counts in calendars.items():       # Sum per-platform counts
+            ...
+            merged[date] = merged.get(date, 0) + count
+
+        for date, count in legacy_fallback.items():        # Merge _legacy with MAX
+            merged[date] = max(merged.get(date, 0), count)
+
+        if merged:
+            has_legacy_fallback = bool(legacy_fallback)
+            legacy = _get_field(user_doc, "external_daily_counts", {})
+            if isinstance(legacy, dict):
+                for date, count in legacy.items():
+                    if coerce_non_negative_number(count) > 0:
+                        if has_legacy_fallback:
+                            merged[date] = max(merged.get(date, 0), count)   # ← MAX when _legacy exists
+                        elif date not in merged:                              # ← SKIP when _legacy absent!
+                            merged[date] = count
+            return merged
+    return _get_field(user_doc, "external_daily_counts", {})
+```
+
+When `_legacy` **exists** (migration in progress), overlapping dates use `max()`. This correctly preserves the higher of the old and new values.
+
+When `_legacy` is **absent** (migration complete, line 310 in `sync_service.py`), `has_legacy_fallback = False`, and the code falls to `elif date not in merged` — overlapping dates in `external_daily_counts` are **silently skipped**.
+
+**The problem:** Per-platform API data is often **less complete** than the cumulative old data:
+
+| Data Source | Coverage |
+|-------------|----------|
+| LeetCode GraphQL `submissionCalendar` | ~90 days of daily breakdown |
+| Old `external_daily_counts` | Entire history (could be years) |
+
+After the first full sync, `_legacy` is removed (because all configured platforms were synced). On the second call to `get_merged_daily_counts`, any date that exists in both the per-platform calendar and the old `external_daily_counts` will use ONLY the per-platform value — which may be lower because the API only returns recent data.
+
+## Impact
+
+- **C-Score consistency component decreases** — C-Score = `min(active_days / 365, 1.0) * 100`. If active days drop from 365 to 90, the consistency score drops from 100 to 24.
+- **Profile "Total Active Days" decreases** — User sees a regression after syncing.
+- **Heatmap shows fewer active days** — Days older than the API window disappear from the visualization.
+- **Long-time users are most affected** — Users with >1 year of history lose the most.
+
+## Sync Flow Interaction
+
+In `app/profile/sync_service.py:308-310`:
+```python
+if user_platforms and requested_platforms and user_platforms.issubset(requested_platforms):
+    platform_calendars.pop("_legacy", None)   # ← removes the safety net
+```
+
+This removal is correct in intent (migration is complete), but the downstream `get_merged_daily_counts` handler then permanently loses the old cumulative data for overlapping dates.
+
+## Suggested Fix
+
+Always use `max()` when merging `external_daily_counts`, regardless of `_legacy` presence:
+
+```python
+# Change lines 263-266 from:
+if has_legacy_fallback:
+    merged[date] = max(merged.get(date, 0), count)
+elif date not in merged:
+    merged[date] = count
+
+# To:
+merged[date] = max(merged.get(date, 0), count)
+```
+
+This ensures the old cumulative `external_daily_counts` data always serves as a **floor** for per-platform data, preventing regressions while still allowing per-platform calendards to contribute new data.
+
+## Files Involved
+
+- `app/utils.py:263-266` — The `elif date not in merged` guard that loses data
+- `app/utils.py:236-268` — Full `get_merged_daily_counts()` function
+- `app/profile/sync_service.py:308-310` — `_legacy` removal after full sync
+- `app/profile/routes.py:387-390` — Profile route consumes merged counts for heatmap
+- `app/utils.py:294-296` — `compute_c_score()` uses merged counts for consistency score

--- a/issue_descriptions/issue-merged-daily-counts-undercount.md
+++ b/issue_descriptions/issue-merged-daily-counts-undercount.md
@@ -1,8 +1,8 @@
 # `get_merged_daily_counts` undercounts active days after `_legacy` migration completes
 
-**Severity:** High  
-**Type:** Bug — Data Integrity / C-Score Regression  
-**Filed:** No  
+**Severity:** High
+**Type:** Bug — Data Integrity / C-Score Regression
+**Filed:** No
 
 ---
 

--- a/issue_descriptions/issue-profile-race-platform-counts.md
+++ b/issue_descriptions/issue-profile-race-platform-counts.md
@@ -1,8 +1,8 @@
 # Race condition between profile page GET and question toggle POST corrupts platform submission counts
 
-**Severity:** High  
-**Type:** Bug — Race Condition / Data Integrity  
-**Filed:** No  
+**Severity:** High
+**Type:** Bug — Race Condition / Data Integrity
+**Filed:** No
 
 ---
 

--- a/issue_descriptions/issue-profile-race-platform-counts.md
+++ b/issue_descriptions/issue-profile-race-platform-counts.md
@@ -1,0 +1,98 @@
+# Race condition between profile page GET and question toggle POST corrupts platform submission counts
+
+**Severity:** High  
+**Type:** Bug — Race Condition / Data Integrity  
+**Filed:** No  
+
+---
+
+## Description
+
+A GET request to `/profile` performs a MongoDB `$set` write on `in_sheet_platform_counts` when the field has not yet been cached on the user document. A concurrent `POST` to `/update_question/<id>` uses `$inc` to adjust the same field. If the `$inc` executes before the `$set`, the increment's effect is **silently overwritten**, causing platform submission counts to diverge from reality.
+
+## Root Cause
+
+**In `app/profile/routes.py` lines 406-408** (profile page GET handler):
+
+```python
+if user.in_sheet_platform_counts:
+    platforms = merge_platform_counts(user.in_sheet_platform_counts, ext_platform_totals)
+else:
+    in_sheet_counts = compute_in_sheet_platform_counts(solved_items, all_questions)
+    db.user.update_one({"_id": user.id}, {"$set": {"in_sheet_platform_counts": in_sheet_counts}})
+    platforms = merge_platform_counts(in_sheet_counts, ext_platform_totals)
+```
+
+The `$set` replaces the **entire** `in_sheet_platform_counts` document.
+
+**In `app/tracker/routes.py` lines 268-279** (question toggle POST handler):
+
+```python
+platform_count_field = f"in_sheet_platform_counts.{platform_from_question_url(question.get('url'))}"
+...
+update_fields[platform_count_field] = 1   # or -1
+...
+# Later converted to $inc:
+inc_fields = {
+    field: update_fields.pop(field)
+    for field in list(update_fields)
+    if field.startswith("in_sheet_platform_counts.")
+}
+...
+db.user.update_one({"_id": user_id}, update_doc)  # Contains $inc
+```
+
+The `$inc` atomically increments/decrements a **single platform key**.
+
+**The Race:**
+
+```
+Time ────────────────────────────────────────────────>
+                                                         Result
+Profile GET:  $set {LeetCode: 5, GFG: 3}                  ← 5, 3 (WRONG!)
+Toggle POST:  $inc {LeetCode: +1}  (writes first,
+               then profile GET $set overwrites)
+```
+
+The `$set` from the profile GET **replaces the entire** `in_sheet_platform_counts` object, destroying the atomically incremented count. The increment is lost with no error or warning.
+
+The reverse order is fine:
+```
+Toggle POST:  $inc {LeetCode: +1}  (writes second, after $set)
+Profile GET:  $set {LeetCode: 5, GFG: 3}                   ← 6, 3 (correct)
+```
+
+## Impact
+
+- Platform counts (`LeetCode`, `GFG`, `Coding Ninjas`, etc.) silently drift wrong
+- The error propagates to `merge_platform_counts()` → `global_total_solved` on the profile page
+- The public progress card uses merged counts → wrong card
+- C-Score uses `compute_total_solved()` which sums platform counts → wrong leaderboard ranking
+- The error is transient and self-corrects on the next profile page load, making it hard to detect
+
+## Trigger Scenarios
+
+High probability in real usage:
+1. User opens their profile page in one tab
+2. User toggles a question as done/undone in another tab
+3. Both requests happen within milliseconds of each other
+
+## Suggested Fix
+
+**Option A (preferred):** Remove the side-effect write from the GET handler entirely. Compute platform counts lazily only when needed and always from scratch using the authoritative `progress` field.
+
+**Option B:** Use `$inc` instead of `$set` in the profile route to avoid overwrites. First read the existing document, compute the delta for each platform, and apply `$inc` for each:
+
+```python
+delta = compute_platform_delta(solved_items, all_questions, user.in_sheet_platform_counts)
+if delta:
+    db.user.update_one({"_id": user.id}, {"$inc": delta})
+```
+
+**Option C:** Move the `$set` into the response rendering phase with an atomic `$setOnInsert`-style guard using a version field.
+
+## Files Involved
+
+- `app/profile/routes.py:406-408` — Profile GET performs destructive `$set`
+- `app/tracker/routes.py:268-279, 303-314` — Question toggle uses `$inc`
+- `app/utils.py:355-374` — `merge_platform_counts()` consumes the corrupted field

--- a/tests/test_progress_import.py
+++ b/tests/test_progress_import.py
@@ -182,6 +182,10 @@ def test_import_commit_route_merge(monkeypatch):
     assert "Existing notes" in progress["notes"]
     assert "Imported notes" in progress["notes"]
     assert user["in_sheet_platform_counts"]["LeetCode"] == 1
+    # Regression: import commit must update computed stats
+    assert user["dsa_progress"] == 100.0
+    assert user["current_streak"] >= 1
+    assert user["longest_streak"] >= 1
 
 
 def test_import_commit_route_replace(monkeypatch):
@@ -240,3 +244,7 @@ def test_import_commit_route_replace(monkeypatch):
     assert untouched_progress["notes"] == "Keep me"
     # Preserve existing done entries, so counts reflect both solved questions.
     assert user["in_sheet_platform_counts"]["LeetCode"] == 2
+    # Regression: import commit must update computed stats
+    assert user["dsa_progress"] == 100.0
+    assert user["current_streak"] >= 1
+    assert user["longest_streak"] >= 1


### PR DESCRIPTION
## Summary
The `import_commit` route writes imported progress and platform counts to the database but never calls `update_computed_stats()`, leaving `dsa_progress`, `current_streak`, and `longest_streak` stale until the user visits their profile or toggles a question.

## Changes Made
- Added call to `update_computed_stats()` at the end of `import_commit()` in `app/tracker/routes.py:616-619`
- Reuses `user_id`, `new_progress`, and `db` already available in scope
- Gets `total_questions` from precomputed config (or DB fallback)

## Related Issue
Closes #708

## Type of Change
- [x] 🐛 Bug fix

## Checklist
- [x] I am a GSSOC'26 contributor
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up-to-date with `main`
- [x] I have tested my changes locally
- [ ] Linting passes (`npm run lint`)
- [ ] All tests pass (`npm test`)
- [x] I have not hardcoded any API keys, secrets, or PII
- [x] I have not merged my own PR
- [x] I have NOT included `package.json` or `package-lock.json` in this PR