### PR TITLE
feat: enable gzip/brotli response compression for text content (#314)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,7 +12,7 @@ from flask import Flask, abort, g, jsonify, request
 from app.admin import admin_bp
 from app.auth import auth_bp
 from app.faq import faq_bp
-from app.extensions import bcrypt, cache, db, limiter, login_manager, mongo, oauth
+from app.extensions import bcrypt, cache, compress, db, limiter, login_manager, mongo, oauth
 from app.leaderboard import leaderboard_bp
 from app.web.routes import public_bp
 from app.profile import profile_bp
@@ -128,6 +128,7 @@ def create_app(config_class=None):
     login_manager.init_app(app)
     oauth.init_app(app)
     limiter.init_app(app)
+    compress.init_app(app)
 
     login_manager.login_view = "auth.login"
 

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -6,6 +6,7 @@ from flask_login import LoginManager
 from flask_pymongo import PyMongo
 from werkzeug.local import LocalProxy
 from flask_caching import Cache
+from flask_compress import Compress
 
 mongo = PyMongo()
 db = LocalProxy(lambda: mongo.db)
@@ -16,6 +17,7 @@ limiter = Limiter(key_func=get_remote_address, default_limits=[], headers_enable
 github = LocalProxy(lambda: oauth.create_client("github"))
 google = LocalProxy(lambda: oauth.create_client("google"))
 cache = Cache()
+compress = Compress()
 
 
 # GSSoC Redis Connection Failure Recovery

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,5 @@ redis==5.0.4
 cachetools==5.3.3
 Flask-Caching==2.0.2
 flasgger==0.9.7.1
+Flask-Compress==1.17
 gunicorn==22.0.0


### PR DESCRIPTION
## Description
Enables gzip/brotli compression for text responses (HTML, JSON, CSS, JS) to reduce bandwidth and improve load times.

## Changes
- Added `Flask-Compress` to `requirements.txt`
- Created `compress` instance in `app/extensions.py`
- Initialized `Compress` in `create_app()` alongside other extensions
- Flask-Compress automatically skips already-compressed resources (images, etc.)

## Testing
- Run `pip install Flask-Compress` and start the app
- Check response headers include `Content-Encoding: gzip` (or `br` if brotli supported)
- Verify images and other binary content are not double-compressed

Closes #314
