### PR TITLE
perf: tune profile card HTTP cache to 5 min with stale-while-revalidate (#690)

### DIFF
--- a/app/profile/card_service.py
+++ b/app/profile/card_service.py
@@ -15,6 +15,7 @@ from streaks import compute_streak
 
 
 CACHE_TTL = 3600
+CARD_HTTP_MAX_AGE = 300
 CACHE_MAXSIZE = 500
 card_cache = TTLCache(maxsize=CACHE_MAXSIZE, ttl=CACHE_TTL)
 _cache_lock = Lock()

--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -8,7 +8,7 @@ from flask_login import current_user, login_required
 from app.extensions import cache, db, limiter
 from app.leaderboard.cache import invalidate_leaderboard_cache
 from app.leaderboard.service import build_leaderboard_data, get_user_rank_by_c_score
-from app.profile.card_service import CACHE_TTL, get_public_card_image, warm_public_card_cache
+from app.profile.card_service import CARD_HTTP_MAX_AGE, CACHE_TTL, get_public_card_image, warm_public_card_cache
 from app.profile.certificate_service import generate_milestone_certificate
 from app.profile.sync_service import (
     build_sync_platforms_response,
@@ -252,7 +252,7 @@ def public_card(user_id):
     try:
         img_io.seek(0)
         response = send_file(img_io, mimetype="image/png")
-        response.headers["Cache-Control"] = f"public, max-age={CACHE_TTL}"
+        response.headers["Cache-Control"] = f"public, max-age={CARD_HTTP_MAX_AGE}, stale-while-revalidate=86400"
         response.set_etag(etag)
         if last_modified is not None:
             response.last_modified = last_modified


### PR DESCRIPTION
## What
Improves the profile card HTTP caching strategy by separating the in-memory cache TTL from the HTTP Cache-Control header, and reducing browser cache to 5 minutes with stale-while-revalidate.

## Changes

### `app/profile/card_service.py`
- Added `CARD_HTTP_MAX_AGE = 300` — dedicated constant for the HTTP Cache-Control max-age
- `CACHE_TTL = 3600` unchanged — still controls the in-memory TTLCache expiry (server-side efficiency)

### `app/profile/routes.py`
- Import `CARD_HTTP_MAX_AGE` from card_service
- `Cache-Control` header changed:
  - **Before:** `public, max-age=3600` (1 hour, tied to in-memory TTL)
  - **After:** `public, max-age=300, stale-while-revalidate=86400`
    - Browsers revalidate every 5 minutes (sooner → fresher cards)
    - In-memory cache still keeps images for 1 hour (efficient)
    - `stale-while-revalidate=86400` — stale content served while revalidating in background (better UX)

## Why
The original issue asked for a `Cache-Control: max-age=300` header. The existing code used the same constant (`CACHE_TTL = 3600`) for both in-memory and HTTP caching, conflating two concerns. This PR separates them, allowing the server to cache efficiently (1h TTL) while asking browsers to revalidate sooner (5 min).

Closes #690
