### PR TITLE
implementing add theme customization options

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -53,6 +53,10 @@ def resolve_oauth_user(provider_field, provider_id, name, email=None):
         provider_field: provider_id,
         "progress": {},
         "profile_visibility": "public",
+        "ui_theme": "dark",
+        "accent_color": "#ff6b00",
+        "compact_mode": False,
+        "chart_palette": "default",
         "is_admin": False,
         "created_at": utc_now(),
     }
@@ -204,6 +208,10 @@ def register():
         "password": hashed_password,
         "progress": {},
         "profile_visibility": "public",
+        "ui_theme": "dark",
+        "accent_color": "#ff6b00",
+        "compact_mode": False,
+        "chart_palette": "default",
         "is_admin": False,
         "created_at": utc_now(),
     }

--- a/profile_validation.py
+++ b/profile_validation.py
@@ -77,6 +77,47 @@ def build_profile_updates(data):
 
         update_fields['profile_visibility'] = visibility
 
+    if 'ui_theme' in data:
+        theme = data['ui_theme']
+        if not isinstance(theme, str):
+            return None, 'ui_theme must be text'
+        theme = theme.strip().lower()
+        if theme not in {'dark', 'light'}:
+            return None, 'ui_theme must be one of: dark, light'
+        update_fields['ui_theme'] = theme
+
+    if 'accent_color' in data:
+        accent_color = data['accent_color']
+        if not isinstance(accent_color, str):
+            return None, 'accent_color must be text'
+        accent_color = accent_color.strip()
+        if not re.fullmatch(r'^#[0-9A-Fa-f]{6}$', accent_color):
+            return None, 'accent_color must be a valid hex color'
+        update_fields['accent_color'] = accent_color
+
+    if 'compact_mode' in data:
+        compact_mode = data['compact_mode']
+        if isinstance(compact_mode, str):
+            compact_mode = compact_mode.strip().lower()
+            if compact_mode in {'true', '1', 'yes', 'on'}:
+                compact_mode = True
+            elif compact_mode in {'false', '0', 'no', 'off'}:
+                compact_mode = False
+            else:
+                return None, 'compact_mode must be a boolean'
+        elif not isinstance(compact_mode, bool):
+            return None, 'compact_mode must be a boolean'
+        update_fields['compact_mode'] = compact_mode
+
+    if 'chart_palette' in data:
+        palette = data['chart_palette']
+        if not isinstance(palette, str):
+            return None, 'chart_palette must be text'
+        palette = palette.strip().lower()
+        if palette not in {'default', 'cool', 'warm', 'monochrome'}:
+            return None, 'chart_palette must be one of: default, cool, warm, monochrome'
+        update_fields['chart_palette'] = palette
+
     return update_fields, None
 
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -26,6 +26,41 @@
     --shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
 }
 
