### PR TITLE
Use synced LeetCode totals in profile difficulty chart

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -462,9 +462,9 @@ def profile():
 
         platforms = merge_platform_counts(effective_counts, ext_platform_totals)
 
-    lc_easy = dsa_easy
-    lc_medium = dsa_medium
-    lc_hard = dsa_hard
+    lc_easy = ext_platform_totals.get("LeetCode_Easy", 0)
+    lc_medium = ext_platform_totals.get("LeetCode_Medium", 0)
+    lc_hard = ext_platform_totals.get("LeetCode_Hard", 0)
 
     lc_contests = ext_platform_totals.get("LeetCode_Contests", 0)
     lc_rating = ext_platform_totals.get("LeetCode_Rating", 0)

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -16,6 +16,7 @@ from app.profile.sync_service import (
     sync_user_platforms,
 )
 from app.utils import (
+    coerce_non_negative_number,
     compute_in_sheet_platform_counts,
     get_merged_daily_counts,
     json_error,
@@ -462,9 +463,9 @@ def profile():
 
         platforms = merge_platform_counts(effective_counts, ext_platform_totals)
 
-    lc_easy = ext_platform_totals.get("LeetCode_Easy", 0)
-    lc_medium = ext_platform_totals.get("LeetCode_Medium", 0)
-    lc_hard = ext_platform_totals.get("LeetCode_Hard", 0)
+    lc_easy = coerce_non_negative_number(ext_platform_totals.get("LeetCode_Easy", 0))
+    lc_medium = coerce_non_negative_number(ext_platform_totals.get("LeetCode_Medium", 0))
+    lc_hard = coerce_non_negative_number(ext_platform_totals.get("LeetCode_Hard", 0))
 
     lc_contests = ext_platform_totals.get("LeetCode_Contests", 0)
     lc_rating = ext_platform_totals.get("LeetCode_Rating", 0)

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -346,10 +346,10 @@
 
     <hr style="border-color:var(--border-color);margin:16px 0">
 
-    <!-- DSA difficulty -->
+    <!-- LeetCode difficulty -->
     <div style="font-size:.8rem;font-weight:700;display:flex;justify-content:space-between;align-items:center;color:var(--text-secondary);margin-bottom:12px">
-      <span style="flex:1;text-align:center;padding-left:24px">DSA</span>
-      <button onclick="exportChart('difficultyChart', 'dsa-difficulty.png')" title="Export Chart as Image" style="background:none;border:none;color:var(--text-muted);cursor:pointer;font-size:1.1rem;transition:color 0.2s;width:24px" onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--text-muted)'" aria-label="Export difficulty chart">
+      <span style="flex:1;text-align:center;padding-left:24px">LeetCode</span>
+      <button onclick="exportChart('difficultyChart', 'leetcode-difficulty.png')" title="Export Chart as Image" style="background:none;border:none;color:var(--text-muted);cursor:pointer;font-size:1.1rem;transition:color 0.2s;width:24px" onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--text-muted)'" aria-label="Export difficulty chart">
         <i class="bi bi-download" aria-hidden="true"></i>
       </button>
     </div>

--- a/tests/test_profile_chart_loading.py
+++ b/tests/test_profile_chart_loading.py
@@ -1,5 +1,11 @@
 from pathlib import Path
 
+from bson import ObjectId
+
+import app.leaderboard.service as leaderboard_service
+import app.profile.routes as profile_routes
+from conftest import build_test_app, login_test_user
+
 
 PROFILE_TEMPLATE = Path("templates/profile.html").read_text(encoding="utf-8")
 
@@ -15,3 +21,87 @@ def test_profile_lazy_loads_charts_on_intersection():
     assert "function loadChartJs()" in PROFILE_TEMPLATE
     assert "new IntersectionObserver" in PROFILE_TEMPLATE
     assert "renderProfileCharts()" in PROFILE_TEMPLATE
