### PR TITLE
feat: added markdown preview and autosave for question notes

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -182,6 +182,8 @@
 
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
     <script>
         
         // Theme Toggle

--- a/templates/macros/modals.html
+++ b/templates/macros/modals.html
@@ -1,15 +1,23 @@
-{% macro notes_modal(modal_id='notesModal', title_id='notesModalTitle', textarea_id='notesTextarea', question_id_input='currentQuestionId', cancel_id='modalCancel', save_id='saveNotesBtn', textarea_label='Notes for this question', textarea_placeholder='Write your notes here...') -%}
+{% macro notes_modal(modal_id='notesModal', title_id='notesModalTitle', textarea_id='notesTextarea', preview_id='notesPreview', status_id='notesSaveStatus', tab_edit_id='tabEdit', tab_preview_id='tabPreview', question_id_input='currentQuestionId', cancel_id='modalCancel', save_id='saveNotesBtn', textarea_label='Notes for this question', textarea_placeholder='Write your notes here...') -%}
 <div class="app-modal" id="{{ modal_id }}" role="dialog" aria-modal="true" aria-labelledby="{{ title_id }}">
   <div class="app-modal__dialog">
     <h3 class="app-modal__title" id="{{ title_id }}">
       <i class="bi bi-journal-text" aria-hidden="true"></i>
       <span>Notes</span>
     </h3>
+    <div class="d-flex gap-2 mb-3">
+      <button type="button" id="{{ tab_edit_id }}" class="ui-btn ui-btn-primary ui-btn-sm">Edit</button>
+      <button type="button" id="{{ tab_preview_id }}" class="ui-btn ui-btn-secondary ui-btn-sm">Preview</button>
+    </div>
     <textarea class="app-modal__textarea" id="{{ textarea_id }}" placeholder="{{ textarea_placeholder }}" aria-label="{{ textarea_label }}"></textarea>
+    <div id="{{ preview_id }}" class="app-modal__textarea d-none overflow-y-auto markdown-body"></div>
     <input type="hidden" id="{{ question_id_input }}">
