### PR TITLE
feat(auth): implement email verification for user registration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,7 +12,7 @@ from flask import Flask, abort, g, jsonify, request
 from app.admin import admin_bp
 from app.auth import auth_bp
 from app.faq import faq_bp
-from app.extensions import bcrypt, cache, db, limiter, login_manager, mongo, oauth
+from app.extensions import bcrypt, cache, db, limiter, login_manager, mongo, oauth, mail
 from app.leaderboard import leaderboard_bp
 from app.web.routes import public_bp
 from app.profile import profile_bp
@@ -124,6 +124,7 @@ def create_app(config_class=None):
     )
 
     mongo.init_app(app, **_mongo_client_options(app))
+    mail.init_app(app)
     bcrypt.init_app(app)
     login_manager.init_app(app)
     oauth.init_app(app)

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -5,7 +5,8 @@ from bson import ObjectId
 from flask import Blueprint, abort, current_app, flash, redirect, render_template, request, session, url_for
 from flask_login import UserMixin, current_user, login_required, login_user, logout_user
 
-from app.extensions import bcrypt, cache, db, github, google, limiter, login_manager
+from app.extensions import bcrypt, cache, db, github, google, limiter, login_manager, mail
+from flask_mail import Message
 from app.leaderboard.cache import invalidate_leaderboard_cache
 from app.profile.sync_service import clear_profile_caches
 from app.utils import utc_now
@@ -158,6 +159,9 @@ def login():
         password = request.form.get("password")
         user_doc = db.user.find_one({"email": email})
         if user_doc and user_doc.get("password") and password and bcrypt.check_password_hash(user_doc["password"], password):
+            if user_doc.get("is_verified") is False:
+                flash("Please verify your email before logging in. Check your inbox.", "warning")
+                return redirect(url_for("auth.login"))
             user_doc = reactivate_user_if_needed(user_doc)
             login_user(UserWrapper(user_doc))
             flash(f"Welcome back, {user_doc.get('name', 'User')}! 👋", "success")
@@ -195,6 +199,7 @@ def register():
             return redirect(url_for("auth.register"))
 
         hashed_password = bcrypt.generate_password_hash(password).decode("utf-8")
+        verification_token = secrets.token_urlsafe(32)
         try:
             db.user.insert_one(
                 {
@@ -204,13 +209,36 @@ def register():
                     "progress": {},
                     "is_admin": False,
                     "created_at": utc_now(),
+                    "is_verified": False,
+                    "verification_token": verification_token,
                 }
             )
-            flash("Your account has been created! You can now log in.", "success")
+            verify_url = url_for("auth.verify_email", token=verification_token, _external=True)
+            if not current_app.config.get("MAIL_USERNAME"):
+                print(f"[DEV] Verify URL: {verify_url}")
+            else:
+                msg = Message("Verify Your Account", recipients=[email])
+                msg.html = render_template("verify_email.html", verify_url=verify_url, email=email)
+                mail.send(msg)
+                
+            flash("Account created! Please check your email to verify your account.", "success")
             return redirect(url_for("auth.login"))
-        except Exception:
+        except Exception as e:
             flash("An error occurred during registration.", "danger")
     return render_template("register.html")
+
+@auth_bp.route("/verify-email/<token>")
+def verify_email(token):
+    user_doc = db.user.find_one({"verification_token": token})
+    if user_doc and not user_doc.get("is_verified", True):
+        db.user.update_one(
+            {"_id": user_doc["_id"]},
+            {"$set": {"is_verified": True}, "$unset": {"verification_token": ""}}
+        )
+        flash("Email verified! You can now log in.", "success")
+    else:
+        flash("Invalid or expired verification link.", "danger")
+    return redirect(url_for("auth.login"))
 
 
 @auth_bp.route("/logout", methods=["POST"])

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -6,7 +6,6 @@ from flask import Blueprint, abort, current_app, flash, redirect, render_templat
 from flask_login import UserMixin, current_user, login_required, login_user, logout_user
 
 from app.extensions import bcrypt, cache, db, github, google, limiter, login_manager, mail
