### PR TITLE
refactor: normalize button utility classes

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -895,6 +895,13 @@ body {
             width: 100%;
         }
 
+        .mt-8 {
+            margin-top: 8px;
+      }
+      .mt-12 {
+        margin-top: 12px;
+    }
+
         .pill-btn {
             display: flex;
             align-items: center;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -897,11 +897,19 @@ body {
 
         .mt-8 {
             margin-top: 8px;
-      }
-      .mt-12 {
-        margin-top: 12px;
-    }
+        }
+        .mt-12 {
+            margin-top: 12px;
+        }
 
+        .ui-btn-close {
+            background: none;
+            border: none;
+            color: var(--text-muted);
+            font-size: 1.2rem;
+            cursor: pointer;
+        }
+        
         .pill-btn {
             display: flex;
             align-items: center;

--- a/templates/_macros.html
+++ b/templates/_macros.html
@@ -3,7 +3,12 @@
   <div class="modal-bx" style="{{ box_style }}">
     <div style="{{ header_style }}">
       <h3 id="{{ title_id }}" style="margin-bottom:0">{{ title|safe }}</h3>
-      <button type="button" onclick="{{ close_action }}" style="background:none;border:none;color:var(--text-muted);font-size:1.2rem;cursor:pointer" aria-label="Close dialog">✕</button>
+      <button type="button"
+class="ui-btn-close"
+onclick="{{ close_action }}"
+aria-label="Close dialog">
+✕
+</button>
     </div>
     {{ caller() }}
   </div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -109,8 +109,12 @@
     <div class="meta-row"><i class="bi bi-geo-alt" style="color:var(--accent)" aria-hidden="true"></i> India</div>
     <div class="meta-row"><i class="bi bi-mortarboard" style="color:var(--info)" aria-hidden="true"></i> Computer Science</div>
     {% endif %}
-    <button class="ui-btn ui-btn-secondary ui-btn-block" onclick="openEditProfile()" style="margin-top:12px" aria-label="Edit your profile"><i class="bi bi-pencil-square" aria-hidden="true"></i> Edit Profile</button>
-    <button class="ui-btn ui-btn-danger ui-btn-block" onclick="openDeleteModal()" style="margin-top:8px" aria-label="Delete your account permanently"><i class="bi bi-trash3" aria-hidden="true"></i> Delete Account</button>
+    <button class="ui-btn ui-btn-secondary ui-btn-block mt-12"
+    onclick="openEditProfile()"
+    aria-label="Edit your profile"><i class="bi bi-pencil-square" aria-hidden="true"></i> Edit Profile</button>
+    <button class="ui-btn ui-btn-danger ui-btn-block mt-8"
+    onclick="openDeleteModal()"
+    aria-label="Delete your account permanently"><i class="bi bi-trash3" aria-hidden="true"></i> Delete Account</button>
   </div>
 
   <div class="card">
@@ -432,7 +436,11 @@
       </div>
       <div style="font-size:.72rem;color:var(--text-muted)">450 DSA Cracker • {{ 2026 }}</div>
     </div>
-    <button onclick="showToast('Profile card copied! 📋')" style="width:100%;margin-top:14px;padding:10px;background:var(--accent);border:none;border-radius:10px;color:#fff;font-weight:700;font-size:.85rem;cursor:pointer;font-family:inherit">Share Card</button>
+    <button
+    class="ui-btn ui-btn-primary ui-btn-block"
+    onclick="showToast('Profile card copied! 📋')">
+    Share Card
+    </button>
 {% endcall %}
 
 <!-- Edit Profile Modal -->
@@ -494,7 +502,11 @@
   <div class="modal-bx" style="max-width:500px">
     <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:20px">
       <h3 id="importModalTitle" style="margin-bottom:0"><i class="bi bi-upload" style="color:var(--accent)"></i> Import Progress</h3>
-      <button type="button" onclick="closeImportModal()" style="background:none;border:none;color:var(--text-muted);font-size:1.2rem;cursor:pointer" aria-label="Close dialog">✕</button>
+      <button type="button"
+      onclick="closeImportModal()"
+      style="background:none;border:none;color:var(--text-muted);font-size:1.2rem;cursor:pointer"
+      aria-label="Close dialog">✕
+    </button>
     </div>
     <p style="font-size:.8rem;color:var(--text-secondary);margin-bottom:15px">Upload a previously exported CSV or JSON progress backup file.</p>
     


### PR DESCRIPTION
# Description

This PR continues the button normalization effort by replacing one-off inline styles with reusable utility classes and improving consistency across templates.

### Changes made

* Added reusable spacing utility classes:

  * `.mt-8`
  * `.mt-12`
* Added reusable `.ui-btn-close` class for modal close buttons.
* Replaced inline margin styles for profile action buttons with utility classes.
* Replaced inline close button styles in `_macros.html` with the shared `.ui-btn-close` class.

Fixes #415

## Type of change

* [x] Refactor (non-breaking change which improves code structure)

# How Has This Been Tested?

* [x] Tested in Local

## Checklist

* [x] I have starred this repository.
* [x] My PR references the issue number.
* [x] I placed files in the correct location.

### Files modified

* `static/css/main.css`
* `templates/profile.html`
* `templates/_macros.html`

### Git summary

3 files changed, 29 insertions(+), 5 deletions(-)

## Contributor Confirmation

* [x] Code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] My changes generate no new warnings or errors