+
+
+def test_profile_difficulty_chart_uses_synced_leetcode_totals(monkeypatch):
+    flask_app, test_db = build_test_app(
+        monkeypatch,
+        extra_db_targets=(profile_routes, leaderboard_service),
+    )
+
+    topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id
+    easy_id = test_db.question.insert_one(
+        {
+            "_id": ObjectId(),
+            "topic": topic_id,
+            "problem": "Reverse Array",
+            "difficulty": "Easy",
+        }
+    ).inserted_id
+    medium_id = test_db.question.insert_one(
+        {
+            "_id": ObjectId(),
+            "topic": topic_id,
+            "problem": "Merge Intervals",
+            "difficulty": "Medium",
+        }
+    ).inserted_id
+
+    user_id = test_db.user.insert_one(
+        {
+            "name": "Synced User",
+            "email": "synced@example.com",
+            "progress": {
+                str(easy_id): {"done": True},
+                str(medium_id): {"done": True},
+            },
+            "external_totals": {
+                "LeetCode": 42,
+                "LeetCode_Easy": 11,
+                "LeetCode_Medium": 22,
+                "LeetCode_Hard": 9,
+            },
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.get("/profile")
+
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert "['difficultyChart','difficultyChartShell',['Easy','Medium','Hard'],[11,22,9]" in html
+
+
+def test_profile_difficulty_chart_defaults_unsynced_leetcode_totals_to_zero(monkeypatch):
+    flask_app, test_db = build_test_app(
+        monkeypatch,
+        extra_db_targets=(profile_routes, leaderboard_service),
+    )
+
+    topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id
+    easy_id = test_db.question.insert_one(
+        {
+            "_id": ObjectId(),
+            "topic": topic_id,
+            "problem": "Reverse Array",
+            "difficulty": "Easy",
+        }
+    ).inserted_id
+
+    user_id = test_db.user.insert_one(
+        {
+            "name": "Unsynced User",
+            "email": "unsynced@example.com",
+            "progress": {str(easy_id): {"done": True}},
+            "external_totals": {},
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.get("/profile")
+
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert "['difficultyChart','difficultyChartShell',['Easy','Medium','Hard'],[0,0,0]" in html

--- a/tests/test_profile_chart_loading.py
+++ b/tests/test_profile_chart_loading.py
@@ -105,3 +105,30 @@ def test_profile_difficulty_chart_defaults_unsynced_leetcode_totals_to_zero(monk
     html = response.get_data(as_text=True)
     assert response.status_code == 200
     assert "['difficultyChart','difficultyChartShell',['Easy','Medium','Hard'],[0,0,0]" in html
+
+
+def test_profile_difficulty_chart_coerces_none_and_missing_leetcode_totals_to_zero(monkeypatch):
+    flask_app, test_db = build_test_app(
+        monkeypatch,
+        extra_db_targets=(profile_routes, leaderboard_service),
+    )
+
+    user_id = test_db.user.insert_one(
+        {
+            "name": "Partial Totals User",
+            "email": "partial@example.com",
+            "progress": {},
+            "external_totals": {
+                "LeetCode_Easy": None,
+                "LeetCode_Medium": 2,
+            },
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.get("/profile")
+
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert "['difficultyChart','difficultyChartShell',['Easy','Medium','Hard'],[0,2,0]" in html

--- a/tests/test_profile_chart_loading.py
+++ b/tests/test_profile_chart_loading.py
@@ -1,6 +1,5 @@
+import re
 from pathlib import Path
-
-from bson import ObjectId
 
 import app.leaderboard.service as leaderboard_service
 import app.profile.routes as profile_routes
@@ -8,6 +7,17 @@ from conftest import build_test_app, login_test_user
 
 
 PROFILE_TEMPLATE = Path("templates/profile.html").read_text(encoding="utf-8")
+DIFFICULTY_CHART_PATTERN = re.compile(
+    r"\[\s*'difficultyChart'\s*,\s*'difficultyChartShell'\s*,"
+    r"\s*\[\s*'Easy'\s*,\s*'Medium'\s*,\s*'Hard'\s*\]\s*,"
+    r"\s*\[(?P<values>[^\]]+)\]"
+)
+
+
+def extract_difficulty_chart_values(html):
+    match = DIFFICULTY_CHART_PATTERN.search(html)
+    assert match is not None
+    return [float(value.strip()) for value in match.group("values").split(",")]
 
 
 def test_profile_does_not_eager_load_chartjs_in_head():
@@ -32,7 +42,6 @@ def test_profile_difficulty_chart_uses_synced_leetcode_totals(monkeypatch):
     topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id
     easy_id = test_db.question.insert_one(
         {
-            "_id": ObjectId(),
             "topic": topic_id,
             "problem": "Reverse Array",
             "difficulty": "Easy",
@@ -40,7 +49,6 @@ def test_profile_difficulty_chart_uses_synced_leetcode_totals(monkeypatch):
     ).inserted_id
     medium_id = test_db.question.insert_one(
         {
-            "_id": ObjectId(),
             "topic": topic_id,
             "problem": "Merge Intervals",
             "difficulty": "Medium",
@@ -70,7 +78,7 @@ def test_profile_difficulty_chart_uses_synced_leetcode_totals(monkeypatch):
 
     html = response.get_data(as_text=True)
     assert response.status_code == 200
-    assert "['difficultyChart','difficultyChartShell',['Easy','Medium','Hard'],[11,22,9]" in html
+    assert extract_difficulty_chart_values(html) == [11, 22, 9]
 
 
 def test_profile_difficulty_chart_defaults_unsynced_leetcode_totals_to_zero(monkeypatch):
@@ -82,7 +90,6 @@ def test_profile_difficulty_chart_defaults_unsynced_leetcode_totals_to_zero(monk
     topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id
     easy_id = test_db.question.insert_one(
         {
-            "_id": ObjectId(),
             "topic": topic_id,
             "problem": "Reverse Array",
             "difficulty": "Easy",
@@ -104,7 +111,30 @@ def test_profile_difficulty_chart_defaults_unsynced_leetcode_totals_to_zero(monk
 
     html = response.get_data(as_text=True)
     assert response.status_code == 200
-    assert "['difficultyChart','difficultyChartShell',['Easy','Medium','Hard'],[0,0,0]" in html
+    assert extract_difficulty_chart_values(html) == [0, 0, 0]
+
+
+def test_profile_difficulty_chart_defaults_missing_external_totals_to_zero(monkeypatch):
+    flask_app, test_db = build_test_app(
+        monkeypatch,
+        extra_db_targets=(profile_routes, leaderboard_service),
+    )
+
+    user_id = test_db.user.insert_one(
+        {
+            "name": "Missing Totals User",
+            "email": "missing@example.com",
+            "progress": {},
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.get("/profile")
+
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert extract_difficulty_chart_values(html) == [0, 0, 0]
 
 
 def test_profile_difficulty_chart_coerces_none_and_missing_leetcode_totals_to_zero(monkeypatch):
@@ -131,4 +161,4 @@ def test_profile_difficulty_chart_coerces_none_and_missing_leetcode_totals_to_ze
 
     html = response.get_data(as_text=True)
     assert response.status_code == 200
-    assert "['difficultyChart','difficultyChartShell',['Easy','Medium','Hard'],[0,2,0]" in html
+    assert extract_difficulty_chart_values(html) == [0, 2, 0]


### PR DESCRIPTION
## Summary
- Use synced LeetCode Easy/Medium/Hard totals for the profile difficulty donut instead of local 450 DSA sheet difficulty counts.
- Update the chart label and export filename so the UI matches the LeetCode-backed data source.
- Add regression coverage for synced LeetCode totals and unsynced users defaulting to zero.

## Tests
- `python -m pytest tests/test_profile_chart_loading.py -q`
- `python -m pytest tests/test_profile_rank_card.py tests/test_profile_chart_loading.py -q`
- `python -m pytest -q` (300 passed)

Fixes #202
