### PR TITLE
fix: regenerate session after login to prevent session fixation (#682)

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -26,6 +26,10 @@ COMMON_WEAK_PASSWORDS = {
 }
 
 
+def _regenerate_session():
+    session.regenerate()
+
+
 def resolve_oauth_user(provider_field, provider_id, name, email=None):
     """Find, link, or create an OAuth-backed user record.
 
@@ -160,6 +164,7 @@ def login():
         if user_doc and user_doc.get("password") and password and bcrypt.check_password_hash(user_doc["password"], password):
             user_doc = reactivate_user_if_needed(user_doc)
             login_user(UserWrapper(user_doc))
+            _regenerate_session()
             flash(f"Welcome back, {user_doc.get('name', 'User')}! 👋", "success")
             return redirect(url_for("tracker.index"))
         flash("Login unsuccessful. Please check email and password.", "danger")
@@ -364,6 +369,7 @@ def authorize_github():
 
     user_doc = reactivate_user_if_needed(user_doc)
     login_user(UserWrapper(user_doc))
+    _regenerate_session()
     return redirect(url_for("tracker.index"))
 
 
@@ -422,6 +428,7 @@ def authorize_google():
 
     user_doc = reactivate_user_if_needed(user_doc)
     login_user(UserWrapper(user_doc))
+    _regenerate_session()
     return redirect(url_for("tracker.index"))
 
 


### PR DESCRIPTION
## Related Issue

Closes #682

## Description

Adds session fixation prevention via \session.regenerate()\ after every \login_user()\ call across all three authentication paths (email/password, GitHub OAuth, Google OAuth).

### Background

The codebase already follows OAuth token security best practices:
- **No OAuth tokens stored in localStorage** — all token exchange happens server-side via Authlib and tokens are never persisted to the browser
- **HttpOnly session cookies** already enforced via config
- **SameSite=Lax** already enforced via config

### Changes Made

- Added \_regenerate_session()\ helper that calls \session.regenerate()\
- Called after \login_user()\ in all three login success paths (email/password login, GitHub authorize, Google authorize)

This ensures a new session identifier is issued after authentication, preventing session fixation attacks where an attacker could force a known session ID on a victim.