### PR TITLE
test: add non-boolean bookmark rejection test for update_question

### DIFF
--- a/tests/test_tracker_routes.py
+++ b/tests/test_tracker_routes.py
@@ -192,6 +192,22 @@ def test_update_question_rejects_non_boolean_skipped(monkeypatch):
     assert response.get_json() == {"success": False, "error": "skipped must be a boolean"}
 
 
+def test_update_question_rejects_non_boolean_bookmark(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
+    question_id = test_db.question.insert_one({"problem": "Two Sum"}).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, test_db)
+        response = client.post(
+            f"/update_question/{question_id}",
+            json={"bookmark": "true"},
+            headers=csrf_headers(client),
+        )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"success": False, "error": "bookmark must be a boolean"}
+
+
 def test_topic_page_accepts_lowercase_difficulty_filter(monkeypatch):
     flask_app, test_db = build_test_app(monkeypatch, extra_db_targets=(tracker_routes,))
     topic_id = test_db.topic.insert_one({"name": "Arrays", "position": 1}).inserted_id


### PR DESCRIPTION
Adds the missing regression test for bookmark field validation in update_question, covering the case the issue (#211) specifically called out alongside done.

The isinstance validation was already in place (commit 9a191d6), but the bookmark test was missing while done and skipped had tests.

Closes #211

## Changes
- \	ests/test_tracker_routes.py\: added \	est_update_question_rejects_non_boolean_bookmark\

## Verification
- Tests pass: 90 passed (1 new)