### PR TITLE
fix: add defensive logging for missing platform_calendars in get_merged_daily_counts (#729)

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from math import isfinite
 from datetime import date, datetime, timezone
@@ -7,6 +8,8 @@ from flask import jsonify
 from app.extensions import db
 from app.platforms.metadata import PLATFORM_META
 from app.search import service as search_service
+
+logger = logging.getLogger(__name__)
 
 
 def utc_now():
@@ -284,6 +287,11 @@ def get_merged_daily_counts(user_doc):
         if merged:
             return merged
         return legacy if legacy else {}
+    elif _get_field(user_doc, "external_totals", {}):
+        logger.warning(
+            "User %s has external_totals but no platform_calendars in projection",
+            str(user_doc.get("_id", "")),
+        )
     return _get_field(user_doc, "external_daily_counts", {})
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -290,7 +290,7 @@ def get_merged_daily_counts(user_doc):
     elif _get_field(user_doc, "external_totals", {}):
         logger.warning(
             "User %s has external_totals but no platform_calendars in projection",
-            str(user_doc.get("_id", "")),
+            str(_get_field(user_doc, "_id", "")),
         )
     return _get_field(user_doc, "external_daily_counts", {})
 

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -398,6 +398,17 @@ def test_sync_clears_stale_totals_when_platform_fails_or_username_cleared(monkey
     assert "GitHub_Commits" not in totals
 
 
+def test_get_merged_daily_counts_object_with_external_totals_no_calendars():
+    """Object-style user with external_totals but no platform_calendars
+    must not raise AttributeError on the warning branch."""
+    user = FakeUser(
+        external_totals={"LeetCode": 10},
+        external_daily_counts={"2026-05-25": 3},
+    )
+    merged = get_merged_daily_counts(user)
+    assert merged == {"2026-05-25": 3}
+
+
 def test_build_sync_platforms_response_all_failed():
     result = build_sync_platforms_response(
         {


### PR DESCRIPTION
## Description

The cohort detail page's MongoDB user projection already includes
`external_daily_counts` and `platform_calendars` (verified by audit), but there
was no warning when these fields are accidentally omitted by future projections,
causing `get_merged_daily_counts` to silently return an empty dict and the
consistency component of C-Score to evaluate to zero.

### Changes

- `app/utils.py` — Added `elif` branch in `get_merged_daily_counts` that logs a
  `logger.warning` when `platform_calendars` is absent from a user document that
  has `external_totals`, making future projection bugs visible immediately.

### Audit summary

All MongoDB projections that feed into `compute_c_score` or
`get_merged_daily_counts` were reviewed:

| File | Status |
|------|--------|
| `app/cohort/routes.py:128-145` | ✅ Already includes both fields |
| `app/leaderboard/service.py:9-27` | ✅ Already includes both fields |
| `app/profile/card_service.py:62` | ✅ No projection (full doc) |
| `app/web/routes.py:12` | ✅ No projection (full doc) |
| `app/admin/routes.py:151,213` | 🔒 Not used for C-Score |
| `app/profile/routes.py:221,461` | 🔒 Not used for C-Score |
| `app/auth/routes.py:291,302` | 🔒 Not used for C-Score |

No routes are affected by this bug. The logging is a defensive guard.

Closes #729