### PR TITLE
feat: add difficulty sorting for search results

### DIFF
--- a/app/search/service.py
+++ b/app/search/service.py
@@ -181,7 +181,14 @@ def search_dsa_questions(raw_query, limit=40, db_handle=None, filters=None, prog
         except InvalidId:
             return empty_payload()
 
-    projection = {"problem": 1, "topic": 1, "url": 1, "url2": 1, "editorial_links": 1}
+    projection = {
+    "problem": 1,
+    "topic": 1,
+    "url": 1,
+    "url2": 1,
+    "editorial_links": 1,
+    "difficulty": 1,
+}
     post_fetch_filters = bool(
         requested_platforms
         or difficulty_filter in DIFFICULTY_FILTERS
@@ -229,7 +236,6 @@ def search_dsa_questions(raw_query, limit=40, db_handle=None, filters=None, prog
 
         if status_filter == "undone" and progress_item.get("done"):
             continue
-
         results.append(
             {
                 "id": q_id_str,
@@ -237,6 +243,7 @@ def search_dsa_questions(raw_query, limit=40, db_handle=None, filters=None, prog
                 "topic": topic_name,
                 "topic_id": str(question.get("topic")),
                 "topic_position": topic_doc.get("position", 999),
+                "difficulty": question.get("difficulty", "Medium"),
                 "links": links,
                 "editorial_links": question_editorial_links(question),
                 "external_searches": build_external_searches(problem, requested_platforms),

--- a/templates/search.html
+++ b/templates/search.html
@@ -297,6 +297,11 @@
         <option value="medium">Medium</option>
         <option value="hard">Hard</option>
       </select>
+      <select id="sortDifficulty" class="filter-select" aria-label="Sort by difficulty">
+        <option value="">Default Order</option>
+        <option value="asc">Easy → Hard</option>
+        <option value="desc">Hard → Easy</option>
+      </select>
       <select id="filterPlatform" class="filter-select" aria-label="Filter by result platform">
         <option value="">All Platforms</option>
         {% for name, meta in PLATFORM_META.items() %}
@@ -347,6 +352,12 @@ const filterTopic = document.getElementById('filterTopic');
 const filterDifficulty = document.getElementById('filterDifficulty');
 const filterPlatform = document.getElementById('filterPlatform');
 const filterStatus = document.getElementById('filterStatus');
+const sortDifficulty = document.getElementById('sortDifficulty');
+const difficultyOrder = {
+  easy: 1,
+  medium: 2,
+  hard: 3
+};
 let activeToken = '';
 let debounceTimer = null;
 let controller = null;
@@ -372,6 +383,19 @@ function hasActiveFilters() {
   return Object.values(getFilters()).some(Boolean);
 }
 
+function buildSearchParams(query) {
+  const params = new URLSearchParams();
+  if (query) params.set('q', query);
+
+  const filters = getFilters();
+  if (filters.topic_id) params.set('topic_id', filters.topic_id);
+  if (filters.difficulty) params.set('difficulty', filters.difficulty);
+  if (filters.platform) params.set('platform', filters.platform);
+  if (filters.status) params.set('status', filters.status);
+
+  return params;
+}
+
 function setFilterActiveStates() {
   [filterTopic, filterDifficulty, filterPlatform, filterStatus].forEach(filter => {
     if (filter) filter.classList.toggle('active', !!filter.value);
@@ -386,17 +410,6 @@ function restoreStateFromUrl() {
   if (filterPlatform && params.get('platform')) filterPlatform.value = params.get('platform');
   if (filterStatus && params.get('status')) filterStatus.value = params.get('status');
   setFilterActiveStates();
-}
-
-function buildSearchParams(query) {
-  const params = new URLSearchParams();
-  if (query) params.set('q', query);
-  const filters = getFilters();
-  if (filters.topic_id) params.set('topic_id', filters.topic_id);
-  if (filters.difficulty) params.set('difficulty', filters.difficulty);
-  if (filters.platform) params.set('platform', filters.platform);
-  if (filters.status) params.set('status', filters.status);
-  return params;
 }
 
 function updateUrl(query) {
@@ -514,6 +527,38 @@ function renderPlatformPrompt() {
 
 function renderResults(payload) {
   const count = payload.results.length;
+  console.log("Sort:", sortDifficulty?.value);
+  console.table(
+  payload.results.map(item => ({
+    problem: item.problem,
+    difficulty: item.difficulty
+  }))
+);
+  if (sortDifficulty?.value) {
+  payload.results = payload.results
+    .map((item, index) => ({ ...item, index }))
+    .sort((a, b) => {
+      const da = difficultyOrder[(a.difficulty || "").toLowerCase()] || 999;
+      const db = difficultyOrder[(b.difficulty || "").toLowerCase()] || 999;
+
+      if (sortDifficulty.value === "asc") {
+        return da - db;
+      }
+
+      return db - da;
+    });
+}
+
+console.log("After sort");
+console.table(
+  payload.results.map(item => ({
+    difficulty: item.difficulty,
+    problem: item.problem
+  }))
+);
+
+console.log("Sort value =", sortDifficulty?.value);
+
   const platforms = payload.requested_platforms || [];
   meta.textContent = count ? `${count} result${count === 1 ? '' : 's'}${platforms.length ? ' with ' + platforms.join(', ') : ''}` : '';
 
@@ -537,7 +582,6 @@ function renderResults(payload) {
     results.innerHTML = `<div class="empty-search"><i class="bi bi-search-heart" aria-hidden="true"></i><p>No sheet match found.</p><div class="link-row" style="justify-content:center">${external}</div></div>`;
     return;
   }
-
   results.innerHTML = payload.results.map(item => {
     const directLinks = (item.links || []).map(link =>
       `<a class="q-badge ${badgeClass(link.color)}" href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="View on ${escapeHtml(link.platform)} (opens new tab)">
@@ -595,7 +639,13 @@ async function runSearch() {
   try {
     const params = buildSearchParams(query);
     const res = await fetch(`${endpointConfig.searchQuestions}?${params}`, { signal: controller.signal });
-    renderResults(await res.json());
+    const data = await res.json();
+
+try {
+    renderResults(data);
+} catch (e) {
+    console.error("renderResults error:", e);
+}
     rememberRecentSearch(input.value, activeToken);
     meta.setAttribute('aria-busy', 'false');
   } catch (err) {
@@ -634,7 +684,7 @@ chips.forEach(chip => {
   });
   chip.setAttribute('aria-pressed', 'false');
 });
-[filterTopic, filterDifficulty, filterPlatform, filterStatus].forEach(filter => {
+[filterTopic, filterDifficulty, sortDifficulty, filterPlatform, filterStatus].forEach(filter => {
   if (!filter) return;
   filter.addEventListener('change', () => {
     setFilterActiveStates();


### PR DESCRIPTION
# Description

Adds difficulty-based sorting to the search page. Users can now sort search results in ascending (Easy → Hard) or descending (Hard → Easy) order while preserving compatibility with existing topic, platform, and difficulty filters.

Fixes #768 

# How Has This Been Tested?

* Verified search results locally.

* Tested default ordering.

* Tested Easy → Hard sorting.

* Tested Hard → Easy sorting.

* Tested sorting together with topic, platform, and difficulty filters.

* [x] Tested in Local

## Checklist

* [x] I have starred this repository.
* [x] My PR references the issue number.
* [x] I placed files in the correct location.

## Screenshots Or Logs

Added screenshots demonstrating difficulty sorting functionality and verified results locally.
<img width="1350" height="636" alt="Screenshot (189)" src="https://github.com/user-attachments/assets/abe847da-8667-4325-9cf6-2aeee77e6641" />


## Contributor Confirmation

* [x] Code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] My changes generate no new warnings or errors.
