### PR TITLE
fix: add dedicated CSRF token endpoint for logout and use single-use tokens

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -219,12 +219,22 @@ def register():
 @login_required
 def logout():
     token = request.form.get("csrf_token", "")
-    expected = session.get("csrf_token", "")
+    expected = session.pop("logout_csrf_token", None)
     if not token or not expected or token != expected:
         abort(403)
 
     logout_user()
     return redirect(url_for("auth.login"))
+
+
+@auth_bp.route("/logout/token", methods=["GET"])
+@login_required
+def logout_token():
+    """Generate and return a CSRF token for the logout form."""
+    token = secrets.token_hex(32)
+    session["logout_csrf_token"] = token
+    from flask import jsonify
+    return jsonify({"csrf_token": token})
 
 
 @auth_bp.route("/delete_account", methods=["POST"])


### PR DESCRIPTION
Fixes #229 - Adds a `/logout/token` endpoint to generate CSRF tokens for the logout form, and uses `session.pop()` for single-use token consumption to prevent CSRF replay attacks. Previously logout CSRF tokens were reused from a generic session key without a dedicated generation endpoint.