-from flask_mail import Message
 from app.leaderboard.cache import invalidate_leaderboard_cache
 from app.profile.sync_service import clear_profile_caches
 from app.utils import utc_now
@@ -200,32 +199,91 @@ def register():
 
         hashed_password = bcrypt.generate_password_hash(password).decode("utf-8")
         verification_token = secrets.token_urlsafe(32)
-        try:
-            db.user.insert_one(
-                {
-                    "name": name,
-                    "email": email,
-                    "password": hashed_password,
-                    "progress": {},
-                    "is_admin": False,
-                    "created_at": utc_now(),
-                    "is_verified": False,
-                    "verification_token": verification_token,
-                }
-            )
-            verify_url = url_for("auth.verify_email", token=verification_token, _external=True)
-            if not current_app.config.get("MAIL_USERNAME"):
-                print(f"[DEV] Verify URL: {verify_url}")
-            else:
-                msg = Message("Verify Your Account", recipients=[email])
-                msg.html = render_template("verify_email.html", verify_url=verify_url, email=email)
+        verify_url = url_for("auth.verify_email", token=verification_token, _external=True)
+        user_data = {
+            "name": name,
+            "email": email,
+            "password": hashed_password,
+            "progress": {},
+            "is_admin": False,
+            "created_at": utc_now(),
+            "is_verified": False,
+            "verification_token": verification_token,
+        }
+
+        if not current_app.config.get("MAIL_USERNAME"):
+            print(f"[DEV] Verify URL: {verify_url}")
+        else:
+            try:
+                from flask_mail import Message
+            except ImportError:
+                flash("Email service is unavailable. Please try again later.", "danger")
+                return redirect(url_for("auth.register"))
+
+            msg = Message("Verify Your Account", recipients=[email])
+            msg.html = render_template("verify_email.html", verify_url=verify_url, email=email)
+            try:
                 mail.send(msg)
-                
-            flash("Account created! Please check your email to verify your account.", "success")
-            return redirect(url_for("auth.login"))
-        except Exception as e:
+            except Exception:
+                flash("Email could not be sent, please try again.", "danger")
+                return redirect(url_for("auth.register"))
+
+        try:
+            db.user.insert_one(user_data)
+        except Exception:
             flash("An error occurred during registration.", "danger")
+            return redirect(url_for("auth.register"))
+
+        flash("Account created! Please check your email to verify your account.", "success")
+        return redirect(url_for("auth.login"))
     return render_template("register.html")
+
+
+@auth_bp.route("/resend-verification", methods=["GET", "POST"])
+def resend_verification():
+    if request.method == "POST":
+        email = normalize_email(request.form.get("email"))
+        if not email:
+            flash("Email is required.", "danger")
+            return redirect(url_for("auth.resend_verification"))
+
+        user_doc = db.user.find_one({"email": email})
+        if not user_doc:
+            flash("No account found with that email.", "danger")
+            return redirect(url_for("auth.resend_verification"))
+        if user_doc.get("is_verified"):
+            flash("Email is already verified. Please log in.", "info")
+            return redirect(url_for("auth.login"))
+
+        verification_token = secrets.token_urlsafe(32)
+        verify_url = url_for("auth.verify_email", token=verification_token, _external=True)
+
+        if not current_app.config.get("MAIL_USERNAME"):
+            print(f"[DEV] Verify URL: {verify_url}")
+        else:
+            try:
+                from flask_mail import Message
+            except ImportError:
+                flash("Email service is unavailable. Please try again later.", "danger")
+                return redirect(url_for("auth.resend_verification"))
+
+            msg = Message("Verify Your Account", recipients=[email])
+            msg.html = render_template("verify_email.html", verify_url=verify_url, email=email)
+            try:
+                mail.send(msg)
+            except Exception:
+                flash("Email could not be sent, please try again.", "danger")
+                return redirect(url_for("auth.resend_verification"))
+
+        db.user.update_one(
+            {"_id": user_doc["_id"]},
+            {"$set": {"verification_token": verification_token}}
+        )
+        flash("Verification email resent. Check your inbox.", "success")
+        return redirect(url_for("auth.login"))
+
+    return render_template("resend_verification.html")
+
 
 @auth_bp.route("/verify-email/<token>")
 def verify_email(token):

