### PR TITLE
feat(admin): add question sheet import with preview and validation (#276)

### DIFF
--- a/app/admin/import_service.py
+++ b/app/admin/import_service.py
@@ -1,0 +1,190 @@
+import csv
+import io
+import json
+
+from bson import ObjectId
+from flask import current_app
+
+from app.extensions import db
+from app.utils import question_editorial_links
+
+VALID_DIFFICULTIES = {"Easy", "Medium", "Hard"}
+
+
+def _parse_json(raw):
+    data = json.loads(raw)
+    if not isinstance(data, list):
+        raise ValueError("JSON must be a list of topic objects")
+    for topic in data:
+        if not isinstance(topic, dict):
+            raise ValueError(f"Expected a topic object, got {type(topic).__name__}")
+        if "topicName" not in topic or "questions" not in topic:
+            raise ValueError(f"Topic object missing 'topicName' or 'questions': {topic.get('topicName', '?')}")
+        if not isinstance(topic["questions"], list):
+            raise ValueError(f"Topic '{topic['topicName']}' questions must be a list")
+    return data
+
+
+def _parse_csv(raw):
+    reader = csv.DictReader(io.StringIO(raw))
+    topics_map = {}
+    for row in reader:
+        topic_name = (row.get("Topic") or "").strip()
+        if not topic_name:
+            continue
+        if topic_name not in topics_map:
+            topics_map[topic_name] = {
+                "topicName": topic_name,
+                "position": _int_or(row.get("Position"), 0),
+                "questions": [],
+            }
+        topics_map[topic_name]["questions"].append({
+            "Problem": (row.get("Problem") or "").strip(),
+            "URL": (row.get("URL") or "").strip(),
+            "URL2": (row.get("URL2") or "").strip(),
+            "difficulty": (row.get("Difficulty") or "Medium").strip(),
+        })
+    if not topics_map:
+        raise ValueError("CSV must have at least one row with a Topic column")
+    return list(topics_map.values())
+
+
+def _int_or(value, default):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def parse_import_data(content, filename):
+    if filename.lower().endswith(".csv"):
+        return _parse_csv(content)
+    return _parse_json(content)
+
+
+def validate_import_data(parsed):
+    errors = []
+    seen_topics = {}
+    for ti, topic in enumerate(parsed):
+        tname = topic.get("topicName", "").strip()
+        if not tname:
+            errors.append(f"Topic #{ti + 1}: missing 'topicName'")
+            continue
+        key = tname.lower()
+        if key in seen_topics:
+            errors.append(f"Duplicate topic: '{tname}' (same as #{seen_topics[key] + 1})")
+        seen_topics[key] = ti
+
+        position = _int_or(topic.get("position"), 0)
+        if position < 0:
+            errors.append(f"Topic '{tname}': position must be non-negative")
+
+        seen_questions = {}
+        for qi, question in enumerate(topic.get("questions", [])):
+            problem = (question.get("Problem") or "").strip()
+            url = (question.get("URL") or "").strip()
+            if not problem:
+                errors.append(f"Topic '{tname}', question #{qi + 1}: missing 'Problem'")
+            if not url:
+                errors.append(f"Topic '{tname}', question #{qi + 1}: missing 'URL'")
+            diff = question.get("difficulty", "Medium")
+            if diff not in VALID_DIFFICULTIES:
+                errors.append(f"Topic '{tname}', '{problem}': invalid difficulty '{diff}' (must be Easy/Medium/Hard)")
+
+            qkey = f"{problem.lower()}|{url.lower()}"
+            if qkey in seen_questions:
+                errors.append(f"Topic '{tname}': duplicate question '{problem}' ({url})")
+            seen_questions[qkey] = qi
+
+    return errors
+
+
+def preview_import(parsed):
+    new_topics = 0
+    existing_topics = 0
+    new_questions = 0
+    existing_questions = 0
+    updated_questions = 0
+
+    for topic in parsed:
+        tname = topic["topicName"].strip()
+        existing_topic = db.topic.find_one({"name": tname}, {"_id": 1})
+        if existing_topic:
+            existing_topics += 1
+            topic_id = existing_topic["_id"]
+        else:
+            new_topics += 1
+            topic_id = None
+
+        for question in topic.get("questions", []):
+            problem = (question.get("Problem") or "").strip()
+            url = (question.get("URL") or "").strip()
+            if not problem or not url:
+                continue
+
+            if topic_id:
+                existing_q = db.question.find_one(
+                    {"topic": topic_id, "problem": problem, "url": url},
+                    {"_id": 1, "difficulty": 1},
+                )
+                if existing_q:
+                    if existing_q.get("difficulty") != question.get("difficulty", "Medium"):
+                        updated_questions += 1
+                    else:
+                        existing_questions += 1
+                else:
+                    new_questions += 1
+            else:
+                new_questions += 1
+
+    return {
+        "new_topics": new_topics,
+        "existing_topics": existing_topics,
+        "new_questions": new_questions,
+        "existing_questions": existing_questions,
+        "updated_questions": updated_questions,
+    }
+
+
+def apply_import(parsed):
+    upserted_topic_ids = set()
+
+    for topic in parsed:
+        tname = topic["topicName"].strip()
+        position = _int_or(topic.get("position"), 0)
+
+        db.topic.update_one(
+            {"name": tname},
+            {"$set": {"position": position}},
+            upsert=True,
+        )
+        topic_doc = db.topic.find_one({"name": tname})
+        if not topic_doc:
+            continue
+        topic_id = topic_doc["_id"]
+        upserted_topic_ids.add(str(topic_id))
+
+        for question in topic.get("questions", []):
+            problem = (question.get("Problem") or "").strip()
+            url = (question.get("URL") or "").strip()
+            if not problem or not url:
+                continue
+
+            difficulty = question.get("difficulty", "Medium")
+            set_fields = {
+                "url2": question.get("URL2", ""),
+                "editorial_links": question_editorial_links(question),
+                "difficulty": difficulty,
+            }
+            if "hints" in question:
+                set_fields["hints"] = question["hints"]
+
+            db.question.update_one(
+                {"topic": topic_id, "problem": problem, "url": url},
+                {"$set": set_fields},
+                upsert=True,
+            )
+
+    config = current_app.config
+    if "_PRECOMPUTED" in config:
+        del config["_PRECOMPUTED"]

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -14,6 +14,8 @@ from app.extensions import cache, db
 from app.leaderboard.cache import invalidate_leaderboard_cache
 from app.profile.sync_service import clear_profile_caches
 
+from .import_service import apply_import, parse_import_data, preview_import, validate_import_data
+
 
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
@@ -186,6 +188,66 @@ def recent_logs():
             "page": log_page,
             "page_size": log_page_size,
         }
