### PR TITLE
feat: add public college profile pages (#290)

### DIFF
--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -1,10 +1,17 @@
+import re
+
 from flask import Blueprint, render_template, current_app
 from bson import ObjectId
 from bson.errors import InvalidId
 from app.extensions import db
+from app.leaderboard.service import build_leaderboard_data
 from app.utils import compute_c_score
 
 public_bp = Blueprint("public", __name__)
+
+
+def _college_slug(name):
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
 
 @public_bp.route("/u/<user_id>")
 def public_profile(user_id):
@@ -32,4 +39,49 @@ def public_profile(user_id):
         "public_profile.html",
         user=public_user_data,
         stats=stats
+    )
+
+
+@public_bp.route("/college/<slug>")
+def college_detail(slug):
+    entries = build_leaderboard_data()
+
+    slug_to_college = {}
+    for entry in entries:
+        college = (entry.get("college") or "").strip()
+        if college:
+            slug_to_college[_college_slug(college)] = college
+
+    college_name = slug_to_college.get(slug)
+    if not college_name:
+        return "College not found", 404
+
+    members = [e for e in entries if (e.get("college") or "").strip().lower() == college_name.lower()]
+    member_count = len(members)
+    total_solved = sum(e.get("total_solved", 0) for e in members)
+    c_score_sum = sum(e.get("c_score", 0) for e in members)
+    dsa_done = sum(e.get("dsa_done", 0) for e in members)
+    lc_total = sum(e.get("lc_total", 0) for e in members)
+    gfg_total = sum(e.get("gfg_total", 0) for e in members)
+    cn_total = sum(e.get("cn_total", 0) for e in members)
+    hr_total = sum(e.get("hr_total", 0) for e in members)
+
+    rated_members = [e for e in members if e.get("lc_rating", 0)]
+    avg_rating = round(sum(e.get("lc_rating", 0) for e in rated_members) / len(rated_members)) if rated_members else 0
+
+    members_sorted = sorted(members, key=lambda e: e.get("c_score", 0), reverse=True)
+
+    return render_template(
+        "college_detail.html",
+        college=college_name,
+        member_count=member_count,
+        total_solved=total_solved,
+        avg_c_score=round(c_score_sum / member_count) if member_count else 0,
+        avg_rating=avg_rating,
+        dsa_done=dsa_done,
+        lc_total=lc_total,
+        gfg_total=gfg_total,
+        cn_total=cn_total,
+        hr_total=hr_total,
+        members=members_sorted,
     )