+.compact .sidebar {
+    padding: 8px 0;
+}
+
+.compact .topbar {
+    min-height: 50px;
+}
+
+.compact .topbar-right .pill-btn,
+.compact .topbar-right .icon-btn,
+.compact .sidebar-link {
+    padding: 6px 10px;
+}
+
+.compact .card,
+.compact .modal-bx,
+.compact .m-inp,
+.compact .sidebar-nav,
+.compact .form-group,
+.compact .page-header {
+    padding: 12px;
+}
+
+.compact .m-actions {
+    gap: 8px;
+}
+
+.compact .m-inp {
+    padding: 8px 10px;
+}
+
+.compact .toast-notification {
+    padding: 10px 12px;
+}
+
 * {
     box-sizing: border-box;
     margin: 0;

--- a/templates/base.html
+++ b/templates/base.html
@@ -49,7 +49,49 @@
     <script src="{{ url_for('static', filename='js/pwa-install.js') }}" defer></script>
     {% block head %}{% endblock %}
     <script>
-        if (localStorage.getItem('theme') === 'light') {
+        const themeSettings = {
+            isAuthenticated: {{ 'true' if current_user.is_authenticated else 'false' }},
+            uiTheme: {{ (current_user.ui_theme or 'dark')|tojson }},
+            accentColor: {{ (current_user.accent_color or '#ff6b00')|tojson }},
+            compactMode: {{ 'true' if current_user.compact_mode else 'false' }},
+            chartPalette: {{ (current_user.chart_palette or 'default')|tojson }},
+            csrfToken: {{ csrf_token()|tojson }},
+        };
+
+        function hexToRgb(hex) {
+            const normalized = hex.replace('#', '');
+            const bigint = parseInt(normalized, 16);
+            return {
+                r: (bigint >> 16) & 255,
+                g: (bigint >> 8) & 255,
+                b: bigint & 255,
+            };
+        }
+
+        function toRgba(hex, alpha) {
+            const { r, g, b } = hexToRgb(hex);
+            return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+        }
+
+        function applyAccentColor(accent) {
+            document.documentElement.style.setProperty('--accent', accent);
+            document.documentElement.style.setProperty('--accent-hover', toRgba(accent, 0.7));
+            document.documentElement.style.setProperty('--accent-dim', toRgba(accent, 0.15));
+        }
+
+        function applyCompactMode(compact) {
+            document.documentElement.classList.toggle('compact', compact === true || compact === 'true');
+        }
+
+        const localTheme = localStorage.getItem('theme');
+        const localAccent = localStorage.getItem('accent_color');
+        const localCompact = localStorage.getItem('compact_mode') === 'true';
+
+        const activeTheme = themeSettings.isAuthenticated ? themeSettings.uiTheme : (localTheme || 'dark');
+        const activeAccent = themeSettings.isAuthenticated ? themeSettings.accentColor : (localAccent || '#ff6b00');
+        const activeCompact = themeSettings.isAuthenticated ? themeSettings.compactMode : localCompact;
+
+        if (activeTheme === 'light') {
             document.documentElement.style.setProperty('--bg-primary', '#f0f2f5');
             document.documentElement.style.setProperty('--bg-secondary', '#ffffff');
             document.documentElement.style.setProperty('--bg-card', '#ffffff');
@@ -57,6 +99,9 @@
             document.documentElement.style.setProperty('--text-secondary', '#555555');
             document.documentElement.style.setProperty('--border-color', '#e0e0e0');
         }
+
+        applyAccentColor(activeAccent);
+        applyCompactMode(activeCompact);
     </script>
 </head>
 
@@ -188,6 +233,9 @@
         const themeToggle = document.getElementById('theme-toggle');
         const themeIcon = document.getElementById('theme-icon');
         const root = document.documentElement;
+        const csrfToken = themeSettings.csrfToken;
+        const isAuthenticated = themeSettings.isAuthenticated;
+        let currentTheme = themeSettings.isAuthenticated ? themeSettings.uiTheme : (localStorage.getItem('theme') || 'dark');
 
         const toastConfig = {
             success: { title: 'Success', icon: 'bi-check-circle-fill' },
@@ -292,6 +340,7 @@
                 root.style.setProperty('--text-secondary', '#555555');
                 root.style.setProperty('--text-muted', '#6b7280');
                 themeIcon.className = 'bi bi-sun-fill';
+                document.documentElement.style.colorScheme = 'light';
             } else {
                 root.style.setProperty('--bg-primary', '#111111');
                 root.style.setProperty('--bg-secondary', '#1a1a1a');
@@ -303,16 +352,38 @@
                 root.style.setProperty('--text-secondary', '#a0a0a0');
                 root.style.setProperty('--text-muted', '#8a8a8a');
                 themeIcon.className = 'bi bi-moon-fill';
+                document.documentElement.style.colorScheme = 'dark';
             }
         }
 
-        const saved = localStorage.getItem('theme') || 'dark';
-        applyTheme(saved);
+        applyTheme(currentTheme);
+
+        function persistPreference(storageKey, serverKey, value) {
+            localStorage.setItem(storageKey, String(value));
+            if (!isAuthenticated) {
+                return;
+            }
+            fetch('{{ url_for('profile.edit_profile') }}', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': csrfToken,
+                },
+                body: JSON.stringify({ [serverKey]: value }),
+            }).then(async (response) => {
+                if (!response.ok) {
+                    const json = await response.json().catch(() => null);
+                    throw new Error(json?.error || 'Unable to save preference.');
+                }
+            }).catch((error) => {
+                showToast(`Failed to save preference: ${error.message}`, 'warning');
+            });
+        }
 
         themeToggle.addEventListener('click', () => {
-            const curr = localStorage.getItem('theme') || 'dark';
-            const next = curr === 'dark' ? 'light' : 'dark';
-            localStorage.setItem('theme', next);
+            const next = currentTheme === 'dark' ? 'light' : 'dark';
+            currentTheme = next;
+            persistPreference('theme', 'ui_theme', next);
             applyTheme(next);
             showToast(`Switched to ${next} mode`, 'info');
         });

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -471,6 +471,30 @@
     <div style="margin-bottom:10px"><label class="m-lbl"><i class="bi bi-twitter-x"></i> Twitter / X URL</label><input class="m-inp" id="ep_twitter" placeholder="https://twitter.com/username" value="{{ user.twitter_url or '' }}"></div>
     <div style="margin-bottom:10px"><label class="m-lbl"><i class="bi bi-globe" style="color:var(--info)"></i> Website / Portfolio</label><input class="m-inp" id="ep_website" placeholder="https://yoursite.com" value="{{ user.website_url or '' }}"></div>
     <div style="margin-bottom:16px"><label class="m-lbl"><i class="bi bi-file-earmark-person" style="color:var(--accent)"></i> Resume URL</label><input class="m-inp" id="ep_resume" placeholder="https://drive.google.com/... or LinkedIn resume link" value="{{ user.resume_url or '' }}"><div style="font-size:.7rem;color:var(--text-muted);margin-top:3px">Paste a Google Drive, Dropbox, or any public resume link</div></div>