+    )
+
+
+@admin_bp.route("/import", methods=["GET", "POST"])
+@login_required
+@admin_required
+def import_sheet():
+    if request.method == "GET":
+        return render_template("admin/import.html")
+
+    confirm = request.form.get("confirm") == "yes"
+
+    if confirm:
+        raw_content = request.form.get("raw_content", "")
+        filename = request.form.get("file", "import.json")
+        if not raw_content:
+            flash("Session expired. Please re-upload the file.", "danger")
+            return render_template("admin/import.html")
+        try:
+            parsed = parse_import_data(raw_content, filename)
+        except (ValueError, json.JSONDecodeError) as exc:
+            flash(f"Parse error: {exc}", "danger")
+            return render_template("admin/import.html")
+    else:
+        file = request.files.get("file")
+        if not file or not file.filename:
+            flash("Please select a file to upload.", "danger")
+            return render_template("admin/import.html")
+        filename = file.filename
+        try:
+            content = file.read().decode("utf-8-sig")
+        except UnicodeDecodeError:
+            flash("File must be UTF-8 encoded.", "danger")
+            return render_template("admin/import.html")
+        try:
+            parsed = parse_import_data(content, filename)
+        except (ValueError, json.JSONDecodeError) as exc:
+            flash(f"Parse error: {exc}", "danger")
+            return render_template("admin/import.html")
+
+    validation_errors = validate_import_data(parsed)
+    if validation_errors:
+        for err in validation_errors:
+            flash(err, "danger")
+        return render_template("admin/import.html")
+
+    if confirm:
+        apply_import(parsed)
+        total_q = sum(len(t.get("questions", [])) for t in parsed)
+        total_t = len(parsed)
+        flash(f"Imported {total_t} topics with {total_q} questions.", "success")
+        return redirect(url_for("admin.dashboard"))
+
+    preview = preview_import(parsed)
+    return render_template(
+        "admin/import.html",
+        preview=preview,
+        filename=filename,
+        raw_content=content,
+        topics=parsed,
     )
 
 

