### PR TITLE
feat: add solutionUrl and codeSnippet fields to questions (#270)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -191,6 +191,8 @@ def create_app(config_class=None):
                             "url2": question.get("URL2", ""),
                             "editorial_links": question_editorial_links(question),
                             "difficulty": difficulty,
+                            "solutionUrl": question.get("solutionUrl", ""),
+                            "codeSnippet": question.get("codeSnippet", ""),
                         }
                         if "hints" in question:
                             q_data["hints"] = question["hints"]
@@ -216,6 +218,8 @@ def create_app(config_class=None):
                     "url2": question.get("URL2", ""),
                     "editorial_links": question_editorial_links(question),
                     "difficulty": difficulty,
+                    "solutionUrl": question.get("solutionUrl", ""),
+                    "codeSnippet": question.get("codeSnippet", ""),
                 }
                 if "hints" in question:
                     set_fields["hints"] = question["hints"]
@@ -261,6 +265,8 @@ def create_app(config_class=None):
                 "url2": q.get("url2", ""),
                 "difficulty": q.get("difficulty", "Medium"),
                 "editorial_links": q.get("editorial_links", []),
+                "solutionUrl": q.get("solutionUrl", ""),
+                "codeSnippet": q.get("codeSnippet", ""),
             })
 
         topics_pc = [

--- a/app/search/service.py
+++ b/app/search/service.py
@@ -181,7 +181,7 @@ def search_dsa_questions(raw_query, limit=40, db_handle=None, filters=None, prog
         except InvalidId:
             return empty_payload()
 
-    projection = {"problem": 1, "topic": 1, "url": 1, "url2": 1, "editorial_links": 1}
+    projection = {"problem": 1, "topic": 1, "url": 1, "url2": 1, "editorial_links": 1, "solutionUrl": 1, "codeSnippet": 1}
     post_fetch_filters = bool(
         requested_platforms
         or difficulty_filter in DIFFICULTY_FILTERS

--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -48,6 +48,8 @@ TOPIC_PAGE_QUESTION_PROJECTION = {
     "url2": 1,
     "editorial_links": 1,
     "hints": 1,
+    "solutionUrl": 1,
+    "codeSnippet": 1,
 }
 TOPIC_NOTES_EXPORT_PROJECTION = {"problem": 1}
 QUESTION_STATUS_PROJECTION = {"problem": 1, "url": 1}
@@ -57,6 +59,8 @@ BOOKMARKS_QUESTION_PROJECTION = {
     "url": 1,
     "url2": 1,
     "editorial_links": 1,
+    "solutionUrl": 1,
+    "codeSnippet": 1,
 }
 CSV_EXPORT_QUESTION_PROJECTION = {
     "topic": 1,

--- a/static/js/topic.js
+++ b/static/js/topic.js
@@ -27,4 +27,17 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     });
   });
+
+  document.querySelectorAll(".show-code-btn").forEach((button) => {
+    button.addEventListener("click", () => {
+      const targetId = button.dataset.target;
+      const codeBlock = document.getElementById(targetId);
+      if (!codeBlock) return;
+      const isHidden = codeBlock.classList.contains("hidden");
+      codeBlock.classList.toggle("hidden");
+      button.innerHTML = isHidden
+        ? '<i class="bi bi-code" aria-hidden="true"></i> Hide Code'
+        : '<i class="bi bi-code" aria-hidden="true"></i> Show Code';
+    });
+  });
 });

--- a/templates/bookmarks.html
+++ b/templates/bookmarks.html
@@ -80,6 +80,8 @@
   .bookmarks-table-wrap .q-num {
     font-size: .78rem;
   }
+  .bookmarks-table-wrap .code-block { background: var(--bg-card); border: 1px solid var(--border-color); border-radius: 8px; padding: 12px 16px; margin-top: 6px; font-size: .75rem; overflow-x: auto; max-height: 250px; overflow-y: auto; white-space: pre-wrap; word-break: break-word; }
+  .bookmarks-table-wrap .code-block.hidden { display: none; }
 
   @media(max-width:640px) {
 
@@ -133,7 +135,17 @@
             {% if q.url2 %}<a href="{{ q.url2 }}" target="_blank" rel="noopener noreferrer"
               class="q-badge badge-link"><i class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{
               q.url2|platform_name }}</a>{% endif %}
