### PR TITLE
feat: add revision queue for due and bookmarked questions (#265)

### DIFF
--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from bson import ObjectId
 from bson.errors import InvalidId
 from flask import Blueprint, Response, current_app, jsonify, render_template, request
@@ -306,6 +308,7 @@ def update_question(question_id):
     if "done" in data:
         if data["done"] and not existing.get("done"):
             update_fields[f"progress.{question_id}.timestamp"] = utc_now()
+            update_fields[f"progress.{question_id}.next_review"] = utc_now() + timedelta(days=1)
             message = f"✅ Marked '{question.get('problem', 'Question')}' as complete!"
             update_fields[f"progress.{question_id}.skipped"] = False
             update_fields[platform_count_field] = 1
@@ -382,6 +385,53 @@ def bookmarks():
         question["topic_name"] = topic_docs.get(question["topic"], "Unknown")
 
     return render_template("bookmarks.html", questions=questions, progress_dict=progress)
+
+
+@tracker_bp.route("/revision")
+@login_required
+def revision():
+    progress = current_user.progress
+    now = utc_now()
+
+    bookmarked_ids = []
+    skipped_ids = []
+    due_ids = []
+
+    for q_id, p_item in progress.items():
+        if p_item.get("bookmark"):
+            bookmarked_ids.append(q_id)
+        if p_item.get("skipped"):
+            skipped_ids.append(q_id)
+        if p_item.get("done") and p_item.get("next_review") and p_item["next_review"] <= now:
+            due_ids.append(q_id)
+
+    def _fetch_question_docs(id_list):
+        oids = []
+        for q_id in id_list:
+            try:
+                oids.append(ObjectId(q_id))
+            except InvalidId:
+                pass
+        return list(db.question.find({"_id": {"$in": oids}}, BOOKMARKS_QUESTION_PROJECTION))
+
+    bookmarked_qs = _fetch_question_docs(bookmarked_ids)
+    skipped_qs = _fetch_question_docs(skipped_ids)
+    due_qs = _fetch_question_docs(due_ids)
+
+    all_questions = bookmarked_qs + skipped_qs + due_qs
+    topic_ids = list(set(q["topic"] for q in all_questions))
+    topic_docs = {t["_id"]: t["name"] for t in db.topic.find({"_id": {"$in": topic_ids}})}
+    for q_list in (bookmarked_qs, skipped_qs, due_qs):
+        for q in q_list:
+            q["topic_name"] = topic_docs.get(q["topic"], "Unknown")
+
+    return render_template(
+        "revision.html",
+        bookmarked_qs=bookmarked_qs,
+        skipped_qs=skipped_qs,
+        due_qs=due_qs,
+        progress_dict=progress,
+    )
 
 
 @tracker_bp.route("/export/csv")

--- a/templates/base.html
+++ b/templates/base.html
@@ -82,6 +82,10 @@
                 <i class="bi bi-bookmark-fill" aria-hidden="true"></i>
                 <span class="tooltip-label">Bookmarks</span>
             </a>
+            <a href="{{ url_for('tracker.revision') }}" class="sidebar-link {% if request.endpoint == 'tracker.revision' %}active{% endif %}" id="nav-revision" aria-label="Revision Queue">
+                <i class="bi bi-arrow-repeat" aria-hidden="true"></i>
+                <span class="tooltip-label">Revision</span>
+            </a>
             <a href="{{ url_for('cohort.index') }}" class="sidebar-link {% if request.endpoint == 'cohort.index' or request.endpoint.startswith('cohort.') %}active{% endif %}" id="nav-cohorts" aria-label="Cohorts">
                 <i class="bi bi-people-fill" aria-hidden="true"></i>
                 <span class="tooltip-label">Cohorts</span>

--- a/templates/revision.html
+++ b/templates/revision.html
@@ -1,0 +1,256 @@
+{% extends "base.html" %}
+{% from "macros/modals.html" import notes_modal, code_modal %}
+{% block content %}
+<style>
+  .page-title { font-size: 1.6rem; font-weight: 800; margin-bottom: 6px; }
+  .page-sub { color: var(--text-secondary); font-size: .88rem; margin-bottom: 24px; }
+  .empty-state { background: var(--bg-card); border: 1px solid var(--border-color); border-radius: 14px; padding: 60px 24px; text-align: center; }
+  .empty-state i { font-size: 3rem; color: var(--text-muted); margin-bottom: 16px; display: block; }
+  .empty-state p { color: var(--text-secondary); margin-bottom: 20px; }
+  .empty-state a { display: inline-flex; align-items: center; gap: 6px; padding: 10px 20px; background: var(--accent); border-radius: 10px; color: #fff; text-decoration: none; font-weight: 700; font-size: .88rem; }
+  .empty-state a:hover { background: var(--accent-hover); color: #fff; }
+  .topic-tag { display: inline-flex; align-items: center; padding: 2px 10px; background: rgba(99, 102, 241, .12); border: 1px solid rgba(99, 102, 241, .2); color: #818cf8; border-radius: 20px; font-size: .73rem; font-weight: 700; text-decoration: none; }
+  .revision-section { margin-bottom: 32px; }
+  .section-header { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
+  .section-header h3 { font-size: 1.1rem; font-weight: 700; margin: 0; color: var(--text-primary); }
+  .section-header h3 i { margin-right: 6px; }
+  .section-header .count-badge { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 20px; padding: 2px 12px; font-size: .78rem; font-weight: 600; color: var(--text-secondary); }
+</style>
+
+<a href="{{ url_for('tracker.index') }}" class="back-btn"><i class="bi bi-arrow-left"></i> Back to Topics</a>
+<div class="page-title">Revision Queue</div>
+<div class="page-sub">Review questions that need your attention</div>
+
+{% set total = due_qs|length + bookmarked_qs|length + skipped_qs|length %}
+
+{% if total > 0 %}
+
+{% if due_qs %}
+<div class="revision-section">
+  <div class="section-header">
+    <h3><i class="bi bi-clock" style="color: var(--accent)"></i> Due for Review</h3>
+    <span class="count-badge">{{ due_qs|length }}</span>
+  </div>
+  <div class="questions-table-wrap">
+    <table class="q-table">
+      <thead>
+        <tr>
+          <th scope="col">#</th>
+          <th scope="col">Topic</th>
+          <th scope="col">Problem</th>
+          <th scope="col">Difficulty</th>
+          <th scope="col">Status</th>
+          <th scope="col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for q in due_qs %}
+        {% set q_id_str = q._id | string %}
+        {% set p = progress_dict.get(q_id_str) %}
+        {% set difficulty = q.get('difficulty', 'Medium') %}
+        <tr>
+          <td class="q-num">{{ loop.index }}</td>
+          <td><span class="topic-tag">{{ q.topic_name }}</span></td>
+          <td>
+            <div class="q-name">{{ q.problem }}</div>
+            <div class="q-links">
+              {% if q.url %}<a href="{{ q.url }}" target="_blank" rel="noopener noreferrer" class="q-badge {% if 'leetcode' in q.url %}badge-lc{% elif 'geeksforgeeks' in q.url %}badge-gfg{% else %}badge-link{% endif %}"><i class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{ q.url|platform_name }}</a>{% endif %}
+              {% if q.url2 %}<a href="{{ q.url2 }}" target="_blank" rel="noopener noreferrer" class="q-badge badge-link"><i class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{ q.url2|platform_name }}</a>{% endif %}
+            </div>
+          </td>
+          <td><span class="difficulty-badge difficulty-{{ difficulty|lower }}">{{ difficulty }}</span></td>
+          <td><span class="status-indicator" title="Due for review"><i class="bi bi-clock" style="color: var(--accent)"></i></span></td>
+          <td>
+            <button class="notes-btn-sm {% if p and p.notes %}has-notes{% endif %} notes-btn" data-id="{{ q_id_str }}"
+              data-notes="{{ p.notes if p and p.notes else '' }}"
+              aria-label="{% if p and p.notes %}Edit notes for {{ q.problem }}{% else %}Add notes for {{ q.problem }}{% endif %}">
+              <i class="bi bi-journal-text" aria-hidden="true"></i> {% if p and p.notes %}Edit{% else %}Add{% endif %}
+            </button>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endif %}
+
+{% if bookmarked_qs %}
+<div class="revision-section">
+  <div class="section-header">
+    <h3><i class="bi bi-bookmark-fill" style="color: var(--warning)"></i> Bookmarked</h3>
+    <span class="count-badge">{{ bookmarked_qs|length }}</span>
+  </div>
+  <div class="questions-table-wrap">
+    <table class="q-table">
+      <thead>
+        <tr>
+          <th scope="col">#</th>
+          <th scope="col">Topic</th>
+          <th scope="col">Problem</th>
+          <th scope="col">Difficulty</th>
+          <th scope="col">Status</th>
+          <th scope="col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for q in bookmarked_qs %}
+        {% set q_id_str = q._id | string %}
+        {% set p = progress_dict.get(q_id_str) %}
+        {% set difficulty = q.get('difficulty', 'Medium') %}
+        <tr>
+          <td class="q-num">{{ loop.index }}</td>
+          <td><span class="topic-tag">{{ q.topic_name }}</span></td>
+          <td>
+            <div class="q-name">{{ q.problem }}</div>
+            <div class="q-links">
+              {% if q.url %}<a href="{{ q.url }}" target="_blank" rel="noopener noreferrer" class="q-badge {% if 'leetcode' in q.url %}badge-lc{% elif 'geeksforgeeks' in q.url %}badge-gfg{% else %}badge-link{% endif %}"><i class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{ q.url|platform_name }}</a>{% endif %}
+              {% if q.url2 %}<a href="{{ q.url2 }}" target="_blank" rel="noopener noreferrer" class="q-badge badge-link"><i class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{ q.url2|platform_name }}</a>{% endif %}
+            </div>
+          </td>
+          <td><span class="difficulty-badge difficulty-{{ difficulty|lower }}">{{ difficulty }}</span></td>
+          <td><span class="status-indicator" title="Bookmarked"><i class="bi bi-bookmark-fill" style="color: var(--warning)"></i></span></td>
+          <td>
+            <button class="notes-btn-sm {% if p and p.notes %}has-notes{% endif %} notes-btn" data-id="{{ q_id_str }}"
+              data-notes="{{ p.notes if p and p.notes else '' }}"
+              aria-label="{% if p and p.notes %}Edit notes for {{ q.problem }}{% else %}Add notes for {{ q.problem }}{% endif %}">
+              <i class="bi bi-journal-text" aria-hidden="true"></i> {% if p and p.notes %}Edit{% else %}Add{% endif %}
+            </button>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endif %}
+
+{% if skipped_qs %}
+<div class="revision-section">
+  <div class="section-header">
+    <h3><i class="bi bi-skip-forward-fill" style="color: var(--warning)"></i> Skipped</h3>
+    <span class="count-badge">{{ skipped_qs|length }}</span>
+  </div>
+  <div class="questions-table-wrap">
+    <table class="q-table">
+      <thead>
+        <tr>
+          <th scope="col">#</th>
+          <th scope="col">Topic</th>
+          <th scope="col">Problem</th>
+          <th scope="col">Difficulty</th>
+          <th scope="col">Status</th>
+          <th scope="col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for q in skipped_qs %}
+        {% set q_id_str = q._id | string %}
+        {% set p = progress_dict.get(q_id_str) %}
+        {% set difficulty = q.get('difficulty', 'Medium') %}
+        <tr>
+          <td class="q-num">{{ loop.index }}</td>
+          <td><span class="topic-tag">{{ q.topic_name }}</span></td>
+          <td>
+            <div class="q-name">{{ q.problem }}</div>
+            <div class="q-links">
+              {% if q.url %}<a href="{{ q.url }}" target="_blank" rel="noopener noreferrer" class="q-badge {% if 'leetcode' in q.url %}badge-lc{% elif 'geeksforgeeks' in q.url %}badge-gfg{% else %}badge-link{% endif %}"><i class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{ q.url|platform_name }}</a>{% endif %}
+              {% if q.url2 %}<a href="{{ q.url2 }}" target="_blank" rel="noopener noreferrer" class="q-badge badge-link"><i class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{ q.url2|platform_name }}</a>{% endif %}
+            </div>
+          </td>
+          <td><span class="difficulty-badge difficulty-{{ difficulty|lower }}">{{ difficulty }}</span></td>
+          <td><span class="status-indicator" title="Skipped"><i class="bi bi-skip-forward-fill" style="color: var(--warning)"></i></span></td>
+          <td>
+            <button class="notes-btn-sm {% if p and p.notes %}has-notes{% endif %} notes-btn" data-id="{{ q_id_str }}"
+              data-notes="{{ p.notes if p and p.notes else '' }}"
+              aria-label="{% if p and p.notes %}Edit notes for {{ q.problem }}{% else %}Add notes for {{ q.problem }}{% endif %}">
+              <i class="bi bi-journal-text" aria-hidden="true"></i> {% if p and p.notes %}Edit{% else %}Add{% endif %}
+            </button>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endif %}
+
+{% else %}
+<div class="empty-state">
+  <i class="bi bi-arrow-repeat"></i>
+  <p>Nothing needs your attention right now.<br>Mark questions as done, bookmark them, or skip them to build your revision queue.</p>
+  <a href="{{ url_for('tracker.index') }}"><i class="bi bi-arrow-right-circle"></i> Browse Topics</a>
+</div>
+{% endif %}
+
+{{ notes_modal(textarea_label='Notes') }}
+{{ code_modal() }}
+{% endblock %}
+
+{% block scripts %}
+<script>
+  const endpointConfig = {{ {
+    "updateQuestionBase": url_for('tracker.update_question', question_id='__QUESTION_ID__'),
+  }|tojson }};
+  const csrfToken = {{ csrf_token()|tojson }};
+  const FOCUSABLE = 'button, [href], input, textarea, select, [tabindex]:not([tabindex="-1"])';
+  const modal = document.getElementById('notesModal');
+
+  function openModal(triggerEl) {
+    modal.classList.add('open');
+    modal._trigger = triggerEl;
+    const focusable = modal.querySelectorAll(FOCUSABLE);
+    if (focusable.length) focusable[0].focus();
+    modal.addEventListener('keydown', trapFocus);
+  }
+
+  function closeModal() {
+    modal.classList.remove('open');
+    modal.removeEventListener('keydown', trapFocus);
+    if (modal._trigger) modal._trigger.focus();
+  }
+
+  function trapFocus(e) {
+    const focusable = Array.from(modal.querySelectorAll(FOCUSABLE));
+    const first = focusable[0], last = focusable[focusable.length - 1];
+    if (e.key === 'Tab') {
+      if (e.shiftKey) { if (document.activeElement === first) { e.preventDefault(); last.focus(); } }
+      else { if (document.activeElement === last) { e.preventDefault(); first.focus(); } }
+    }
+    if (e.key === 'Escape') closeModal();
+  }
+
+  function updateQuestion(id, data, callback) {
+    fetch(endpointConfig.updateQuestionBase.replace('__QUESTION_ID__', encodeURIComponent(id)), { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken }, body: JSON.stringify(data) })
+      .then(r => r.json()).then(res => { if (res.success) { if (callback) callback(); } })
+      .catch(() => alert('Error updating.'));
+  }
+
+  document.querySelectorAll('.notes-btn').forEach(btn => {
+    btn.addEventListener('click', function () {
+      document.getElementById('currentQuestionId').value = this.dataset.id;
+      document.getElementById('notesTextarea').value = this.dataset.notes || '';
+      openModal(this);
+    });
+  });
+
+  document.getElementById('modalCancel').addEventListener('click', closeModal);
+  modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
+
+  document.getElementById('saveNotesBtn').addEventListener('click', function () {
+    const qId = document.getElementById('currentQuestionId').value;
+    const notes = document.getElementById('notesTextarea').value;
+    updateQuestion(qId, { notes: notes }, () => {
+      closeModal();
+      const btn = document.querySelector(`.notes-btn[data-id="${qId}"]`);
+      if (btn) {
+        btn.dataset.notes = notes;
+        btn.classList.toggle('has-notes', notes.trim() !== '');
+        const label = notes.trim() ? 'Edit' : 'Add';
+        btn.innerHTML = `<i class="bi bi-journal-text" aria-hidden="true"></i> ${label}`;
+        btn.setAttribute('aria-label', `${label} notes for this question`);
+      }
+    });
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Related Issue

Closes #265

## Description

Adds a revision queue page that lists bookmarked, skipped, and overdue questions sorted by review priority.

### Changes Made

* New \GET /revision\ route that filters user progress for:
  * **Due for Review** — questions marked done >24h ago (uses new \
ext_review\ timestamp)
  * **Bookmarked** — questions the user has bookmarked
  * **Skipped** — questions the user has skipped
* New \	emplates/revision.html\ with three sections, notes modal integration, and empty state
* Navigation link in sidebar for authenticated users
* \
ext_review\ field set on question progress when marked as done (24h from completion)

### Implementation Notes

Reuses existing \BOOKMARKS_QUESTION_PROJECTION\ and progress data. Adds \
ext_review\ timestamp (not \last_reviewed_at\) to mark questions as due for review.