--- a/app/config.py
+++ b/app/config.py
@@ -48,6 +48,12 @@ class BaseConfig:
         "title": "450 DSA Tracker API",
         "uiversion": 3,
     }
+    MAIL_SERVER = os.environ.get('MAIL_SERVER', 'smtp.gmail.com')
+    MAIL_PORT = env_int('MAIL_PORT', 587)
+    MAIL_USE_TLS = True
+    MAIL_USERNAME = os.environ.get('MAIL_USERNAME')
+    MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD')
+    MAIL_DEFAULT_SENDER = os.environ.get('MAIL_USERNAME')
     RATELIMIT_STORAGE_URI = "memory://"
     INSECURE_SECRET_KEYS = {
         None,

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -6,11 +6,13 @@ from flask_login import LoginManager
 from flask_pymongo import PyMongo
 from werkzeug.local import LocalProxy
 from flask_caching import Cache
+from flask_mail import Mail
 
 mongo = PyMongo()
 db = LocalProxy(lambda: mongo.db)
 bcrypt = Bcrypt()
 login_manager = LoginManager()
+mail = Mail()
 oauth = OAuth()
 limiter = Limiter(key_func=get_remote_address, default_limits=[], headers_enabled=True)
 github = LocalProxy(lambda: oauth.create_client("github"))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,5 @@ pytest==8.2.2
 pytest-cov==5.0.0
 ruff==0.4.8
 black==24.4.2
+Flask-Mail==0.10.0
 pre-commit==3.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ cachetools==5.3.3
 Flask-Caching==2.0.2
 flasgger==0.9.7.1
 gunicorn==22.0.0
+flask-mail==0.9.1

--- a/templates/login.html
+++ b/templates/login.html
@@ -58,6 +58,9 @@
         <div class="auth-footer">
             Don't have an account? <a href="{{ url_for('auth.register') }}">Register here</a>
         </div>
+        <div class="auth-footer">
+            Need to verify your email? <a href="{{ url_for('auth.resend_verification') }}">Resend verification email</a>
+        </div>
     </div>
 </div>
 

--- a/templates/resend_verification.html
+++ b/templates/resend_verification.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block head %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
+{% endblock %}
+{% block content %}
+<div class="auth-wrap">
+    <div class="auth-card">
+        <div class="auth-logo">D</div>
+        <h2>Resend Verification</h2>
+        <p class="subtitle">Enter your email to resend the verification link.</p>
+
+        {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+            <div class="flash-inline {{ category }}">
+                <i class="bi bi-{% if category == 'danger' %}x-circle{% else %}check-circle{% endif %}"></i>
+                {{ message }}
+            </div>
+            {% endfor %}
+        {% endif %}
+        {% endwith %}
+
+        <form method="POST" action="{{ url_for('auth.resend_verification') }}" id="resendForm" novalidate>
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="form-group">
+                <label class="form-label" for="email">Email Address</label>
+                <div class="input-wrap">
+                    <input type="email" class="form-control" id="email" name="email" placeholder="you@example.com" required>
+                    <span class="field-icon" id="emailIcon"></span>
+                </div>
+                <div class="field-error" id="emailError">Please enter a valid email address.</div>
+            </div>
+            <button type="submit" class="btn-primary-full">
+                <i class="bi bi-envelope"></i> Resend Verification Email
+            </button>
+        </form>
+
+        <div class="auth-footer">
+            Already verified? <a href="{{ url_for('auth.login') }}">Sign in</a>
+        </div>
+    </div>
+</div>
+
+<script src="{{ url_for('static', filename='js/auth_forms.js') }}"></script>
+{% endblock %}

--- a/templates/verify_email.html
+++ b/templates/verify_email.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Verify Your Account</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; max-width: 600px; margin: 0 auto; padding: 20px;">
+    <h2>Welcome to 450 DSA Tracker!</h2>
+    <p>Hi,</p>
+    <p>Thank you for registering. You used the email address: <strong>{{ email }}</strong>.</p>
+    <p>Please click the link below to verify your email address and activate your account:</p>
+    <p style="margin: 30px 0;">
+        <a href="{{ verify_url }}" style="background-color: #4CAF50; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">
+            Verify Email Address
+        </a>
+    </p>
+    <p>Or alternatively, copy and paste this link into your browser:</p>
+    <p><a href="{{ verify_url }}">{{ verify_url }}</a></p>
+    <p>If you didn't create an account, you can safely ignore this email.</p>
+    <br>
+    <p>Best regards,<br>The 450 DSA Tracker Team</p>
+</body>
+</html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ def build_test_app(monkeypatch, *, extra_db_targets=(), oauth_clients=None):
     monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
 
     flask_app = app_module.create_app()
-    flask_app.config.update(TESTING=True)
+    flask_app.config.update(TESTING=True, MAIL_SUPPRESS_SEND=True)
     flask_app._db_initialized = True
     return flask_app, test_db
 

--- a/tests/test_email_verification.py
+++ b/tests/test_email_verification.py
@@ -99,3 +99,26 @@ def test_registration_creates_unverified_user(monkeypatch):
     assert user["is_verified"] is False
     assert user["verification_token"] is not None
     assert len(user["verification_token"]) > 0
+
+
+def test_resend_verification_updates_token(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    monkeypatch.setattr(auth_routes, "db", test_db)
+
+    _create_user(test_db, "resend@example.com", "Password123!", is_verified=False, verification_token="old-token")
+
+    with flask_app.test_client() as client:
+        headers = csrf_headers(client)
+        response = client.post(
+            "/resend-verification",
+            data={"email": "resend@example.com"},
+            headers=headers,
+        )
+
+    assert response.status_code == 302
+    assert response.location == "/login"
+
+    user = test_db.user.find_one({"email": "resend@example.com"})
+    assert user is not None
+    assert user["verification_token"] != "old-token"
+    assert user["verification_token"]

--- a/tests/test_email_verification.py
+++ b/tests/test_email_verification.py
@@ -1,0 +1,101 @@
+import app.auth.routes as auth_routes
+from conftest import build_test_app, csrf_headers
+from app.extensions import bcrypt
+
+
+def _create_user(test_db, email, password, is_verified=True, verification_token=""):
+    test_db.user.insert_one(
+        {
+            "name": "Test User",
+            "email": email,
+            "password": bcrypt.generate_password_hash(password).decode("utf-8"),
+            "progress": {},
+            "is_admin": False,
+            "is_verified": is_verified,
+            "verification_token": verification_token,
+        }
+    )
+
+
+def test_login_blocked_when_unverified(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    monkeypatch.setattr(auth_routes, "db", test_db)
+    
+    _create_user(test_db, "unverified@example.com", "Password123!", is_verified=False)
+
+    with flask_app.test_client() as client:
+        headers = csrf_headers(client)
+        response = client.post(
+            "/login",
+            data={"email": "unverified@example.com", "password": "Password123!"},
+            headers=headers,
+        )
+
+    assert response.status_code == 302
+    assert response.location == "/login"
+    
+    with client.session_transaction() as session:
+        flashes = session.get("_flashes", [])
+        assert any(b"Please verify your email" in msg[1].encode('utf-8') for msg in flashes)
+
+
+def test_login_success_when_verified(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    monkeypatch.setattr(auth_routes, "db", test_db)
+    
+    _create_user(test_db, "verified@example.com", "Password123!", is_verified=True)
+
+    with flask_app.test_client() as client:
+        headers = csrf_headers(client)
+        response = client.post(
+            "/login",
+            data={"email": "verified@example.com", "password": "Password123!"},
+            headers=headers,
+        )
+
+    assert response.status_code == 302
+    assert response.location == "/"
+    
+    
+def test_verify_email_route(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    monkeypatch.setattr(auth_routes, "db", test_db)
+    
+    _create_user(test_db, "unverified@example.com", "Password123!", is_verified=False, verification_token="test-token")
+
+    with flask_app.test_client() as client:
+        response = client.get("/verify-email/test-token")
+        
+    assert response.status_code == 302
+    assert response.location == "/login"
+    
+    user = test_db.user.find_one({"email": "unverified@example.com"})
+    assert user["is_verified"] is True
+    assert "verification_token" not in user
+
+
+def test_registration_creates_unverified_user(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    monkeypatch.setattr(auth_routes, "db", test_db)
+    
+    with flask_app.test_client() as client:
+        headers = csrf_headers(client)
+        response = client.post(
+            "/register",
+            data={
+                "name": "New User",
+                "email": "newuser@example.com",
+                "password": "Password123!",
+                "confirm_password": "Password123!"
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 302
+    assert response.location == "/login"
+
+    user = test_db.user.find_one({"email": "newuser@example.com"})
+    assert user is not None
+    assert user["is_verified"] is False
+    assert user["verification_token"] is not None
+    assert len(user["verification_token"]) > 0


### PR DESCRIPTION
## Summary

This PR introduces a mandatory email verification step for new users registering through the local sign-up flow to resolve Issue #35.

Previously, users were able to sign up and log in immediately without validating their email addresses. This update blocks unverified accounts from logging in until they confirm ownership of their email address via a secure link.

Fixes #35

---

## Changes Made

- **Database:** Updated the user creation logic to include `is_verified` (defaults to `False`) and `verification_token` fields. Existing data logic (like OAuth or previously created accounts) is preserved via `user_doc.get("is_verified", True)` fallback.
- **Flask-Mail Integration:** Added `flask-mail` to `requirements.txt` and configured SMTP settings via environment variables.
- **New Route:** Added `GET /verify-email/<token>` to validate tokens, update the user to `is_verified: True`, and clear the token.
- **Login Protection:** Secured the `/login` route to block access if `is_verified` is explicitly `False`, with a descriptive flash message.
- **Dev Fallback:** If SMTP env vars are not set, the verification URL is printed to the terminal so local development is never blocked.
- **Template:** Added `verify_email.html` confirming email dispatch with user instructions.
- **Tests:** Added `test_email_verification.py` covering unverified login blocking, successful registration, and token redemption.

---

## How to Test Locally

**Without SMTP (Dev mode):**
1. Run `python run.py`
2. Go to `/register` and create a new account
3. Try to log in - you should be blocked with: *"Please verify your email before logging in. Check your inbox."*
4. Check the terminal for: `[DEV] Verify URL: http://localhost:5000/verify-email/<token>`
5. Open that URL - you should be redirected to `/login` with a success flash
6. Log in - should now work

**With SMTP (Prod mode):**
1. Add `MAIL_USERNAME` and `MAIL_PASSWORD` (Gmail App Password) to your `.env`
2. Register with a real email and check your inbox for the verification link

---

## Checklist

- [x] Tested locally (registration, login block, token verification, expired token)
- [x] Dev fallback implemented for environments without SMTP credentials
- [x] Backward compatible — existing users and OAuth accounts unaffected
- [x] Unit tests added for auth flow
- [x] Verification email HTML template added