### PR TITLE
feat: add per-user custom question lists (#277)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,6 +25,7 @@ from app.security import (
 from app.search import search_bp
 from app.tracker import tracker_bp
 from app.cohort.routes import cohort_bp
+from app.mylist import mylist_bp
 from app.utils import (
     platform_color_filter,
     platform_name_filter,
@@ -349,6 +350,7 @@ def create_app(config_class=None):
     app.register_blueprint(admin_bp)
     app.register_blueprint(public_bp)
     app.register_blueprint(cohort_bp)
+    app.register_blueprint(mylist_bp)
 
     @app.errorhandler(429)
     def ratelimit_handler(e):

--- a/app/mylist/__init__.py
+++ b/app/mylist/__init__.py
@@ -1,0 +1,1 @@
+from .routes import mylist_bp

--- a/app/mylist/routes.py
+++ b/app/mylist/routes.py
@@ -1,0 +1,94 @@
+from bson import ObjectId
+from bson.errors import InvalidId
+from flask import Blueprint, render_template, request
+from flask_login import current_user, login_required
+from app.extensions import db
+from app.utils import json_error, json_success, json_response, utc_now
+
+mylist_bp = Blueprint("mylist", __name__, url_prefix="/mylist")
+
+VALID_DIFFICULTIES = ("Easy", "Medium", "Hard")
+
+def _owned(doc):
+    return doc and str(doc.get("owner")) == str(current_user.id)
+
+@mylist_bp.route("/")
+@login_required
+def index():
+    questions = list(db.user_questions.find({"owner": current_user.id}).sort("created_at", -1))
+    return render_template("mylist.html", questions=questions)
+
+@mylist_bp.route("/add", methods=["POST"])
+@login_required
+def add_question():
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return json_error("Invalid request body", 400)
+    title = (data.get("title") or "").strip()
+    if not title:
+        return json_error("Title is required", 400)
+    difficulty = data.get("difficulty", "Medium")
+    if difficulty not in VALID_DIFFICULTIES:
+        return json_error("difficulty must be Easy, Medium or Hard", 400)
+    doc = {
+        "owner": current_user.id,
+        "title": title,
+        "url": (data.get("url") or "").strip(),
+        "category": (data.get("category") or "").strip(),
+        "difficulty": difficulty,
+        "notes": (data.get("notes") or "").strip(),
+        "done": False,
+        "created_at": utc_now(),
+    }
+    result = db.user_questions.insert_one(doc)
+    return json_response({"success": True, "id": str(result.inserted_id)}, 201)
+
+@mylist_bp.route("/<question_id>", methods=["PATCH"])
+@login_required
+def update_question(question_id):
+    try:
+        oid = ObjectId(question_id)
+    except InvalidId:
+        return json_error("Not found", 404)
+    doc = db.user_questions.find_one({"_id": oid})
+    if not _owned(doc):
+        return json_error("Not found", 404)
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return json_error("Invalid request body", 400)
+    fields = {}
+    if "title" in data:
+        title = (data["title"] or "").strip()
+        if not title:
+            return json_error("Title is required", 400)
+        fields["title"] = title
+    if "url" in data:
+        fields["url"] = (data["url"] or "").strip()
+    if "category" in data:
+        fields["category"] = (data["category"] or "").strip()
+    if "difficulty" in data:
+        if data["difficulty"] not in VALID_DIFFICULTIES:
+            return json_error("difficulty must be Easy, Medium or Hard", 400)
+        fields["difficulty"] = data["difficulty"]
+    if "notes" in data:
+        fields["notes"] = (data["notes"] or "").strip()
+    if "done" in data:
+        if not isinstance(data["done"], bool):
+            return json_error("done must be a boolean", 400)
+        fields["done"] = data["done"]
+    if fields:
+        db.user_questions.update_one({"_id": oid}, {"$set": fields})
+    return json_success()
+
+@mylist_bp.route("/<question_id>", methods=["DELETE"])
+@login_required
+def delete_question(question_id):
+    try:
+        oid = ObjectId(question_id)
+    except InvalidId:
+        return json_error("Not found", 404)
+    doc = db.user_questions.find_one({"_id": oid})
+    if not _owned(doc):
+        return json_error("Not found", 404)
+    db.user_questions.delete_one({"_id": oid})
+    return json_success()

--- a/templates/mylist.html
+++ b/templates/mylist.html
@@ -1,0 +1,166 @@
+{% extends "base.html" %}
+{% block head %}
+<style>
+.mylist-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 24px; flex-wrap: wrap; gap: 12px; }
+.mylist-header h1 { font-size: 1.6rem; font-weight: 700; color: var(--text-primary); margin: 0; }
+.ml-table-wrap { background: var(--bg-card); border: 1px solid var(--border-color); border-radius: var(--radius-lg); overflow: hidden; }
+.ml-table { width: 100%; border-collapse: collapse; }
+.ml-table th { padding: 12px 16px; font-size: 0.75rem; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 1px solid var(--border-color); text-align: left; }
+.ml-table td { padding: 14px 16px; border-bottom: 1px solid var(--border-color); color: var(--text-primary); font-size: 0.9rem; vertical-align: middle; }
+.ml-table tr:last-child td { border-bottom: none; }
+.ml-table tr.done-row td { opacity: 0.5; text-decoration: line-through; }
+.diff-badge { border-radius: 99px; padding: 2px 10px; font-size: 0.75rem; font-weight: 600; }
+.diff-easy { background: #22c55e22; color: #22c55e; }
+.diff-medium { background: #f59e0b22; color: #f59e0b; }
+.diff-hard { background: #ef444422; color: #ef4444; }
+.ml-actions { display: flex; gap: 8px; }
+.ml-btn { border: none; background: transparent; cursor: pointer; color: var(--text-secondary); padding: 4px 6px; border-radius: var(--radius); transition: color 0.15s; font-size: 1rem; }
+.ml-btn:hover { color: var(--accent); }
+.ml-btn.delete:hover { color: #ef4444; }
+.empty-state { text-align: center; padding: 60px 20px; color: var(--text-secondary); }
+.empty-state i { font-size: 2.5rem; margin-bottom: 12px; display: block; }
+.ml-modal-backdrop { display: none; position: fixed; inset: 0; background: #0008; z-index: 1000; align-items: center; justify-content: center; }
+.ml-modal-backdrop.open { display: flex; }
+.ml-modal { background: var(--bg-card); border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: 28px; width: 100%; max-width: 480px; }
+.ml-modal h2 { font-size: 1.1rem; font-weight: 700; margin-bottom: 20px; color: var(--text-primary); }
+.ml-field { margin-bottom: 14px; }
+.ml-field label { display: block; font-size: 0.8rem; font-weight: 600; color: var(--text-secondary); margin-bottom: 4px; }
+.ml-field input, .ml-field select, .ml-field textarea { width: 100%; background: var(--bg-main); border: 1px solid var(--border-color); border-radius: var(--radius); padding: 8px 12px; color: var(--text-primary); font-size: 0.9rem; outline: none; }
+.ml-field input:focus, .ml-field select:focus, .ml-field textarea:focus { border-color: var(--accent); }
+.ml-field textarea { resize: vertical; min-height: 80px; }
+.ml-modal-actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 20px; }
+</style>
+{% endblock %}
+{% block content %}
+<div class="mylist-header">
+    <h1><i class="bi bi-journal-plus" aria-hidden="true"></i> My Question List</h1>
+    <button class="ui-btn ui-btn-primary" id="add-btn">
+        <i class="bi bi-plus-lg" aria-hidden="true"></i> Add Question
+    </button>
+</div>
+{% if questions %}
+<div class="ml-table-wrap">
+    <table class="ml-table">
+        <thead>
+            <tr>
+                <th>Done</th>
+                <th>Title</th>
+                <th>Category</th>
+                <th>Difficulty</th>
+                <th>Notes</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody id="ml-tbody">
+        {% for q in questions %}
+        <tr id="row-{{ q._id }}" class="{% if q.done %}done-row{% endif %}">
+            <td><input type="checkbox" class="ml-done-check" data-id="{{ q._id }}" {% if q.done %}checked{% endif %}></td>
+            <td>
+                {% if q.url %}<a href="{{ q.url|safe_url }}" target="_blank" rel="noopener noreferrer" style="color:var(--accent)">{{ q.title }}</a>
+                {% else %}{{ q.title }}{% endif %}
+            </td>
+            <td>{{ q.category or "—" }}</td>
+            <td><span class="diff-badge diff-{{ q.difficulty|lower }}">{{ q.difficulty }}</span></td>
+            <td style="max-width:200px;white-space:pre-wrap;font-size:0.82rem">{{ q.notes or "—" }}</td>
+            <td>
+                <div class="ml-actions">
+                    <button class="ml-btn edit-btn" data-id="{{ q._id }}" data-title="{{ q.title }}" data-url="{{ q.url }}" data-category="{{ q.category }}" data-difficulty="{{ q.difficulty }}" data-notes="{{ q.notes }}" aria-label="Edit">
+                        <i class="bi bi-pencil" aria-hidden="true"></i>
+                    </button>
+                    <button class="ml-btn delete ml-del-btn" data-id="{{ q._id }}" aria-label="Delete">
+                        <i class="bi bi-trash" aria-hidden="true"></i>
+                    </button>
+                </div>
+            </td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% else %}
+<div class="empty-state">
+    <i class="bi bi-journal-x" aria-hidden="true"></i>
+    <p>No custom questions yet.<br>Click <strong>Add Question</strong> to get started.</p>
+</div>
+{% endif %}
+<div class="ml-modal-backdrop" id="ml-modal" role="dialog" aria-modal="true">
+    <div class="ml-modal">
+        <h2 id="modal-title">Add Question</h2>
+        <input type="hidden" id="edit-id">
+        <div class="ml-field"><label for="f-title">Title *</label><input type="text" id="f-title" placeholder="e.g. Two Sum"></div>
+        <div class="ml-field"><label for="f-url">URL</label><input type="url" id="f-url" placeholder="https://leetcode.com/problems/..."></div>
+        <div class="ml-field"><label for="f-category">Category</label><input type="text" id="f-category" placeholder="e.g. Arrays, Trees"></div>
+        <div class="ml-field"><label for="f-difficulty">Difficulty</label>
+            <select id="f-difficulty"><option value="Easy">Easy</option><option value="Medium" selected>Medium</option><option value="Hard">Hard</option></select>
+        </div>
+        <div class="ml-field"><label for="f-notes">Notes</label><textarea id="f-notes" placeholder="Approach, key insight..."></textarea></div>
+        <div class="ml-modal-actions">
+            <button class="ui-btn ui-btn-secondary" id="modal-cancel">Cancel</button>
+            <button class="ui-btn ui-btn-primary" id="modal-save">Save</button>
+        </div>
+    </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script>
+const csrfToken = {{ csrf_token()|tojson }};
+const modal = document.getElementById('ml-modal');
+const editId = document.getElementById('edit-id');
+const openModal = (title, data={}) => {
+    document.getElementById('modal-title').textContent = title;
+    editId.value = data.id || '';
+    document.getElementById('f-title').value = data.title || '';
+    document.getElementById('f-url').value = data.url || '';
+    document.getElementById('f-category').value = data.category || '';
+    document.getElementById('f-difficulty').value = data.difficulty || 'Medium';
+    document.getElementById('f-notes').value = data.notes || '';
+    modal.classList.add('open');
+    document.getElementById('f-title').focus();
+};
+const closeModal = () => modal.classList.remove('open');
+document.getElementById('add-btn').onclick = () => openModal('Add Question');
+document.getElementById('modal-cancel').onclick = closeModal;
+modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
+document.getElementById('modal-save').onclick = async () => {
+    const id = editId.value;
+    const body = {
+        title: document.getElementById('f-title').value.trim(),
+        url: document.getElementById('f-url').value.trim(),
+        category: document.getElementById('f-category').value.trim(),
+        difficulty: document.getElementById('f-difficulty').value,
+        notes: document.getElementById('f-notes').value.trim(),
+    };
+    if (!body.title) { alert('Title is required'); return; }
+    const url = id ? `/mylist/${id}` : '/mylist/add';
+    const method = id ? 'PATCH' : 'POST';
+    const r = await fetch(url, { method, headers: {'Content-Type':'application/json', 'X-CSRFToken': csrfToken}, body: JSON.stringify(body) });
+    const data = await r.json();
+    if (data.success || data.id) { closeModal(); location.reload(); }
+    else alert(data.error || 'Something went wrong');
+};
+document.querySelectorAll('.edit-btn').forEach(btn => {
+    btn.onclick = () => openModal('Edit Question', {
+        id: btn.dataset.id, title: btn.dataset.title, url: btn.dataset.url,
+        category: btn.dataset.category, difficulty: btn.dataset.difficulty, notes: btn.dataset.notes
+    });
+});
+document.querySelectorAll('.ml-del-btn').forEach(btn => {
+    btn.onclick = async () => {
+        if (!confirm('Delete this question?')) return;
+        const r = await fetch(`/mylist/${btn.dataset.id}`, { method: 'DELETE', headers: {'X-CSRFToken': csrfToken} });
+        const data = await r.json();
+        if (data.success) document.getElementById(`row-${btn.dataset.id}`).remove();
+    };
+});
+document.querySelectorAll('.ml-done-check').forEach(chk => {
+    chk.onchange = async function() {
+        const r = await fetch(`/mylist/${this.dataset.id}`, {
+            method: 'PATCH', headers: {'Content-Type':'application/json', 'X-CSRFToken': csrfToken},
+            body: JSON.stringify({done: this.checked})
+        });
+        const data = await r.json();
+        if (data.success) document.getElementById(`row-${this.dataset.id}`).classList.toggle('done-row', this.checked);
+    };
+});
+</script>
+{% endblock %}

--- a/templates/partials/sidebar.html
+++ b/templates/partials/sidebar.html
@@ -10,6 +10,10 @@
                 <i class="bi bi-person-circle" aria-hidden="true"></i>
                 <span class="tooltip-label">Profile</span>
             </a>
+            <a href="{{ url_for('mylist.index') }}" class="sidebar-link {% if request.endpoint == 'mylist.index' %}active{% endif %}" id="nav-mylist" aria-label="My List">
+                <i class="bi bi-journal-plus" aria-hidden="true"></i>
+                <span class="tooltip-label">My List</span>
+            </a>
             <a href="{{ url_for('tracker.bookmarks') }}" class="sidebar-link {% if request.endpoint == 'tracker.bookmarks' %}active{% endif %}" id="nav-bookmarks" aria-label="Bookmarks">
                 <i class="bi bi-bookmark-fill" aria-hidden="true"></i>
                 <span class="tooltip-label">Bookmarks</span>

--- a/tests/test_mylist_routes.py
+++ b/tests/test_mylist_routes.py
@@ -1,0 +1,140 @@
+"""Tests for the My List blueprint (app/mylist/routes.py)."""
+import app.mylist.routes as mylist_routes
+import app.tracker.routes as tracker_routes
+from conftest import build_test_app, csrf_headers, login_test_user
+
+
+def _setup(monkeypatch):
+    flask_app, test_db = build_test_app(
+        monkeypatch,
+        extra_db_targets=(tracker_routes, mylist_routes),
+    )
+    user_id = test_db.user.insert_one({
+        "email": "a@example.com",
+        "name": "A",
+        "progress": {},
+        "is_admin": False,
+        "external_daily_counts": {},
+        "external_totals": {},
+    }).inserted_id
+    other_id = test_db.user.insert_one({
+        "email": "b@example.com",
+        "name": "B",
+        "progress": {},
+        "is_admin": False,
+        "external_daily_counts": {},
+        "external_totals": {},
+    }).inserted_id
+    return flask_app, test_db, user_id, other_id
+
+
+def test_add_question(monkeypatch):
+    flask_app, test_db, user_id, _ = _setup(monkeypatch)
+    client = flask_app.test_client()
+    login_test_user(client, user_id)
+    r = client.post("/mylist/add", json={
+        "title": "Two Sum",
+        "url": "https://leetcode.com/problems/two-sum/",
+        "category": "Arrays",
+        "difficulty": "Easy",
+        "notes": "Use a hashmap",
+    }, headers=csrf_headers(client))
+    assert r.status_code == 201
+    data = r.get_json()
+    assert data["success"] is True
+    assert "id" in data
+    assert test_db.user_questions.count_documents({}) == 1
+
+
+def test_add_question_requires_title(monkeypatch):
+    flask_app, test_db, user_id, _ = _setup(monkeypatch)
+    client = flask_app.test_client()
+    login_test_user(client, user_id)
+    r = client.post("/mylist/add", json={"title": "", "difficulty": "Easy"},
+                    headers=csrf_headers(client))
+    assert r.status_code == 400
+    assert r.get_json()["success"] is False
+
+
+def test_add_question_invalid_difficulty(monkeypatch):
+    flask_app, test_db, user_id, _ = _setup(monkeypatch)
+    client = flask_app.test_client()
+    login_test_user(client, user_id)
+    r = client.post("/mylist/add", json={"title": "X", "difficulty": "Extreme"},
+                    headers=csrf_headers(client))
+    assert r.status_code == 400
+
+
+def test_update_question(monkeypatch):
+    flask_app, test_db, user_id, _ = _setup(monkeypatch)
+    client = flask_app.test_client()
+    login_test_user(client, user_id)
+    r = client.post("/mylist/add", json={"title": "Two Sum", "difficulty": "Easy"},
+                    headers=csrf_headers(client))
+    qid = r.get_json()["id"]
+    r2 = client.patch(f"/mylist/{qid}", json={"done": True, "difficulty": "Hard"},
+                      headers=csrf_headers(client))
+    assert r2.status_code == 200
+    assert r2.get_json()["success"] is True
+    doc = test_db.user_questions.find_one({})
+    assert doc["done"] is True
+    assert doc["difficulty"] == "Hard"
+
+
+def test_toggle_done(monkeypatch):
+    flask_app, test_db, user_id, _ = _setup(monkeypatch)
+    client = flask_app.test_client()
+    login_test_user(client, user_id)
+    r = client.post("/mylist/add", json={"title": "Q", "difficulty": "Medium"},
+                    headers=csrf_headers(client))
+    qid = r.get_json()["id"]
+    client.patch(f"/mylist/{qid}", json={"done": True}, headers=csrf_headers(client))
+    doc = test_db.user_questions.find_one({})
+    assert doc["done"] is True
+    client.patch(f"/mylist/{qid}", json={"done": False}, headers=csrf_headers(client))
+    doc = test_db.user_questions.find_one({})
+    assert doc["done"] is False
+
+
+def test_delete_question(monkeypatch):
+    flask_app, test_db, user_id, _ = _setup(monkeypatch)
+    client = flask_app.test_client()
+    login_test_user(client, user_id)
+    r = client.post("/mylist/add", json={"title": "Q", "difficulty": "Easy"},
+                    headers=csrf_headers(client))
+    qid = r.get_json()["id"]
+    r2 = client.delete(f"/mylist/{qid}", headers=csrf_headers(client))
+    assert r2.status_code == 200
+    assert r2.get_json()["success"] is True
+    assert test_db.user_questions.count_documents({}) == 0
+
+
+def test_ownership_isolation(monkeypatch):
+    flask_app, test_db, user_id, other_id = _setup(monkeypatch)
+    client = flask_app.test_client()
+    login_test_user(client, user_id)
+    r = client.post("/mylist/add", json={"title": "Q", "difficulty": "Easy"},
+                    headers=csrf_headers(client))
+    qid = r.get_json()["id"]
+    login_test_user(client, other_id)
+    r2 = client.delete(f"/mylist/{qid}", headers=csrf_headers(client))
+    assert r2.status_code == 404
+    assert test_db.user_questions.count_documents({}) == 1
+
+
+def test_unauthenticated_add_redirects(monkeypatch):
+    flask_app, test_db, user_id, _ = _setup(monkeypatch)
+    client = flask_app.test_client()
+    r = client.post("/mylist/add", json={"title": "Q", "difficulty": "Easy"},
+                    headers=csrf_headers(client))
+    assert r.status_code in (302, 401, 403)
+
+
+def test_csrf_rejection(monkeypatch):
+    flask_app, test_db, user_id, _ = _setup(monkeypatch)
+    client = flask_app.test_client()
+    login_test_user(client, user_id)
+    r = client.post("/mylist/add",
+                    data='{"title":"Q","difficulty":"Easy"}',
+                    content_type="application/json")
+    assert r.status_code in (400, 403)


### PR DESCRIPTION
Closes #277

## What this does
- New `/mylist/` page for authenticated users to manage personal questions
- Supports title, URL, category, difficulty (Easy/Medium/Hard), and notes
- Questions are private — scoped to the owner, stored in `user_questions` collection
- Full CRUD: add, edit, delete, and mark done
- Sidebar nav link added

