### PR TITLE
Fix: Docker healthcheck, leaderboard CTA, C-Score, sync validation, and registration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ EXPOSE 5000
 
 # Run the application using Gunicorn for production
 CMD ["gunicorn", "--bind", "0.0.0.0:5000", "run:app"]
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD curl -f http://localhost:5000/health || exit 1
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:5000/health')" || exit 1

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -177,13 +177,16 @@ def register():
         password = request.form.get("password")
         confirm_password = request.form.get("confirm_password")
 
+        if not name:
+            flash("Name is required", "danger")
+            return redirect(url_for("auth.register"))
+        if not email:
+            flash("Email is required", "danger")
+            return redirect(url_for("auth.register"))
+
         password_errors = validate_registration_password(password, confirm_password)
         if password_errors:
             flash(" ".join(password_errors), "danger")
-            return redirect(url_for("auth.register"))
-
-        if not name:
-            flash("Name is required", "danger")
             return redirect(url_for("auth.register"))
 
         existing_user = db.user.find_one({"email": email})

--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -135,22 +135,22 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
 
     try:
         if "leetcode" in data:
-            leetcode_username = data.get("leetcode", "").strip()
+            leetcode_username = str(data.get("leetcode", "") or "").strip()
             update_fields["leetcode_username"] = validate_username(leetcode_username)
         if "github" in data:
-            github_username = data.get("github", "").strip()
+            github_username = str(data.get("github", "") or "").strip()
             update_fields["github_username"] = validate_username(github_username)
         if "gfg" in data:
-            gfg_username = data.get("gfg", "").strip()
+            gfg_username = str(data.get("gfg", "") or "").strip()
             update_fields["gfg_username"] = validate_username(gfg_username)
         if "hackerrank" in data:
-            hackerrank_username = data.get("hackerrank", "").strip()
+            hackerrank_username = str(data.get("hackerrank", "") or "").strip()
             update_fields["hackerrank_username"] = validate_username(hackerrank_username)
         if "codingninjas" in data:
-            codingninjas_username = normalize_coding_ninjas_profile_id(data.get("codingninjas", ""))
+            codingninjas_username = normalize_coding_ninjas_profile_id(str(data.get("codingninjas", "") or ""))
             update_fields["codingninjas_username"] = validate_username(codingninjas_username)
         if "atcoder" in data:
-            atcoder_username = data.get("atcoder", "").strip()
+            atcoder_username = str(data.get("atcoder", "") or "").strip()
             update_fields["atcoder_username"] = validate_username(atcoder_username)
         if "codewars" in data:
             codewars_username = data.get("codewars", "").strip()

--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -153,7 +153,7 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
             atcoder_username = str(data.get("atcoder", "") or "").strip()
             update_fields["atcoder_username"] = validate_username(atcoder_username)
         if "codewars" in data:
-            codewars_username = data.get("codewars", "").strip()
+            codewars_username = str(data.get("codewars", "") or "").strip()
             update_fields["codewars_username"] = validate_username(codewars_username)
     except ValueError as e:
         return {"success": False, "error": str(e)}, 400

--- a/app/utils.py
+++ b/app/utils.py
@@ -326,7 +326,8 @@ def compute_c_score(user_doc, all_questions=None):
             extra_progress_days.add(day_key)
     active_days = valid_external_days + len(extra_progress_days)
 
-    s_dsa = min(dsa_done / 450, 1.0) * 250
+    total_sheet_questions = len(all_questions) if all_questions else 450
+    s_dsa = min(dsa_done / total_sheet_questions, 1.0) * 250
     s_lc_total = min(lc_total / 500, 1.0) * 200
     s_lc_diff = min((lc_easy * 1 + lc_medium * 3 + lc_hard * 6) / 1500, 1.0) * 150
     s_lc_rating = min(lc_rating / 2500, 1.0) * 200

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -172,7 +172,7 @@
       <i class="bi bi-bar-chart-fill" style="color:var(--accent);font-size:1.4rem" aria-hidden="true"></i>
       <span class="rank-num">{{ profile_leaderboard_rank if profile_leaderboard_rank is not none else "—" }}</span>
     </div>
