### PR TITLE
fix: hard-fail on insecure SECRET_KEY in production, remove hardcoded OAuth fallbacks

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -133,8 +133,8 @@ def create_app(config_class=None):
 
     oauth.register(
         name="github",
-        client_id=os.environ.get("GITHUB_CLIENT_ID", "your-github-client-id"),
-        client_secret=os.environ.get("GITHUB_CLIENT_SECRET", "your-github-client-secret"),
+        client_id=os.environ.get("GITHUB_CLIENT_ID"),
+        client_secret=os.environ.get("GITHUB_CLIENT_SECRET"),
         access_token_url="https://github.com/login/oauth/access_token",
         access_token_params=None,
         authorize_url="https://github.com/login/oauth/authorize",
@@ -145,8 +145,8 @@ def create_app(config_class=None):
 
     oauth.register(
         name="google",
-        client_id=os.environ.get("GOOGLE_CLIENT_ID", "your-google-client-id"),
-        client_secret=os.environ.get("GOOGLE_CLIENT_SECRET", "your-google-client-secret"),
+        client_id=os.environ.get("GOOGLE_CLIENT_ID"),
+        client_secret=os.environ.get("GOOGLE_CLIENT_SECRET"),
         server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
         client_kwargs={"scope": "openid email profile"},
     )

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,6 @@
 import os
 import secrets
+import sys
 import warnings
 
 
@@ -115,6 +116,16 @@ class TestingConfig(BaseConfig):
 
 class ProductionConfig(BaseConfig):
     SESSION_COOKIE_SECURE = True
+
+    @classmethod
+    def apply_environment_overrides(cls, app):
+        secret_key = os.environ.get("SECRET_KEY", "").strip()
+        if secret_key in cls.INSECURE_SECRET_KEYS:
+            sys.exit(
+                "[FATAL] SECRET_KEY must be set to a secure value in production. "
+                "Run: python -c \"import secrets; print(secrets.token_hex(32))\""
+            )
+        super().apply_environment_overrides(app)
 
 
 CONFIG_BY_ENV = {


### PR DESCRIPTION
… OAuth fallbacks

# Description

- `ProductionConfig.apply_environment_overrides` now calls `sys.exit()` with a clear message if `SECRET_KEY` is missing or matches any known insecure placeholder value, preventing silent session invalidation on restart.
- Removed hardcoded fallback strings (`"your-github-client-id"`, `"your-google-client-id"`, etc.) from `os.environ.get()` calls in `__init__.py`. OAuth is simply disabled (returns `None`) when credentials are not set.
- Dev/test environments retain the existing `warnings.warn` + temp key fallback behaviour (no breaking change).

Fixes #706

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security (non-breaking change which improves security)

# How Has This Been Tested?

- Verified app exits with [FATAL] message when SECRET_KEY is missing or insecure in production mode
- Verified app starts normally when a valid SECRET_KEY is set
- Verified OAuth routes handle None credentials gracefully when env vars are unset

- [x] Tested in Local

## Checklist
- [x] I have starred this repository.
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I added or updated tests where useful.

## Screenshots Or Logs

No UI changes. Tested via terminal — app exits with [FATAL] message when SECRET_KEY is insecure in production mode.


## Contributor Confirmation

- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