-    <div class="app-modal__actions">
-      <button class="ui-btn ui-btn-secondary" id="{{ cancel_id }}" aria-label="Cancel editing notes">Cancel</button>
-      <button class="ui-btn ui-btn-primary" id="{{ save_id }}" aria-label="Save notes">Save Notes</button>
+    <div class="app-modal__actions d-flex justify-content-between align-items-center w-100 mt-3">
+      <span id="{{ status_id }}" class="text-muted small" aria-live="polite"></span>
+      <div class="d-flex gap-2">
+        <button class="ui-btn ui-btn-secondary" id="{{ cancel_id }}" aria-label="Close notes">Close</button>
+        <button class="ui-btn ui-btn-primary" id="{{ save_id }}" aria-label="Save notes">Save Notes</button>
+      </div>
     </div>
   </div>
 </div>

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -406,6 +406,7 @@ async function flushQueue() {
 window.addEventListener('online', flushQueue);
 
 function updateQuestion(id, data, callback) {
+
     if (!navigator.onLine) {
         enqueue(id, data);
         showOfflineBanner(true);
@@ -635,11 +636,90 @@ function trapFocus(e) {
     if (e.key === 'Escape') closeModal();
 }
 
+// Notes Tabs and Preview Logic
+const tabEdit = document.getElementById('tabEdit');
+const tabPreview = document.getElementById('tabPreview');
+const notesTextarea = document.getElementById('notesTextarea');
+const notesPreview = document.getElementById('notesPreview');
+const notesSaveStatus = document.getElementById('notesSaveStatus');
+
+if (tabEdit && tabPreview) {
+    tabEdit.addEventListener('click', () => {
+        tabEdit.classList.replace('ui-btn-secondary', 'ui-btn-primary');
+        tabPreview.classList.replace('ui-btn-primary', 'ui-btn-secondary');
+        notesTextarea.classList.remove('d-none');
+        notesPreview.classList.add('d-none');
+    });
+
+    tabPreview.addEventListener('click', () => {
+        tabPreview.classList.replace('ui-btn-secondary', 'ui-btn-primary');
+        tabEdit.classList.replace('ui-btn-primary', 'ui-btn-secondary');
+        notesTextarea.classList.add('d-none');
+        notesPreview.classList.remove('d-none');
+        
+        const rawMarkdown = notesTextarea.value;
+        // Parse markdown and sanitize HTML safely
+        const cleanHTML = typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined' 
+            ? DOMPurify.sanitize(marked.parse(rawMarkdown)) 
+            : rawMarkdown;
+        notesPreview.innerHTML = cleanHTML || '<em class="text-muted">Nothing to preview</em>';
+    });
+}
+
+// Debounce function for autosave
+function debounce(func, wait) {
+    let timeout;
+    const debounced = function(...args) {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => func.apply(this, args), wait);
+    };
+    debounced.cancel = () => clearTimeout(timeout);
+    return debounced;
+}
+
+// Autosave Logic
+const triggerAutosave = debounce(() => {
+    const qId = document.getElementById('currentQuestionId').value;
+    const notes = notesTextarea.value;
+    if (!qId) return;
+
+    if (notesSaveStatus) notesSaveStatus.textContent = 'Saving...';
+
+    updateQuestion(qId, {notes: notes}, () => {
+        if (notesSaveStatus) notesSaveStatus.textContent = 'Saved';
+        
+        // Sync button state in the background
+        const btn = document.querySelector(`.notes-btn[data-id="${qId}"]`);
+        if (btn) {
+            btn.dataset.notes = notes;
+            btn.classList.toggle('has-notes', notes.trim() !== '');
+            const label = notes.trim() ? 'Edit' : 'Add';
+            btn.innerHTML = `<i class="bi bi-journal-text" aria-hidden="true"></i> ${label}`;
+            btn.setAttribute('aria-label', `${label} notes for this question`);
+        }
+    }).catch(() => {
+        if (notesSaveStatus) notesSaveStatus.textContent = 'Failed to save';
+    });
+}, 1000);
+
+if (notesTextarea) {
+    notesTextarea.addEventListener('input', () => {
+        if (notesSaveStatus) notesSaveStatus.textContent = 'Draft...';
+        triggerAutosave();
+    });
+}
+
 document.querySelectorAll('.notes-btn').forEach(btn => {
     btn.addEventListener('click', function() {
         if (!isAuthenticated) { window.location.href = "{{ url_for('auth.login') }}"; return; }
         document.getElementById('currentQuestionId').value = this.dataset.id;
         document.getElementById('notesTextarea').value = this.dataset.notes || '';
+        
+        // Reset modal state
+        if (notesSaveStatus) notesSaveStatus.textContent = '';
+        if (tabEdit) tabEdit.click();
+        triggerAutosave.cancel();
+        
         openModal(this);
     });
 });
@@ -648,6 +728,7 @@ document.getElementById('modalCancel').addEventListener('click', closeModal);
 modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
 
 document.getElementById('saveNotesBtn').addEventListener('click', function() {
+    triggerAutosave.cancel(); // Cancel any pending autosave
     const qId = document.getElementById('currentQuestionId').value;
     const notes = document.getElementById('notesTextarea').value;
     const previousContent = this.innerHTML;


### PR DESCRIPTION
## Description

Implemented the enhancements requested in Issue #269 by improving the question notes experience with markdown support, autosave functionality, and save-state feedback.

### Changes Made

✅ Added Markdown Preview for question notes

* Introduced Edit and Preview modes within the notes modal
* Added safe markdown rendering using Markdown parser and HTML sanitization
* Users can now preview formatted notes before saving

✅ Added Debounce-Based Autosave

* Implemented autosave with a 1000ms debounce delay
* Prevents excessive save requests while typing
* Preserves existing backend note storage as plain text

✅ Added Save Status Indicators

* Displays draft state while editing
* Shows "Saving..." during autosave operations
* Shows "Saved" after successful persistence
* Displays failure feedback if a save operation encounters an error

✅ Maintained Existing Functionality

* Existing Save Notes button remains fully functional
* Backend APIs and note storage format remain unchanged
* Existing note loading and editing workflow preserved

### Testing Performed

* Verified markdown preview rendering
* Verified autosave after typing inactivity
* Verified save-state indicator transitions
* Verified manual Save Notes workflow
* Verified notes persist correctly after reopening the modal
* Verified no backend changes were required

Closes #269
