### PR TITLE
fix: sanitize text search query to prevent MongoDB text errors

### DIFF
--- a/app/search/service.py
+++ b/app/search/service.py
@@ -129,11 +129,20 @@ DIFFICULTY_FILTERS = {
 }
 
 
+def _sanitize_text_search(query):
+    """Remove characters that can cause MongoDB $text search errors."""
+    if not query:
+        return query
+    sanitized = re.sub(r"[^\w\s\"@+\-]", " ", query)
+    return re.sub(r"\s+", " ", sanitized).strip()
+
+
 def search_dsa_questions(raw_query, limit=40, db_handle=None, filters=None, progress=None):
     db_handle = db_handle or db
     filters = filters or {}
     progress = progress or {}
     query, requested_platforms = parse_search_query(raw_query)
+    query = _sanitize_text_search(query)
     query_tokens = tokenize_search_text(query)
     topic_id_str = filters.get("topic_id", "")
     difficulty_filter = filters.get("difficulty", "")


### PR DESCRIPTION
## Summary

Adds query sanitization to prevent MongoDB text search parse errors when users type special characters like (array, *sort, or [graph].

## Changes

- Added _sanitize_text_search() in search/service.py that strips characters unsafe for MongoDB text search while preserving valid operators like quoted phrases, -exclude, +require
- Applied sanitization to user query before passing to 

Closes #686