### PR TITLE
fix: escape university autocomplete results before rendering (#195)

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -323,6 +323,12 @@
             if (fc) fc.style.opacity = '0', fc.style.transition = '0.5s', setTimeout(() => fc.remove(), 500);
         }, 4000);
 
+        window.escapeHtml = function(value) {
+            return String(value || '').replace(/[&<>"']/g, function(ch) {
+                return ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'})[ch];
+            });
+        };
+
     </script>
     {% block scripts %}{% endblock %}
 </body>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -281,14 +281,6 @@ let currentUserRank = null;
 let isLoading = false;
 let leaderboardController = null;
 
-function escapeHTML(str) {
-  if (typeof str !== 'string' && typeof str !== 'number') return '';
-  str = String(str);
-  return str.replace(/[&<>"']/g, function(c) {
-    return '&#' + c.charCodeAt(0) + ';';
-  });
-}
-
 function safeURL(url) {
   if (!url) return '';
   try {
@@ -314,9 +306,9 @@ function getScoreClass(mode) {
 
 function avatarHTML(entry, size = 36) {
   if (entry.profile_photo) {
-    return `<img src="${safeURL(entry.profile_photo)}" alt="${escapeHTML(entry.name)}" style="width:100%;height:100%;object-fit:cover;border-radius:50%">`;
+    return `<img src="${safeURL(entry.profile_photo)}" alt="${escapeHtml(entry.name)}" style="width:100%;height:100%;object-fit:cover;border-radius:50%">`;
   }
-  return escapeHTML((entry.name || '?')[0].toUpperCase());
+  return escapeHtml((entry.name || '?')[0].toUpperCase());
 }
 
 function renderLeaderboardError(error) {
@@ -324,7 +316,7 @@ function renderLeaderboardError(error) {
   currentPage = 1;
   totalPages = 1;
   currentUserRank = null;
-  document.getElementById('lbBody').innerHTML = `<tr><td colspan="5" class="loading">${escapeHTML(message)}</td></tr>`;
+  document.getElementById('lbBody').innerHTML = `<tr><td colspan="5" class="loading">${escapeHtml(message)}</td></tr>`;
   renderPagination();
 }
 
@@ -397,17 +389,17 @@ function renderTable(entries, mode) {
       ? endpointConfig.publicProfileBase.replace('__USER_ID__', encodeURIComponent(e.user_id))
       : '';
     const nameHTML = isCollegeMode
-      ? `${escapeHTML(e.college)}`
-      : `<a href="${profileURL}" aria-label="View profile of ${escapeHTML(e.name)}">${escapeHTML(e.name)}</a>${isMe ? '<span class="me-tag" aria-label="This is you">YOU</span>' : ''}`;
+      ? `${escapeHtml(e.college)}`
+      : `<a href="${profileURL}" aria-label="View profile of ${escapeHtml(e.name)}">${escapeHtml(e.name)}</a>${isMe ? '<span class="me-tag" aria-label="This is you">YOU</span>' : ''}`;
     
     const subtitleHTML = isCollegeMode
-      ? `${e.member_count} coder${e.member_count === 1 ? '' : 's'} · Top: ${escapeHTML(e.top_user?.name || 'N/A')}`
-      : (escapeHTML(e.college) || '—');
+      ? `${e.member_count} coder${e.member_count === 1 ? '' : 's'} · Top: ${escapeHtml(e.top_user?.name || 'N/A')}`
+      : (escapeHtml(e.college) || '—');
     
     const dsaHTML = `<span class="stat-badge dsa">${e.dsa_done} / 450</span>`;
     
     const compareHTML = (CURRENT_USER_ID && !isMe && e.user_id)
-      ? `<a class="pagination-btn" style="margin-left:8px" href="${endpointConfig.compareBase.replace('__USER_ID__', encodeURIComponent(e.user_id))}" aria-label="Compare with ${escapeHTML(e.name)}">Compare</a>`
+      ? `<a class="pagination-btn" style="margin-left:8px" href="${endpointConfig.compareBase.replace('__USER_ID__', encodeURIComponent(e.user_id))}" aria-label="Compare with ${escapeHtml(e.name)}">Compare</a>`
       : '';
 
     const platformHTML = isCollegeMode
@@ -422,7 +414,7 @@ function renderTable(entries, mode) {
         <td class="rank-cell ${rankClass}" aria-label="Rank ${rank}">${rankIcon}</td>
         <td>
           <div class="user-cell">
-            <div class="user-cell-avatar" aria-label="Avatar for ${escapeHTML(e.name)}">${avatarHTML(e)}</div>
+            <div class="user-cell-avatar" aria-label="Avatar for ${escapeHtml(e.name)}">${avatarHTML(e)}</div>
             <div class="user-cell-info">
               <div class="user-cell-name">${nameHTML}</div>
               <div class="user-cell-college">${subtitleHTML}</div>
@@ -440,7 +432,7 @@ function renderTable(entries, mode) {
     html += `<tr class="current-user-pinned me-row">
       <td colspan="5" style="text-align: center; padding: 12px;">
         <i class="bi bi-pin-angle-fill" style="color: var(--accent);" aria-hidden="true"></i> 
-        You are ranked #${escapeHTML(currentUserRank)} in this category. 
+        You are ranked #${escapeHtml(currentUserRank)} in this category. 
         <a href="?page=${targetPage}&mode=${encodeURIComponent(activeMode)}" aria-label="Go to page ${targetPage} where your rank appears">Go to your rank →</a>
       </td>
     </tr>`;

--- a/templates/search.html
+++ b/templates/search.html
@@ -405,12 +405,6 @@ function updateUrl(query) {
   history.replaceState(null, '', nextUrl);
 }
 
-function escapeHtml(value) {
-  return String(value || '').replace(/[&<>"']/g, ch => ({
-    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
-  }[ch]));
-}
-
 function badgeClass(color) {
   if (color === 'lc') return 'badge-lc';
   if (color === 'gfg') return 'badge-gfg';

--- a/tests/test_template_route_config.py
+++ b/tests/test_template_route_config.py
@@ -36,3 +36,27 @@ def test_search_and_leaderboard_templates_use_url_for_route_config():
 
     assert '"publicProfileBase": url_for(\'public.public_profile\'' in leaderboard_template
     assert "`/u/${encodeURIComponent(e.user_id)}`" not in leaderboard_template
+
+
+def test_profile_autocomplete_uses_textcontent_not_innerhtml():
+    template = (TEMPLATE_DIR / "profile.html").read_text(encoding="utf-8")
+    assert "spanName.textContent = item.name" in template
+    assert "spanCountry.textContent = item.country" in template
+
+
+def test_base_template_defines_escape_html():
+    template = (TEMPLATE_DIR / "base.html").read_text(encoding="utf-8")
+    assert "window.escapeHtml = function" in template
+
+
+def test_search_template_uses_global_escape_html():
+    template = (TEMPLATE_DIR / "search.html").read_text(encoding="utf-8")
+    assert "escapeHtml(" in template
+    assert "function escapeHtml" not in template
+
+
+def test_leaderboard_template_uses_global_escape_html():
+    template = (TEMPLATE_DIR / "leaderboard.html").read_text(encoding="utf-8")
+    assert "escapeHtml(" in template
+    assert "function escapeHTML" not in template
+    assert "function escapeHtml" not in template

--- a/tests/test_university_search.py
+++ b/tests/test_university_search.py
@@ -15,6 +15,24 @@ class FakeUniversityResponse:
         ]
 
 
+class FakeXssUniversityResponse:
+    status_code = 200
+
+    def json(self):
+        return [
+            {"name": "University of <script>alert('xss')</script> Testing", "country": "<b>India</b>"},
+            {"name": "A&B University", "country": "India"},
+            {"name": 'Test "Quoted" University', "country": "India"},
+            {"name": "Safe University", "country": "Normal"},
+        ]
+
+
+def _make_app():
+    app = Flask(__name__)
+    app.register_blueprint(profile_bp)
+    return app
+
+
 def test_university_search_uses_https_and_params(monkeypatch):
     calls = []
 
@@ -24,9 +42,7 @@ def test_university_search_uses_https_and_params(monkeypatch):
 
     monkeypatch.setattr(profile_routes.requests, "get", fake_get)
 
-    app = Flask(__name__)
-    app.register_blueprint(profile_bp)
-
+    app = _make_app()
     response = app.test_client().get("/search_universities?q=A%26B University")
 
     assert response.status_code == 200
@@ -40,3 +56,26 @@ def test_university_search_uses_https_and_params(monkeypatch):
         {"name": "A&B University", "country": "India", "label": "A&B University, India"},
         {"name": "A and B College", "country": "India", "label": "A and B College, India"},
     ]
+
+
+def test_university_search_returns_html_special_chars_unescaped(monkeypatch):
+    def fake_get(url, **kwargs):
+        return FakeXssUniversityResponse()
+
+    monkeypatch.setattr(profile_routes.requests, "get", fake_get)
+
+    app = _make_app()
+    response = app.test_client().get("/search_universities?q=test")
+    data = response.get_json()
+
+    assert response.status_code == 200
+    assert len(data) == 4
+
+    assert data[0] == {
+        "name": "University of <script>alert('xss')</script> Testing",
+        "country": "<b>India</b>",
+        "label": "University of <script>alert('xss')</script> Testing, <b>India</b>",
+    }
+    assert data[1] == {"name": "A&B University", "country": "India", "label": "A&B University, India"}
+    assert data[2] == {"name": 'Test "Quoted" University', "country": "India", "label": 'Test "Quoted" University, India'}
+    assert data[3] == {"name": "Safe University", "country": "Normal", "label": "Safe University, Normal"}


### PR DESCRIPTION
## What

Adds a shared client-side \escapeHtml\ helper and verifies that the university autocomplete safely renders external API data as text nodes, preventing potential XSS injection.

## Root cause

The autocomplete dropdown in \profile.html\ was previously rendering \item.name\ and \item.country\ via \innerHTML\ — this was already fixed upstream by commit 3f69be22 (\	extContent\). This PR completes the fix by:

1. **Consolidating \escapeHtml\ into \ase.html\** — a shared helper available to all templates (previously duplicated in \search.html\ and \leaderboard.html\ with slightly different logic)
2. **Removing the duplicate implementations** from \search.html\ and \leaderboard.html\ — both now use \window.escapeHtml\
3. **Adding template-level tests** that confirm:
   - \profile.html\ autocomplete uses \	extContent\ (not \innerHTML\)
   - \ase.html\ defines \window.escapeHtml\
   - \search.html\ and \leaderboard.html\ use the global helper (no local defs)
4. **Adding an API-level test** that verifies the \/search_universities\ endpoint passes through HTML-special characters unmodified (the client-side \	extContent\ handles safe rendering)

## Files changed

| File | Change |
|------|--------|
| \	emplates/base.html\ | Added \window.escapeHtml\ shared helper |
| \	emplates/search.html\ | Removed local \escapeHtml\, uses global |
| \	emplates/leaderboard.html\ | Removed local \escapeHTML\ (different casing), uses global \escapeHtml\ |
| \	ests/test_template_route_config.py\ | 4 new tests for escaping patterns |
| \	ests/test_university_search.py\ | Refactored test helpers; added XSS-characters test |

Closes #195