### PR TITLE
fix: prevent stored XSS via leetcode_username and github_username (#710)

### DIFF
--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -15,6 +15,7 @@ from app.platforms.fetchers import (
     run_fetch_jobs,
 )
 from app.utils import ensure_utc_datetime, normalize_coding_ninjas_profile_id, utc_now
+from profile_validation import validate_username
 
 logger = logging.getLogger("flask.app")
 
@@ -118,27 +119,30 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
     atcoder_username = user.atcoder_username or ""
     codewars_username = getattr(user, "codewars_username", "") or ""
 
-    if "leetcode" in data:
-        leetcode_username = data.get("leetcode", "").strip()
-        update_fields["leetcode_username"] = leetcode_username
-    if "github" in data:
-        github_username = data.get("github", "").strip()
-        update_fields["github_username"] = github_username
-    if "gfg" in data:
-        gfg_username = data.get("gfg", "").strip()
-        update_fields["gfg_username"] = gfg_username
-    if "hackerrank" in data:
-        hackerrank_username = data.get("hackerrank", "").strip()
-        update_fields["hackerrank_username"] = hackerrank_username
-    if "codingninjas" in data:
-        codingninjas_username = normalize_coding_ninjas_profile_id(data.get("codingninjas", ""))
-        update_fields["codingninjas_username"] = codingninjas_username
-    if "atcoder" in data:
-        atcoder_username = data.get("atcoder", "").strip()
-        update_fields["atcoder_username"] = atcoder_username
-    if "codewars" in data:
-        codewars_username = data.get("codewars", "").strip()
-        update_fields["codewars_username"] = codewars_username
+    try:
+        if "leetcode" in data:
+            leetcode_username = data.get("leetcode", "").strip()
+            update_fields["leetcode_username"] = validate_username(leetcode_username)
+        if "github" in data:
+            github_username = data.get("github", "").strip()
+            update_fields["github_username"] = validate_username(github_username)
+        if "gfg" in data:
+            gfg_username = data.get("gfg", "").strip()
+            update_fields["gfg_username"] = validate_username(gfg_username)
+        if "hackerrank" in data:
+            hackerrank_username = data.get("hackerrank", "").strip()
+            update_fields["hackerrank_username"] = validate_username(hackerrank_username)
+        if "codingninjas" in data:
+            codingninjas_username = normalize_coding_ninjas_profile_id(data.get("codingninjas", ""))
+            update_fields["codingninjas_username"] = validate_username(codingninjas_username)
+        if "atcoder" in data:
+            atcoder_username = data.get("atcoder", "").strip()
+            update_fields["atcoder_username"] = validate_username(atcoder_username)
+        if "codewars" in data:
+            codewars_username = data.get("codewars", "").strip()
+            update_fields["codewars_username"] = validate_username(codewars_username)
+    except ValueError as e:
+        return {"success": False, "error": str(e)}, 400
 
     platform_totals = {}
     platform_status = {}

--- a/profile_validation.py
+++ b/profile_validation.py
@@ -1,6 +1,8 @@
 from urllib.parse import urlparse
 
 
+import re
+
 PROFILE_FIELD_LIMITS = {
     'name': 100,
     'bio': 500,
@@ -53,3 +55,12 @@ def build_profile_updates(data):
 
         update_fields[field] = value
     return update_fields, None
+
+
+def validate_username(username):
+    """Reject usernames containing characters dangerous in JavaScript string contexts."""
+    if not username:
+        return username
+    if re.search(r"['\"\\<>\n\r]|</", username):
+        raise ValueError("Username contains invalid characters")
+    return username

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -591,13 +591,13 @@ window.handleQuickSync = function(btn) {
   const icon = document.getElementById('quickSyncIcon');
   if (btn.disabled) return;
   
-  const lc = {{ user.leetcode_username|tojson }};
-  const gh = {{ user.github_username|tojson }};
-  const gfg = {{ user.gfg_username|tojson }};
-  const hr = {{ user.hackerrank_username|tojson }};
-  const cn = {{ user.codingninjas_username|tojson }};
-  const ac = {{ user.atcoder_username|tojson }};
-  const cw = {{ user.codewars_username|tojson }};
+  const lc = {{ (user.leetcode_username or "")|tojson }};
+  const gh = {{ (user.github_username or "")|tojson }};
+  const gfg = {{ (user.gfg_username or "")|tojson }};
+  const hr = {{ (user.hackerrank_username or "")|tojson }};
+  const cn = {{ (user.codingninjas_username or "")|tojson }};
+  const ac = {{ (user.atcoder_username or "")|tojson }};
+  const cw = {{ (user.codewars_username or "")|tojson }};
   
   if(!lc && !gh && !gfg && !hr && !cn && !ac && !cw){
     showToast('⚠️ No platforms connected to sync!');

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -591,13 +591,13 @@ window.handleQuickSync = function(btn) {
   const icon = document.getElementById('quickSyncIcon');
   if (btn.disabled) return;
   
-  const lc = '{{ user.leetcode_username or "" }}';
-  const gh = '{{ user.github_username or "" }}';
-  const gfg = '{{ user.gfg_username or "" }}';
-  const hr = '{{ user.hackerrank_username or "" }}';
-  const cn = '{{ user.codingninjas_username or "" }}';
-  const ac = '{{ user.atcoder_username or "" }}';
-  const cw = '{{ user.codewars_username or "" }}';
+  const lc = {{ user.leetcode_username|tojson }};
+  const gh = {{ user.github_username|tojson }};
+  const gfg = {{ user.gfg_username|tojson }};
+  const hr = {{ user.hackerrank_username|tojson }};
+  const cn = {{ user.codingninjas_username|tojson }};
+  const ac = {{ user.atcoder_username|tojson }};
+  const cw = {{ user.codewars_username|tojson }};
   
   if(!lc && !gh && !gfg && !hr && !cn && !ac && !cw){
     showToast('⚠️ No platforms connected to sync!');

--- a/tests/test_sync_overlay_steps.py
+++ b/tests/test_sync_overlay_steps.py
@@ -30,7 +30,23 @@ def test_sync_profile_template_wires_platforms_into_sync_requests():
     template = PROFILE_TEMPLATE.read_text(encoding="utf-8")
 
     assert 'id="ac_username"' in template
-    assert "const ac = {{ user.atcoder_username|tojson }};" in template
+    assert "const ac = {{ (user.atcoder_username or \"\")|tojson }};" in template
     assert 'id="cw_username"' in template
-    assert "const cw = {{ user.codewars_username|tojson }};" in template
+    assert "const cw = {{ (user.codewars_username or \"\")|tojson }};" in template
     assert "body:JSON.stringify({leetcode:lc,github:gh,gfg:gfg,hackerrank:hr,codingninjas:cn,atcoder:ac,codewars:cw})" in template
+
+
+def test_quick_sync_coalesces_none_to_empty_string():
+    """Quick-sync variables use (or '') before |tojson so null becomes '', never JS null."""
+    template = PROFILE_TEMPLATE.read_text(encoding="utf-8")
+
+    var_to_field = {
+        "lc": "leetcode_username", "gh": "github_username",
+        "gfg": "gfg_username", "hr": "hackerrank_username",
+        "cn": "codingninjas_username", "ac": "atcoder_username",
+        "cw": "codewars_username",
+    }
+    for var, field in var_to_field.items():
+        assert f"const {var} = {{{{ (user.{field} or \"\")|tojson }}}};" in template, \
+            f"Expected coalesced pattern for {var} ({field}), bare |tojson would emit JS null"
+        assert f"{{{{ user.{field}|tojson }}}};" not in template

--- a/tests/test_sync_overlay_steps.py
+++ b/tests/test_sync_overlay_steps.py
@@ -30,7 +30,7 @@ def test_sync_profile_template_wires_platforms_into_sync_requests():
     template = PROFILE_TEMPLATE.read_text(encoding="utf-8")
 
     assert 'id="ac_username"' in template
-    assert "const ac = '{{ user.atcoder_username or \"\" }}';" in template
+    assert "const ac = {{ user.atcoder_username|tojson }};" in template
     assert 'id="cw_username"' in template
-    assert "const cw = '{{ user.codewars_username or \"\" }}';" in template
+    assert "const cw = {{ user.codewars_username|tojson }};" in template
     assert "body:JSON.stringify({leetcode:lc,github:gh,gfg:gfg,hackerrank:hr,codingninjas:cn,atcoder:ac,codewars:cw})" in template


### PR DESCRIPTION
## Summary
Multiple places in `profile.html` embed user-controlled strings (leetcode_username, github_username, etc.) directly into inline JavaScript using single-quoted Jinja2 expressions. Jinja2 auto-escaping only handles HTML entities, not JS context injection, enabling stored XSS.

## Changes Made
- **Template fix** (`templates/profile.html:594-600`): Replaced `'{{ user.xxx or "" }}'` with `{{ user.xxx|tojson }}`. The `|tojson` filter outputs a valid JS string literal with proper escaping.
- **Server-side validation** (`profile_validation.py`): Added `validate_username()` that rejects characters dangerous in JS contexts (`'`, `\`, `<`, `>`, newlines, `</`).
- **Sync validation** (`app/profile/sync_service.py`): Wrapped all username field assignments with `validate_username()`, returning a 400 error if validation fails.

## Related Issue
Closes #710

## Type of Change
- [x] 🐛 Bug fix

## Checklist
- [x] I am a GSSOC'26 contributor
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up-to-date with `main`
- [x] I have tested my changes locally
- [ ] Linting passes (`npm run lint`)
- [ ] All tests pass (`npm test`)
- [x] I have not hardcoded any API keys, secrets, or PII
- [x] I have not merged my own PR
- [x] I have NOT included `package.json` or `package-lock.json` in this PR