### PR TITLE
feat: add platform sync history display on profile page (#205)

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -514,6 +514,9 @@ def profile():
 
     update_computed_stats(user.id, user.progress, db, total_questions, user)
 
+    platform_last_sync = user.platform_last_sync or {}
+    last_sync = user.last_sync
+
     return render_template(
         "profile.html",
         user=user,
@@ -542,4 +545,6 @@ def profile():
         profile_leaderboard_rank=profile_leaderboard_rank,
         current_streak=current_streak,
         longest_streak=longest_streak,
+        platform_last_sync=platform_last_sync,
+        last_sync=last_sync,
     )

--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -171,12 +171,19 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
                 platform_totals.pop(total_key, None)
 
     platform_status = {}
+    platform_last_sync = dict(getattr(user, "platform_last_sync", {}) or {})
 
     def _mark(platform_key: str, status: str, error: str = None):
         payload = {"status": status}
         if error:
             payload["error"] = error
         platform_status[platform_key] = payload
+        if status in ("synced", "failed"):
+            platform_last_sync[platform_key] = {
+                "synced_at": now.isoformat(),
+                "status": status,
+                "error": error or None,
+            }
 
     # Preserve existing per-platform calendar data across partial syncs
     existing_calendars = getattr(user, "platform_calendars", {})
@@ -353,6 +360,7 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
 
     update_fields["platform_calendars"] = platform_calendars
     update_fields["external_totals"] = platform_totals
+    update_fields["platform_last_sync"] = platform_last_sync
     db_handle.user.update_one({"_id": user_id}, {"$set": update_fields})
     user.reload()
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -156,6 +156,26 @@
       </span>
     </div>
     <button class="add-btn ui-btn ui-btn-secondary ui-btn-block" onclick="openSyncModal()" aria-label="Add or connect coding platform accounts"><i class="bi bi-plus" aria-hidden="true"></i> Add Platform</button>
+    {% if last_sync or platform_last_sync %}
+    <div class="sync-history" style="margin-top:12px;padding:8px 10px;background:var(--bg-card-hover);border-radius:8px;font-size:.75rem">
+      <div style="font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.04em;margin-bottom:6px">Sync History</div>
+      {% if last_sync %}
+      <div style="color:var(--text-secondary);margin-bottom:4px">Last sync: {{ last_sync | datetimeformat }}</div>
+      {% endif %}
+      {% for key, info in (platform_last_sync or {}).items() %}
+      <div style="display:flex;justify-content:space-between;align-items:center;padding:2px 0">
+        <span>{{ key | capitalize }}</span>
+        <span style="color:{% if info.status == 'synced' %}var(--success){% elif info.status == 'failed' %}var(--danger){% else %}var(--text-muted){% endif %}">
+          {% if info.status == 'synced' %}<i class="bi bi-check-circle-fill" aria-hidden="true"></i>
+          {% elif info.status == 'failed' %}<i class="bi bi-exclamation-circle-fill" aria-hidden="true"></i>
+          {% else %}<i class="bi bi-dash-circle" aria-hidden="true"></i>{% endif %}
+          {{ info.status | capitalize }}
+          {% if info.status == 'synced' %} {{ info.synced_at | datetimeformat }}{% endif %}
+        </span>
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
     <div class="sec-title" style="margin-top:14px">Development Stats</div>
     <div class="platform-row">
       <span><i class="bi bi-github" style="margin-right:6px" aria-hidden="true"></i>GitHub</span>


### PR DESCRIPTION
Closes #205

Adds per-platform sync history tracking and display on the profile page.

### Changes
- **sync_service.py**: Tracks \synced_at\, \status\, and \error\ per platform in a \platform_last_sync\ dict, persisted to the user document
- **routes.py**: Passes \platform_last_sync\ and \last_sync\ to the profile template
- **profile.html**: New Sync History section in the sidebar showing last overall sync time and per-platform status with timestamps