### PR TITLE
fix: normalize stored progress timestamps to prevent strftime crash on legacy string timestamps (#212)

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -21,6 +21,7 @@ from app.utils import (
     json_error,
     json_success,
     merge_platform_counts,
+    normalize_timestamp,
     update_computed_stats,
     utc_now,
 )
@@ -416,8 +417,9 @@ def profile():
     for question in all_questions:
         question_id = str(question["_id"])
         if question_id in solved_items:
-            solved_at = solved_items[question_id].get("timestamp") or utc_now()
-            day = solved_at.strftime("%Y-%m-%d")
+            day = normalize_timestamp(solved_items[question_id].get("timestamp"))
+            if day is None:
+                continue
             daily_counts[day] = daily_counts.get(day, 0) + 1
 
     if merged_daily_counts:

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,6 @@
 import re
 from math import isfinite
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 from flask import jsonify
 
@@ -11,6 +11,24 @@ from app.search import service as search_service
 
 def utc_now():
     return datetime.now(timezone.utc)
+
+
+def normalize_timestamp(timestamp):
+    """Convert a progress timestamp to a date string (YYYY-MM-DD).
+
+    Accepts datetime, date, or ISO-format string.  Returns None for
+    unparseable or missing values so callers can skip the entry safely.
+    """
+    if isinstance(timestamp, datetime):
+        return timestamp.strftime("%Y-%m-%d")
+    if isinstance(timestamp, date):
+        return timestamp.isoformat()
+    if isinstance(timestamp, str):
+        try:
+            return date.fromisoformat(timestamp[:10]).isoformat()
+        except (ValueError, TypeError):
+            return None
+    return None
 
 
 def json_response(payload=None, status_code=200, **fields):

--- a/tests/test_compute_c_score.py
+++ b/tests/test_compute_c_score.py
@@ -1,9 +1,12 @@
+from datetime import date, datetime, timezone
+
 from app.utils import (
     compute_c_score,
     compute_in_sheet_platform_counts,
     compute_total_solved,
     compute_user_platforms,
     merge_platform_counts,
+    normalize_timestamp,
 )
 
 
@@ -334,3 +337,33 @@ def test_return_keys_present():
         "cw_total", "active_days", "total_solved",
     }
     assert expected_keys == set(result.keys())
+
+
+def test_normalize_timestamp_from_datetime():
+    ts = datetime(2026, 5, 1, 12, 30, 0, tzinfo=timezone.utc)
+    assert normalize_timestamp(ts) == "2026-05-01"
+
+
+def test_normalize_timestamp_from_date():
+    ts = date(2026, 5, 1)
+    assert normalize_timestamp(ts) == "2026-05-01"
+
+
+def test_normalize_timestamp_from_iso_string():
+    assert normalize_timestamp("2026-05-01") == "2026-05-01"
+
+
+def test_normalize_timestamp_from_iso_string_with_time():
+    assert normalize_timestamp("2026-05-01T12:30:00Z") == "2026-05-01"
+
+
+def test_normalize_timestamp_returns_none_for_none():
+    assert normalize_timestamp(None) is None
+
+
+def test_normalize_timestamp_returns_none_for_invalid_type():
+    assert normalize_timestamp(12345) is None
+
+
+def test_normalize_timestamp_returns_none_for_garbage_string():
+    assert normalize_timestamp("not-a-date") is None


### PR DESCRIPTION
## Summary

- Add 
ormalize_timestamp() helper to pp/utils.py that converts datetime, date, or ISO-format strings to YYYY-MM-DD and returns None for unparseable values
- Use it in the profile route daily-count loop to prevent AttributeError: 'str' object has no attribute 'strftime' on legacy/imported string timestamps
- Add unit tests covering datetime, date, ISO string, ISO string with time, None, int, and garbage string inputs

Closes #212