--- a/templates/admin/import.html
+++ b/templates/admin/import.html
@@ -1,0 +1,113 @@
+{% extends "base.html" %}
+{% block content %}
+<style>
+.admin-header { display:flex; justify-content:space-between; align-items:flex-start; gap:12px; margin-bottom:22px; flex-wrap:wrap; }
+.admin-title { font-size:1.7rem; font-weight:800; letter-spacing:-0.02em; }
+.admin-subtitle { color:var(--text-secondary); font-size:0.92rem; }
+.import-zone { background:var(--bg-card); border:1px solid var(--border-color); border-radius:14px; padding:24px; margin-bottom:20px; }
+.sheet-preview { margin-top:20px; }
+.sheet-preview table { width:100%; border-collapse:collapse; font-size:0.88rem; }
+.sheet-preview th { text-align:left; padding:8px 10px; border-bottom:2px solid var(--border-color); font-weight:600; }
+.sheet-preview td { padding:8px 10px; border-bottom:1px solid var(--border-color); vertical-align:top; }
+.topic-row td { background:rgba(255,107,0,0.04); font-weight:700; }
+.preview-stats { display:grid; grid-template-columns:repeat(auto-fit,minmax(140px,1fr)); gap:12px; margin-bottom:20px; }
+.preview-stat { background:var(--bg-card); border:1px solid var(--border-color); border-radius:10px; padding:14px; text-align:center; }
+.preview-stat .value { font-size:1.4rem; font-weight:800; }
+.preview-stat .label { font-size:0.78rem; color:var(--text-secondary); margin-top:2px; }
+.preview-stat.new .value { color:#22c55e; }
+.preview-stat.update .value { color:#f59e0b; }
+.preview-stat.existing .value { color:var(--text-secondary); }
+.btn { display:inline-flex; align-items:center; gap:6px; padding:8px 18px; border-radius:8px; font-weight:600; font-size:0.88rem; cursor:pointer; border:none; text-decoration:none; }
+.btn-primary { background:#ff6b00; color:#fff; }
+.btn-primary:hover { background:#e65c00; }
+.btn-mono { background:var(--bg-card); color:var(--text-primary); border:1px solid var(--border-color); }
+.btn-mono:hover { background:var(--border-color); }
+.btn-danger { background:#dc2626; color:#fff; }
+.btn-danger:hover { background:#b91c1c; }
+.action-row { display:flex; gap:10px; margin-top:18px; flex-wrap:wrap; }
+.file-input { padding:8px 12px; border:1px solid var(--border-color); border-radius:8px; background:var(--bg-card); color:var(--text-primary); font-size:0.88rem; }
+</style>
+
+<div class="admin-header">
+  <div>
+    <div class="admin-title"><a href="{{ url_for('admin.dashboard') }}" style="color:var(--text-secondary);text-decoration:none">Admin</a> / Import sheet</div>
+    <div class="admin-subtitle">Upload a JSON or CSV file to add or update questions</div>
+  </div>
+</div>
+
+{% if not preview %}
+<div class="import-zone">
+  <form method="POST" enctype="multipart/form-data">
+    <p style="margin:0 0 12px 0;font-weight:600">Select file</p>
+    <p style="font-size:0.85rem;color:var(--text-secondary);margin:0 0 14px 0">
+      JSON format: Array of <code>{ topicName, position, questions: [{ Problem, URL, URL2?, difficulty?, hints? }] }</code><br>
+      CSV format: Columns <code>Topic, Position, Problem, URL, URL2, Difficulty</code>
+    </p>
+    <input type="file" name="file" accept=".json,.csv" class="file-input" required>
+    <div class="action-row">
+      <button type="submit" class="btn btn-primary">Upload & preview</button>
+      <a href="{{ url_for('admin.dashboard') }}" class="btn btn-mono">Cancel</a>
+    </div>
+  </form>
+</div>
+{% endif %}
+
+{% if preview %}
+<div class="preview-stats">
+  <div class="preview-stat new">
+    <div class="value">+{{ preview.new_topics }}</div>
+    <div class="label">New topics</div>
+  </div>
+  <div class="preview-stat existing">
+    <div class="value">{{ preview.existing_topics }}</div>
+    <div class="label">Existing topics</div>
+  </div>
+  <div class="preview-stat new">
+    <div class="value">+{{ preview.new_questions }}</div>
+    <div class="label">New questions</div>
+  </div>
+  <div class="preview-stat existing">
+    <div class="value">{{ preview.existing_questions }}</div>
+    <div class="label">Unchanged</div>
+  </div>
+  <div class="preview-stat update">
+    <div class="value">{{ preview.updated_questions }}</div>
+    <div class="label">Will update</div>
+  </div>
+</div>
+
+<div class="import-zone">
+  <p style="margin:0 0 12px 0;font-weight:600">Preview: {{ filename }}</p>
+  <div class="sheet-preview">
+    <table>
+      <thead>
+        <tr><th>Topic</th><th>Position</th><th>Problem</th><th>URL</th><th>Difficulty</th></tr>
+      </thead>
+      <tbody>
+        {% for topic in topics %}
+        <tr class="topic-row"><td colspan="5">{{ topic.topicName }}</td></tr>
+        {% for q in topic.questions %}
+        <tr>
+          <td></td>
+          <td>{{ topic.position }}</td>
+          <td>{{ q.Problem }}</td>
+          <td style="font-size:0.8rem;word-break:break-all">{{ q.URL }}</td>
+          <td>{{ q.difficulty }}</td>
+        </tr>
+        {% endfor %}
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <form method="POST" enctype="multipart/form-data">
+    <input type="hidden" name="file" value="{{ filename }}">
+    <input type="hidden" name="confirm" value="yes">
+    <textarea name="raw_content" style="display:none">{{ raw_content }}</textarea>
+    <div class="action-row">
+      <button type="submit" class="btn btn-primary">Confirm import</button>
+      <a href="{{ url_for('admin.import_sheet') }}" class="btn btn-mono">Choose another file</a>
+    </div>
+  </form>
+</div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## What
Adds an admin-only question sheet import flow — upload a JSON or CSV file with new or updated topics/questions, preview the changes, then confirm the upsert.

## Changes

### New: `app/admin/import_service.py`
- `parse_import_data(content, filename)` — parses JSON (array of `{topicName, position, questions}`) or CSV (columns: `Topic, Position, Problem, URL, URL2, Difficulty`)
- `validate_import_data(parsed)` — checks for missing topic/URL, invalid difficulty, duplicate topics and questions
- `preview_import(parsed)` — queries MongoDB to classify entries as new/existing/updated
- `apply_import(parsed)` — upserts topics and questions using the same pattern as `init_db()`, then invalidates `_PRECOMPUTED` cache

### New: `templates/admin/import.html`
- Upload form with format hints (JSON/CSV)
- Preview table showing all topics and questions
- Stats cards: new topics, existing topics, new questions, unchanged, will update
- Confirm / Cancel actions

### Modified: `app/admin/routes.py`
- Added `GET|POST /admin/import` route guarded by `@login_required` + `@admin_required`
- Two-step flow: upload → preview → confirm
- File content preserved across steps via hidden textarea (no session bloat)

## Usage
1. Go to `/admin/import`
2. Upload a `.json` or `.csv` file
3. Review the preview stats and table
4. Click "Confirm import" to upsert into MongoDB

Closes #276