+    <div style="font-size:.75rem;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:10px;margin-top:10px">Interface Preferences</div>
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:12px">
+      <div>
+        <label class="m-lbl">Accent Color</label>
+        <input class="m-inp" type="color" id="ep_accent_color" value="{{ user.accent_color or '#ff6b00' }}" style="width:100%;height:46px;padding:0;border-radius:10px;border:1px solid var(--border-color);">
+      </div>
+      <div>
+        <label class="m-lbl">Compact Mode</label>
+        <label style="display:flex;align-items:center;gap:10px;cursor:pointer">
+          <input type="checkbox" id="ep_compact_mode" style="width:18px;height:18px;" {% if user.compact_mode %}checked{% endif %}>
+          <span style="font-size:.9rem;color:var(--text-secondary);line-height:1.3">Reduce spacing and density for more content on screen</span>
+        </label>
+      </div>
+    </div>
+    <div style="margin-bottom:16px">
+      <label class="m-lbl">Chart Palette</label>
+      <select class="m-inp" id="ep_chart_palette">
+        <option value="default" {% if (user.chart_palette or 'default') == 'default' %}selected{% endif %}>Default</option>
+        <option value="cool" {% if user.chart_palette == 'cool' %}selected{% endif %}>Cool Blues</option>
+        <option value="warm" {% if user.chart_palette == 'warm' %}selected{% endif %}>Warm Ember</option>
+        <option value="monochrome" {% if user.chart_palette == 'monochrome' %}selected{% endif %}>Monochrome</option>
+      </select>
+      <div style="font-size:.7rem;color:var(--text-muted);margin-top:3px">Choose how charts are colored across your profile analytics.</div>
+    </div>
     <div style="margin-bottom:16px">
   <label class="m-lbl"><i class="bi bi-shield-lock" style="color:var(--accent)"></i> Profile Visibility</label>
   <select class="m-inp" id="ep_profile_visibility">
@@ -598,6 +622,9 @@ window.handleSaveProfile = function(btn){
   twitter_url: document.getElementById('ep_twitter').value,
   website_url: document.getElementById('ep_website').value,
   resume_url: document.getElementById('ep_resume').value,
+  accent_color: document.getElementById('ep_accent_color').value,
+  compact_mode: document.getElementById('ep_compact_mode').checked,
+  chart_palette: document.getElementById('ep_chart_palette').value,
   profile_visibility: document.getElementById('ep_profile_visibility').value,
 };
   window.setButtonBusyState(btn, contentEl, { busy: true, busyLabel: 'Saving...' });
