### PR TITLE
Fix: Use LeetCode difficulty totals from external_totals instead of DSA sheet counts

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -464,9 +464,9 @@ def profile():
 
         platforms = merge_platform_counts(effective_counts, ext_platform_totals)
 
-    lc_easy = dsa_easy
-    lc_medium = dsa_medium
-    lc_hard = dsa_hard
+    lc_easy = ext_platform_totals.get("LeetCode_Easy", 0)
+    lc_medium = ext_platform_totals.get("LeetCode_Medium", 0)
+    lc_hard = ext_platform_totals.get("LeetCode_Hard", 0)
 
     lc_contests = ext_platform_totals.get("LeetCode_Contests", 0)
     lc_rating = ext_platform_totals.get("LeetCode_Rating", 0)


### PR DESCRIPTION
## Summary

The profile difficulty donut chart was displaying local DSA sheet difficulty counts (dsa_easy/dsa_medium/dsa_hard) instead of the user's actual synced LeetCode Easy/Medium/Hard totals.

## Changes

- Changed lc_easy/lc_medium/lc_hard to read from LeetCode_Easy/LeetCode_Medium/LeetCode_Hard keys in external_totals
- Added fallback to 0 for users who have not synced their LeetCode account

## Before

lc_easy = dsa_easy
lc_medium = dsa_medium
lc_hard = dsa_hard

## After

lc_easy = ext_platform_totals.get('LeetCode_Easy', 0)
lc_medium = ext_platform_totals.get('LeetCode_Medium', 0)
lc_hard = ext_platform_totals.get('LeetCode_Hard', 0)

## Validation

- The keys are already populated by sync_platforms() in app/profile/sync_service.py lines 211-213
- Unsynced users will see zeros (graceful fallback)

Closes #202