### PR TITLE
fix: validate edit_profile JSON body type before processing (#209)

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -192,9 +192,9 @@ def edit_profile():
       401:
         description: Login required.
     """
-    data = request.get_json()
-    if not data:
-        return json_error("No data", status_code=400)
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"success": False, "error": "Request body must be a JSON object."}), 400
     update_fields, error = build_profile_updates(data)
     if error:
         return json_error(error, status_code=400)

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -1,3 +1,4 @@
+from conftest import build_test_app, csrf_headers, login_test_user
 from profile_validation import build_profile_updates
 
 
@@ -42,3 +43,47 @@ def test_profile_updates_reject_non_text_values():
 
     assert updates is None
     assert error == 'headline must be text'
+
+
+def test_edit_profile_rejects_missing_json_body(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    user_id = test_db.user.insert_one({"email": "user@example.com", "progress": {}}).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.post("/edit_profile", headers=csrf_headers(client))
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "success": False,
+        "error": "Request body must be a JSON object.",
+    }
+
+
+def test_edit_profile_rejects_malformed_json(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    user_id = test_db.user.insert_one({"email": "user@example.com", "progress": {}}).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.post(
+            "/edit_profile",
+            data="{not-json",
+            content_type="application/json",
+            headers=csrf_headers(client),
+        )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "Request body must be a JSON object."
+
+
+def test_edit_profile_rejects_json_array(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    user_id = test_db.user.insert_one({"email": "user@example.com", "progress": {}}).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.post("/edit_profile", json=["name"], headers=csrf_headers(client))
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "Request body must be a JSON object."


### PR DESCRIPTION
## Summary

- Use equest.get_json(silent=True) so malformed JSON returns None instead of Flask's HTML 400 page
- Check isinstance(data, dict) instead of if not data to reject JSON arrays/strings with a proper JSON error response
- Add regression tests for missing body, malformed JSON, and JSON array payloads

Closes #209