### PR TITLE
fix: add update_computed_stats to reset_topic_progress

### DIFF
--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -219,6 +219,10 @@ def reset_topic_progress(topic_id):
 
     invalidate_leaderboard_cache()
     warm_public_card_cache(current_user.id, db_handle=db)
+    pre = current_app.config.get("_PRECOMPUTED")
+    total_questions = (pre["total_questions"] if pre
+                       else db.question.count_documents({}))
+    update_computed_stats(current_user.id, current_user.progress, db, total_questions)
     return json_success(message=f"Reset progress for '{topic_doc.get('name', 'this topic')}'")
 
 


### PR DESCRIPTION
## Description

The `reset_topic_progress` route resets a user's progress for a given topic but
did not call `update_computed_stats()`, leaving the cached stats (total solved,
platform counts, streak data) out of sync. Subsequent leaderboard rankings and
profile stats reflected stale data until the next sync.

### Changes

- `app/tracker/routes.py` — Added `update_computed_stats(current_user.id)` call
  after the reset operation, matching the pattern used by other progress-mutating
  routes.

Closes #727