@@ -774,9 +801,39 @@ for(let i=0;i<days;i++){
 const ratingHistory = {{ rating_history | tojson }};
 const cumData = {{ cumulative_data | tojson }};
 const pData = {{ platforms | tojson }};
+const userChartPalette = {{ (user.chart_palette or 'default')|tojson }};
+function resolveChartPalette(name){
+  const palettes = {
+    default: {
+      line: '#f68b24',
+      area: 'rgba(246,139,36,.15)',
+      platformColors: ['{{ PLATFORM_META["LeetCode"].brand_color }}','{{ PLATFORM_META["GFG"].brand_color }}','{{ PLATFORM_META["Coding Ninjas"].brand_color }}','{{ PLATFORM_META["HackerRank"].brand_color }}','#6c757d'],
+      difficultyColors: ['#00b8a3','#ffc01e','#ff375f'],
+    },
+    cool: {
+      line: '#3b82f6',
+      area: 'rgba(59,130,246,.15)',
+      platformColors: ['#3b82f6','#60a5fa','#38bdf8','#22d3ee','#94a3b8'],
+      difficultyColors: ['#60a5fa','#38bdf8','#6366f1'],
+    },
+    warm: {
+      line: '#f97316',
+      area: 'rgba(249,115,22,.15)',
+      platformColors: ['#f97316','#fb7185','#facc15','#f97316','#fb7185'],
+      difficultyColors: ['#f59e0b','#f87171','#ef4444'],
+    },
+    monochrome: {
+      line: '#9ca3af',
+      area: 'rgba(156,163,175,.15)',
+      platformColors: ['#d1d5db','#9ca3af','#6b7280','#4b5563','#374151'],
+      difficultyColors: ['#d1d5db','#9ca3af','#6b7280'],
+    },
+  };
+  return palettes[name] || palettes.default;
+}
 const chartShells=['progressChartShell','platformsChartShell','difficultyChartShell'].map(i=>document.getElementById(i)).filter(Boolean);let chartJsPromise;
 function loadChartJs(){return window.Chart?Promise.resolve(window.Chart):chartJsPromise||(chartJsPromise=new Promise((ok,bad)=>{let add=(src,err)=>{let s=document.createElement('script');s.src=src;s.async=true;s.onload=()=>ok(window.Chart);s.onerror=err||bad;document.head.appendChild(s)};add('https://cdn.jsdelivr.net/npm/chart.js',()=>add('https://unpkg.com/chart.js@4/dist/chart.umd.js'))}))}
-function renderProfileCharts(){loadChartJs().then(()=>{let c=document.getElementById('progressChart'),d=ratingHistory.length?ratingHistory:cumData;if(d.length&&c)new Chart(c,{type:'line',data:{labels:d.map(x=>x.x),datasets:[{data:d.map(x=>x.y),borderColor:'#f68b24',backgroundColor:'rgba(246,139,36,.15)',borderWidth:2,fill:true,tension:.4,pointRadius:ratingHistory.length?3:0,pointHoverRadius:5,pointBackgroundColor:'#f68b24'}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}},scales:{x:{grid:{display:false},ticks:{color:'#888',maxTicksLimit:5,font:{size:10}}},y:{grid:{color:'rgba(255,255,255,.05)'},ticks:{color:'#888',font:{size:10}}}}}});else if(c){let x=c.getContext('2d');x.fillStyle='#555';x.font='13px Inter, sans-serif';x.textAlign='center';x.fillText('Sync LeetCode to see rating chart',c.width/2,c.height/2-8)}markChartReady('progressChartShell');[['platformsChart','platformsChartShell',['LeetCode','GFG','Coding Ninjas','HackerRank','Other'],[pData.LeetCode,pData.GFG,pData['Coding Ninjas'],pData.HackerRank,pData.Other],['{{ PLATFORM_META["LeetCode"].brand_color }}','{{ PLATFORM_META["GFG"].brand_color }}','{{ PLATFORM_META["Coding Ninjas"].brand_color }}','{{ PLATFORM_META["HackerRank"].brand_color }}','#6c757d']],['difficultyChart','difficultyChartShell',['Easy','Medium','Hard'],[{{lc_easy}},{{lc_medium}},{{lc_hard}}],['#00b8a3','#ffc01e','#ff375f']]].forEach(a=>{try{new Chart(document.getElementById(a[0]),{type:'doughnut',data:{labels:a[2],datasets:[{data:a[3],backgroundColor:a[4],borderWidth:0,cutout:'78%'}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}}}})}catch(e){}markChartReady(a[1])})}).catch(()=>chartShells.forEach(s=>s.classList.add('is-ready')))}
+function renderProfileCharts(){loadChartJs().then(()=>{const palette=resolveChartPalette(userChartPalette);let c=document.getElementById('progressChart'),d=ratingHistory.length?ratingHistory:cumData;if(d.length&&c)new Chart(c,{type:'line',data:{labels:d.map(x=>x.x),datasets:[{data:d.map(x=>x.y),borderColor:palette.line,backgroundColor:palette.area,borderWidth:2,fill:true,tension:.4,pointRadius:ratingHistory.length?3:0,pointHoverRadius:5,pointBackgroundColor:palette.line} ]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}},scales:{x:{grid:{display:false},ticks:{color:'#888',maxTicksLimit:5,font:{size:10}}},y:{grid:{color:'rgba(255,255,255,.05)'},ticks:{color:'#888',font:{size:10}}}}}});else if(c){let x=c.getContext('2d');x.fillStyle='#555';x.font='13px Inter, sans-serif';x.textAlign='center';x.fillText('Sync LeetCode to see rating chart',c.width/2,c.height/2-8)}markChartReady('progressChartShell');[['platformsChart','platformsChartShell',['LeetCode','GFG','Coding Ninjas','HackerRank','Other'],[pData.LeetCode,pData.GFG,pData['Coding Ninjas'],pData.HackerRank,pData.Other],palette.platformColors],['difficultyChart','difficultyChartShell',['Easy','Medium','Hard'],[{{lc_easy}},{{lc_medium}},{{lc_hard}}],palette.difficultyColors]].forEach(a=>{try{new Chart(document.getElementById(a[0]),{type:'doughnut',data:{labels:a[2],datasets:[{data:a[3],backgroundColor:a[4],borderWidth:0,cutout:'78%'}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}}}})}catch(e){}markChartReady(a[1])})}).catch(()=>chartShells.forEach(s=>s.classList.add('is-ready')))}
 if('IntersectionObserver'in window&&chartShells.length){const io=new IntersectionObserver((e,o)=>{if(e.some(x=>x.isIntersecting)){o.disconnect();renderProfileCharts()}},{rootMargin:'160px'});chartShells.forEach(s=>io.observe(s))}else renderProfileCharts();
 
 function openSyncModal(){document.getElementById('syncModal').classList.add('open')}

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -64,6 +64,35 @@ def test_profile_updates_reject_invalid_profile_visibility():
     assert error == "profile_visibility must be one of: public, private, stats_only"
 
 
