### PR TITLE
fix(auth): add @login_required to tracker index and topic routes (#707)

### DIFF
--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -68,6 +68,7 @@ CSV_EXPORT_QUESTION_PROJECTION = {
 ALL_NOTES_QUESTION_PROJECTION = {"problem": 1, "topic": 1}
 
 @tracker_bp.route("/")
+@login_required
 def index():
     pre = current_app.config.get("_PRECOMPUTED")
     if pre:
@@ -110,6 +111,7 @@ def index():
 
 
 @tracker_bp.route("/topic/<topic_id>")
+@login_required
 def topic(topic_id):
     try:
         topic_id_obj = ObjectId(topic_id)


### PR DESCRIPTION
## What
Adds `@login_required` to the two main tracker pages that render user-specific progress data:

| Route | Before | After |
|-------|--------|-------|
| `/` (tracker dashboard) | unprotected | `@login_required` |
| `/topic/<topic_id>` | unprotected | `@login_required` |

## Why
The issue reported `/update_question/<id>` and `/delete_account` as missing `@login_required` — those are **already protected** in the current codebase. This PR extends the same protection to the main tracker pages that show personal progress data.

## Changes
- **`app/tracker/routes.py`** — added `@login_required` decorator to `index()` and `topic()` (the import already existed)
- Unauthenticated users are redirected to the login page (already configured via `login_manager.login_view = "auth.login"`)

Closes #707