+            {% if q.solutionUrl %}<a href="{{ q.solutionUrl }}" target="_blank" rel="noopener noreferrer"
+              class="q-badge badge-link"><i class="bi bi-code-slash" style="font-size:.7rem"></i> Solution</a>{% endif %}
           </div>
+          {% if q.codeSnippet %}
+          <div class="code-snippet-container" style="margin-top:6px;">
+            <button type="button" class="show-code-btn ui-btn ui-btn-secondary ui-btn-sm" data-target="code-block-{{ q_id_str }}" style="font-size:.73rem;">
+              <i class="bi bi-code" aria-hidden="true"></i> Show Code
+            </button>
+            <pre class="code-block hidden" id="code-block-{{ q_id_str }}"><code>{{ q.codeSnippet }}</code></pre>
+          </div>
+          {% endif %}
         </td>
         <td>
           <button class="action-icon bookmark-btn" data-id="{{ q_id_str }}" data-bookmarked="true"
@@ -246,6 +258,18 @@
         btn.innerHTML = `<i class="bi bi-journal-text" aria-hidden="true"></i> ${label}`;
         btn.setAttribute('aria-label', `${label} notes for this question`);
       }
+    });
+  });
+  document.querySelectorAll('.show-code-btn').forEach(btn => {
+    btn.addEventListener('click', function () {
+      const targetId = this.dataset.target;
+      const codeBlock = document.getElementById(targetId);
+      if (!codeBlock) return;
+      const isHidden = codeBlock.classList.contains('hidden');
+      codeBlock.classList.toggle('hidden');
+      this.innerHTML = isHidden
+        ? '<i class="bi bi-code" aria-hidden="true"></i> Hide Code'
+        : '<i class="bi bi-code" aria-hidden="true"></i> Show Code';
     });
   });
 </script>

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -40,6 +40,9 @@
 .btn-busy { pointer-events: none; opacity: 0.75; }
 .btn-busy::before { content: ""; width: 12px; height: 12px; border-radius: 50%; border: 2px solid currentColor; border-right-color: transparent; display: inline-block; animation: topic-spin 0.7s linear infinite; }
 .row-updating { opacity: 0.55; }
+.code-block { background: var(--bg-card); border: 1px solid var(--border-color); border-radius: 8px; padding: 12px 16px; margin-top: 8px; font-size: 0.78rem; overflow-x: auto; max-height: 300px; overflow-y: auto; white-space: pre-wrap; word-break: break-word; }
+.code-block.hidden { display: none; }
+.show-code-btn { margin-top: 8px; }
 
 @keyframes topic-spin {
     to { transform: rotate(360deg); }
@@ -185,6 +188,13 @@
                                <i class="bi bi-journal-text" aria-hidden="true"></i> {{ editorial.label }}
                             </a>
                         {% endfor %}
+                        {% if q.solutionUrl %}
+                            <a href="{{ q.solutionUrl }}" target="_blank" rel="noopener noreferrer"
+                               class="q-badge badge-link"
+                               aria-label="View solution (opens in new tab)">
+                               <i class="bi bi-code-slash" aria-hidden="true"></i> Solution
+                            </a>
+                        {% endif %}
                     </div>
                     {% if q.hints %}
                       <div class="hints-container" id="hints-container-{{ q_id_str }}" data-hints-total="{{ q.hints|length }}" data-hints-revealed="0">
@@ -199,6 +209,14 @@
                             </li>
                           {% endfor %}
                         </ul>
+                      </div>
+                    {% endif %}
+                    {% if q.codeSnippet %}
+                      <div class="code-snippet-container" id="code-container-{{ q_id_str }}">
+                        <button type="button" class="show-code-btn ui-btn ui-btn-secondary ui-btn-sm" data-target="code-block-{{ q_id_str }}">
+                          <i class="bi bi-code" aria-hidden="true"></i> Show Code
+                        </button>
+                        <pre class="code-block hidden" id="code-block-{{ q_id_str }}"><code>{{ q.codeSnippet }}</code></pre>
                       </div>
                     {% endif %}
                 </td>


### PR DESCRIPTION
## Summary
- Adds \solutionUrl\ and \codeSnippet\ fields to the question seed data and upsert logic so users can link to their submitted solutions
- Defaults both new fields to empty string via \.get()\ in the upsert and seeding routes for backward compatibility
- Existing \data.json\ and records without these fields continue to work without errors

Closes #270