+def test_profile_updates_accepts_new_display_preferences():
+    updates, error = build_profile_updates({
+        "accent_color": "#123abc",
+        "compact_mode": True,
+        "chart_palette": "cool",
+    })
+
+    assert error is None
+    assert updates == {
+        "accent_color": "#123abc",
+        "compact_mode": True,
+        "chart_palette": "cool",
+    }
+
+
+def test_profile_updates_rejects_invalid_accent_color():
+    updates, error = build_profile_updates({"accent_color": "blue"})
+
+    assert updates is None
+    assert error == "accent_color must be a valid hex color"
+
+
+def test_profile_updates_rejects_invalid_chart_palette():
+    updates, error = build_profile_updates({"chart_palette": "rainbow"})
+
+    assert updates is None
+    assert error == "chart_palette must be one of: default, cool, warm, monochrome"
+
+
 def test_edit_profile_rejects_missing_json_body(monkeypatch):
     flask_app, test_db = build_test_app(monkeypatch)
     user_id = test_db.user.insert_one({"email": "user@example.com", "progress": {}}).inserted_id
@@ -106,3 +135,27 @@ def test_edit_profile_rejects_json_array(monkeypatch):
 
     assert response.status_code == 400
     assert response.get_json()["error"] == "Request body must be a JSON object."
+
+
+def test_edit_profile_updates_display_preferences(monkeypatch):
+    flask_app, test_db = build_test_app(monkeypatch)
+    user_id = test_db.user.insert_one({"email": "user@example.com", "progress": {}, "profile_visibility": "public"}).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        response = client.post(
+            "/edit_profile",
+            json={
+                "accent_color": "#1a2b3c",
+                "compact_mode": True,
+                "chart_palette": "warm",
+            },
+            headers=csrf_headers(client),
+        )
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    updated_user = test_db.user.find_one({"_id": user_id})
+    assert updated_user["accent_color"] == "#1a2b3c"
+    assert updated_user["compact_mode"] is True
+    assert updated_user["chart_palette"] == "warm"


### PR DESCRIPTION
Adds first-class personalization for interface preferences by persisting accent color, compact layout mode, and chart palette preferences.

What this changes

- Extends the existing theme context to include [accent_color](vscode-file://vscode-app/c:/Users/Admin/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html), compact_mode, and chart_palette

- Persists these preferences for authenticated users in the profile document

- Falls back to localStorage for anonymous sessions

- Applies compact mode at the root using a density state, keeping layout scaling modular

- Updates chart rendering to use the selected palette immediately


Why it’s valuable

- Provides meaningful personalization beyond light/dark

- Keeps authenticated preferences consistent across devices

- Preserves current anonymous behavior without forcing login

- Uses a design-token-friendly accent architecture to avoid contrast and theme inversion issues

- Enables dynamic chart styling without page reloads

Notes

- Validation is handled in the profile update pipeline

- Existing theme toggle and profile form behavior are preserved

- This aligns with the current repo architecture while adding a clean extensible preference layer

I present this as my pr as a part of NSOC26 and GSSOC26, thank you