-    <a href="https://codolio.com/leaderboard" target="_blank" rel="noopener noreferrer" class="view-lb-btn ui-btn ui-btn-primary ui-btn-block" aria-label="View global leaderboard (opens in new tab)">View Leaderboard</a>
+    <a href="{{ url_for('leaderboard.leaderboard') }}" class="view-lb-btn ui-btn ui-btn-primary ui-btn-block" aria-label="View app leaderboard">View Leaderboard</a>
     <div class="meta-footer">
       <span><span>Profile Views:</span><span>{{ [dsa_done // 10, 1]|max }}</span></span>
       <span><span>Profile Visibility:</span><span>Public</span></span>

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -14,6 +14,7 @@ class FakeUser:
         self.hackerrank_username = kwargs.get("hackerrank_username", "")
         self.codingninjas_username = kwargs.get("codingninjas_username", "")
         self.atcoder_username = kwargs.get("atcoder_username", "")
+        self.codewars_username = kwargs.get("codewars_username", "")
         self.platform_calendars = kwargs.get("platform_calendars", {})
         self.external_daily_counts = kwargs.get("external_daily_counts", {})
         self.external_totals = kwargs.get("external_totals", {})
@@ -407,3 +408,61 @@ def test_build_sync_platforms_response_all_failed():
     )
     assert result["success"] is False
     assert "all platforms" in result["error"].lower()
+
+
+def test_sync_codewars_handles_non_string_value(monkeypatch):
+    """Codewars username normalization must tolerate null and non-string
+    payload values the same way other platform fields do."""
+    now = datetime.now(timezone.utc)
+    user = FakeUser(codewars_username="old_codewars_user")
+    db = FakeDB()
+    cache = FakeCache()
+
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_codewars",
+        lambda username: {"total": 42},
+    )
+    monkeypatch.setattr("app.profile.sync_service.invalidate_leaderboard_cache", lambda: None)
+
+    # Non-string value — should not raise AttributeError
+    payload, status_code = sync_user_platforms(
+        user,
+        {"codewars": 12345},
+        db,
+        cache,
+        now=now,
+    )
+
+    assert status_code == 200
+    assert payload["platforms"]["codewars"]["status"] == "synced"
+
+    update_doc = db.user.updates[0][1]
+    # The integer 12345 was converted to string "12345" before stripping
+    assert update_doc["$set"]["codewars_username"] == "12345"
+
+
+def test_sync_codewars_handles_null_value(monkeypatch):
+    """A null/None codewars value must be normalized to empty string without
+    raising AttributeError."""
+    now = datetime.now(timezone.utc)
+    user = FakeUser()
+    db = FakeDB()
+    cache = FakeCache()
+
+    monkeypatch.setattr(
+        "app.profile.sync_service.fetch_codewars",
+        lambda username: None,
+    )
+    monkeypatch.setattr("app.profile.sync_service.invalidate_leaderboard_cache", lambda: None)
+
+    payload, status_code = sync_user_platforms(
+        user,
+        {"codewars": None},
+        db,
+        cache,
+        now=now,
+    )
+
+    assert status_code == 200
+    # None results in empty string username → fetch returns None → no data → failed
+    assert payload["platforms"]["codewars"]["status"] == "failed"

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -443,16 +443,13 @@ def test_sync_codewars_handles_non_string_value(monkeypatch):
 
 def test_sync_codewars_handles_null_value(monkeypatch):
     """A null/None codewars value must be normalized to empty string without
-    raising AttributeError."""
+    raising AttributeError. An empty username means no fetch job is created,
+    matching the same skipped behavior as other platforms."""
     now = datetime.now(timezone.utc)
     user = FakeUser()
     db = FakeDB()
     cache = FakeCache()
 
-    monkeypatch.setattr(
-        "app.profile.sync_service.fetch_codewars",
-        lambda username: None,
-    )
     monkeypatch.setattr("app.profile.sync_service.invalidate_leaderboard_cache", lambda: None)
 
     payload, status_code = sync_user_platforms(
@@ -464,5 +461,5 @@ def test_sync_codewars_handles_null_value(monkeypatch):
     )
 
     assert status_code == 200
-    # None results in empty string username → fetch returns None → no data → failed
-    assert payload["platforms"]["codewars"]["status"] == "failed"
+    # None normalizes to empty string → no fetch job enqueued → skipped
+    assert payload["platforms"]["codewars"]["status"] == "skipped"


### PR DESCRIPTION
## Summary

Five small bug fixes for the 450 DSA project:

### #190 - Docker healthcheck
Replaced `curl` with Python's built-in `urllib` in the Dockerfile healthcheck so it works in `python:3.11-slim` (which has no curl).

### #239 - Leaderboard CTA
Changed the profile leaderboard button from linking to an external site (`codolio.com/leaderboard`) to using the app's own leaderboard (`url_for('leaderboard.leaderboard')`).

### #215 - C-Score total questions
Replaced hardcoded `450` with the actual length of the questions list (`len(all_questions)`), with a fallback to 450 when questions are not available.

### #194 - Sync username validation
Wrapped all `.get()` calls on sync username fields with `str()` coercion to prevent crashes when non-string values (e.g. `null`, `123`) are passed via JSON.

### #227 - Registration validation
Added an explicit server-side check that email is not empty before proceeding with account creation.

## Files Changed

- `Dockerfile` — healthcheck uses python urllib
- `templates/profile.html` — leaderboard link uses url_for
- `app/utils.py` — C-Score uses actual question count
- `app/profile/sync_service.py` — username fields coerced to string
- `app/auth/routes.py` — email required check before registration

Closes #190, Closes #239, Closes #215, Closes #194, Closes #227