### PR TITLE
fix: replace racy \ with atomic recomputation of in_sheet_platform_counts (#709)

### DIFF
--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -302,19 +302,21 @@ def update_question(question_id):
         message = f"📝 Notes saved for '{question.get('problem', 'Question')}'!"
 
     if update_fields:
-        inc_fields = {
-            field: update_fields.pop(field)
-            for field in list(update_fields)
-            if field.startswith("in_sheet_platform_counts.")
-        }
+        for field in list(update_fields):
+            if field.startswith("in_sheet_platform_counts."):
+                del update_fields[field]
         update_doc = {}
         if update_fields:
             update_doc["$set"] = update_fields
-        if inc_fields:
-            update_doc["$inc"] = inc_fields
-        db.user.update_one({"_id": user_id}, update_doc)
+        if update_doc:
+            db.user.update_one({"_id": user_id}, update_doc)
         current_user.reload()
         pre = current_app.config.get("_PRECOMPUTED")
+        all_questions = (pre["all_questions"] if pre
+                         else list(db.question.find({}, {"_id": 1, "url": 1})))
+        solved_items = {q_id: p for q_id, p in current_user.progress.items() if p.get("done")}
+        in_sheet_counts = compute_in_sheet_platform_counts(solved_items, all_questions)
+        db.user.update_one({"_id": user_id}, {"$set": {"in_sheet_platform_counts": in_sheet_counts}})
         total_questions = (pre["total_questions"] if pre
                            else db.question.count_documents({}))
         update_computed_stats(user_id, current_user.progress, db, total_questions)


### PR DESCRIPTION
## Summary
The `update_question` route used MongoDB `$inc` to adjust `in_sheet_platform_counts` based on a stale `existing.done` value read at request start. Under concurrent rapid toggles, increment operations could compound incorrectly, causing the counter to go negative or overshoot with no recovery path.

## Changes Made
- Replaced racy `$inc` with atomic recomputation in `app/tracker/routes.py:304-319`
- Removed `in_sheet_platform_counts.*` entries from `update_fields` before `$set`
- After progress update is committed and user reloaded, recompute counts from scratch using `compute_in_sheet_platform_counts()`
- Uses precomputed `all_questions` when available to avoid extra DB queries

## Related Issue
Closes #709

## Type of Change
- [x] 🐛 Bug fix

## Checklist
- [x] I am a GSSOC'26 contributor
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up-to-date with `main`
- [x] I have tested my changes locally
- [ ] Linting passes (`npm run lint`)
- [ ] All tests pass (`npm test`)
- [x] I have not hardcoded any API keys, secrets, or PII
- [x] I have not merged my own PR
- [x] I have NOT included `package.json` or `package-lock.json` in this PR