### PR TITLE
fix: add type and length validation for notes field in update_question endpoint

### DIFF
--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -366,7 +366,12 @@ def update_question(question_id):
             f"'{question.get('problem', 'Question')}'"
         )
     if "notes" in data:
-        update_fields[f"progress.{question_id}.notes"] = data["notes"]
+        notes_value = data["notes"]
+        if not isinstance(notes_value, str):
+            return jsonify({"success": False, "error": "notes must be a string"}), 400
+        if len(notes_value) > 2000:
+            return jsonify({"success": False, "error": "notes must be at most 2000 characters"}), 400
+        update_fields[f"progress.{question_id}.notes"] = notes_value
         message = f"📝 Notes saved for '{question.get('problem', 'Question')}'!"
 
     if update_fields:


### PR DESCRIPTION
## Summary
Fixes #754 

## Problem
The `notes` field in `/update_question/<question_id>` accepted and stored 
user input with no validation — any type, any length written directly to MongoDB.

Every other field in the same endpoint was validated:
- `done`, `bookmark`, `skipped` → checked as boolean
- `revision_status` → checked against `REVISION_STATUSES` allowlist

`notes` was the only field that skipped this pattern entirely.

## Fix
Added two validation checks in `app/tracker/routes.py`:
1. Reject non-string values with `400 Bad Request`
2. Enforce a 2000 character limit consistent with other text fields 
   in `profile_validation.py`

## Changes
- `app/tracker/routes.py` — added type and length validation for `notes` field

## Type of Change
- [x] Bug fix

I am a contributor under both GSSoC 2026 and NSoC. Could you please add 
both `gssoc26` and `nsoc26` labels to this PR?