--- a/templates/college_detail.html
+++ b/templates/college_detail.html
@@ -1,0 +1,123 @@
+{% extends "base.html" %}
+{% block head %}
+<meta property="og:title" content="{{ college }} | 450 DSA Tracker" />
+<meta property="og:description" content="{{ college }} has {{ member_count }} members, {{ total_solved }} total problems solved, average C-Score of {{ avg_c_score }}." />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="{{ request.url }}" />
+<title>{{ college }} | 450 DSA</title>
+{% endblock %}
+
+{% block content %}
+<style>
+.cp-header { margin-bottom: 24px; }
+.cp-header h1 { font-size: 1.6rem; font-weight: 800; color: var(--text-primary); display: flex; align-items: center; gap: 10px; }
+.cp-header p { color: var(--text-secondary); font-size: 0.88rem; margin-top: 4px; }
+.cp-back { display: inline-flex; align-items: center; gap: 6px; color: var(--accent); text-decoration: none; font-size: 0.85rem; font-weight: 600; margin-bottom: 8px; }
+.cp-back:hover { text-decoration: underline; }
+.stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; margin-bottom: 24px; }
+.stat-card { background: var(--bg-card); border: 1px solid var(--border-color); border-radius: 14px; padding: 18px; text-align: center; }
+.stat-card .num { font-size: 2rem; font-weight: 900; line-height: 1.2; color: var(--text-primary); }
+.stat-card .lbl { font-size: 0.75rem; color: var(--text-secondary); font-weight: 600; margin-top: 4px; text-transform: uppercase; letter-spacing: 0.03em; }
+.member-table-wrap { overflow-x: auto; }
+.member-table { width: 100%; border-collapse: collapse; font-size: 0.88rem; }
+.member-table thead th { text-align: left; padding: 10px 12px; font-size: 0.73rem; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; border-bottom: 1px solid var(--border-color); white-space: nowrap; }
+.member-table tbody td { padding: 10px 12px; border-bottom: 1px solid var(--border-color); vertical-align: middle; }
+.member-table tbody tr:hover { background: var(--bg-secondary); }
+.rank-badge { display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 50%; font-size: 0.78rem; font-weight: 700; background: var(--bg-secondary); color: var(--text-secondary); }
+.rank-1 { background: linear-gradient(135deg, #ffd700, #ffb300); color: #000; }
+.rank-2 { background: linear-gradient(135deg, #e0e0e0, #bdbdbd); color: #000; }
+.rank-3 { background: linear-gradient(135deg, #cd7f32, #b8712e); color: #fff; }
+.user-info { display: flex; align-items: center; gap: 10px; }
+.user-avatar { width: 32px; height: 32px; border-radius: 50%; object-fit: cover; background: var(--bg-secondary); display: flex; align-items: center; justify-content: center; font-size: 0.85rem; font-weight: 700; color: var(--text-secondary); overflow: hidden; }
+.user-avatar img { width: 100%; height: 100%; }
+.user-name { font-weight: 600; color: var(--accent); text-decoration: none; }
+.user-name:hover { text-decoration: underline; }
+.plat-badge { display: inline-block; padding: 2px 8px; border-radius: 6px; font-size: 0.72rem; font-weight: 700; margin-right: 4px; }
+.plat-lc { background: rgba(255, 184, 0, 0.15); color: #ffb800; }
+.plat-gfg { background: rgba(47, 180, 103, 0.15); color: #2fb467; }
+.plat-cn { background: rgba(99, 102, 241, 0.15); color: #818cf8; }
+.plat-hr { background: rgba(0, 188, 108, 0.15); color: #00bc6c; }
+.section-title { font-size: 1rem; font-weight: 700; color: var(--text-primary); margin: 24px 0 12px; display: flex; align-items: center; gap: 8px; }
+.loading { text-align: center; padding: 40px; color: var(--text-secondary); font-size: 0.88rem; }
+</style>
+
+<a href="{{ url_for('leaderboard.leaderboard') }}" class="cp-back"><i class="bi bi-arrow-left"></i> Back to Leaderboard</a>
+<div class="cp-header">
+  <h1><i class="bi bi-mortarboard-fill" style="color: var(--accent)"></i> {{ college }}</h1>
+  <p>{{ member_count }} member{{ 's' if member_count != 1 else '' }} &middot; Ranked on the DSA leaderboard</p>
+</div>
+
+<div class="stat-grid">
+  <div class="stat-card">
+    <div class="num" style="color: var(--accent)">{{ total_solved }}</div>
+    <div class="lbl">Total Solved</div>
+  </div>
+  <div class="stat-card">
+    <div class="num">{{ member_count }}</div>
+    <div class="lbl">Members</div>
+  </div>
+  <div class="stat-card">
+    <div class="num">{{ avg_c_score }}</div>
+    <div class="lbl">Avg C-Score</div>
+  </div>
+  <div class="stat-card">
+    <div class="num">{{ avg_rating }}</div>
+    <div class="lbl">Avg Rating</div>
+  </div>
+  <div class="stat-card">
+    <div class="num">{{ dsa_done }}</div>
+    <div class="lbl">DSA Done</div>
+  </div>
+</div>
+
+<div class="section-title"><i class="bi bi-people-fill" style="color: var(--accent)"></i> Members</div>
+
+{% if members %}
+<div class="member-table-wrap">
+  <table class="member-table">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Name</th>
+        <th scope="col">C-Score</th>
+        <th scope="col">DSA</th>
+        <th scope="col">Platforms</th>
+        <th scope="col">Rating</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for m in members %}
+      <tr>
+        <td><span class="rank-badge rank-{{ loop.index if loop.index <= 3 else '' }}">{{ loop.index }}</span></td>
+        <td>
+          <div class="user-info">
+            <div class="user-avatar">
+              {% if m.profile_photo %}
+              <img src="{{ m.profile_photo }}" alt="{{ m.name }}" width="32" height="32">
+              {% else %}
+              {{ (m.name or 'U')[0]|upper }}
+              {% endif %}
+            </div>
+            <a href="{{ url_for('public.public_profile', user_id=m.user_id) }}" class="user-name">{{ m.name }}</a>
+          </div>
+        </td>
+        <td style="font-weight: 700; color: var(--accent)">{{ m.c_score }}</td>
+        <td>{{ m.dsa_done }} / 450</td>
+        <td>
+          {% if m.lc_total %}<span class="plat-badge plat-lc">LC {{ m.lc_total }}</span>{% endif %}
+          {% if m.gfg_total %}<span class="plat-badge plat-gfg">GFG {{ m.gfg_total }}</span>{% endif %}
+          {% if m.cn_total %}<span class="plat-badge plat-cn">CN {{ m.cn_total }}</span>{% endif %}
+          {% if m.hr_total %}<span class="plat-badge plat-hr">HR {{ m.hr_total }}</span>{% endif %}
+        </td>
+        <td>{{ m.lc_rating or '—' }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% else %}
+<div class="loading">No members found for this college.</div>
+{% endif %}
+{% endblock %}
+
+{% block scripts %}{% endblock %}

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -271,6 +271,7 @@ const CURRENT_USER_ID = {{ current_user_id | tojson }};
 const endpointConfig = {{ {
   "publicProfileBase": url_for('public.public_profile', user_id='__USER_ID__'),
   "compareBase": url_for('leaderboard.compare', user_id='__USER_ID__'),
+  "collegeBase": url_for('public.college_detail', slug='__COLLEGE_SLUG__'),
 }|tojson }};
 const VALID_MODES = ['cscore', 'questions', 'rating', 'college'];
 const urlParams = new URLSearchParams(window.location.search);
@@ -287,6 +288,10 @@ function escapeHTML(str) {
   return str.replace(/[&<>"']/g, function(c) {
     return '&#' + c.charCodeAt(0) + ';';
   });
+}
+
+function collegeSlug(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 }
 
 function safeURL(url) {
@@ -397,7 +402,7 @@ function renderTable(entries, mode) {
       ? endpointConfig.publicProfileBase.replace('__USER_ID__', encodeURIComponent(e.user_id))
       : '';
     const nameHTML = isCollegeMode
-      ? `${escapeHTML(e.college)}`
+      ? `<a href="${endpointConfig.collegeBase.replace('__COLLEGE_SLUG__', encodeURIComponent(collegeSlug(e.college)))}" aria-label="View ${escapeHTML(e.college)} page">${escapeHTML(e.college)}</a>`
       : `<a href="${profileURL}" aria-label="View profile of ${escapeHTML(e.name)}">${escapeHTML(e.name)}</a>${isMe ? '<span class="me-tag" aria-label="This is you">YOU</span>' : ''}`;
     
     const subtitleHTML = isCollegeMode


### PR DESCRIPTION
## Related Issue

Closes #290

## Description

Adds a public college detail page showing member stats, top performers, and aggregate analytics for each college on the platform.

### Changes Made

* New \GET /college/<slug>\ route in \pp/web/routes.py\ that:
  * Looks up college by URL-safe slug derived from the college name
  * Aggregates member stats from \uild_leaderboard_data()\
  * Sorts members by C-Score descending
  * Returns aggregate stats (member count, total solved, avg C-Score, avg LC rating, platform totals)
* New \	emplates/college_detail.html\ with stat cards, member table with avatars, platform badges, and ratings
* College names on the leaderboard (college ranking mode) now link to their college detail page

### Implementation Notes

Uses existing \uild_leaderboard_data()\ output. College slug is computed client-side (JS) and server-side (Python) using the same algorithm: lowercase, replace non-alphanumeric with hyphens, strip leading/trailing hyphens.