### PR TITLE
fix: add rate limit and caching to search_universities endpoint (#206)

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -273,6 +273,8 @@ def milestone_certificate(milestone_id):
 
 
 @profile_bp.route("/search_universities")
+@limiter.limit("30 per minute")
+@cache.cached(timeout=300, query_string=True)
 def search_universities():
     """Return matching universities for an autocomplete query.
     ---


### PR DESCRIPTION
Closes #206

Adds rate limiting (30/min) and response caching (300s, keyed by query string) to the university autocomplete endpoint.