### PR TITLE
fix: validate int() conversion in leaderboard query params; return 429 for sync cooldown

### DIFF
--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -131,8 +131,15 @@ def api_leaderboard():
               x-nullable: true
     """
     mode = request.args.get("mode", "cscore")
-    page = int(request.args.get("page", 1))
-    per_page = min(int(request.args.get("per_page", 20)), 100)
+    try:
+        page = int(request.args.get("page", 1))
+    except (ValueError, TypeError):
+        return jsonify({"error": "Invalid page parameter"}), 400
+    try:
+        per_page = min(int(request.args.get("per_page", 20)), 100)
+    except (ValueError, TypeError):
+        per_page = 20
+    page = max(page, 1)
     
     entries = build_leaderboard_data()
 

--- a/app/profile/sync_service.py
+++ b/app/profile/sync_service.py
@@ -121,7 +121,7 @@ def sync_user_platforms(user, data, db_handle, cache_backend, now=None):
             return {
                 "success": False,
                 "error": f"Please wait {mins}m {secs}s before syncing again.",
-            }, 200
+            }, 429
 
     update_fields = {"last_sync": now}
 


### PR DESCRIPTION
Fixes #766 and #768

Changes:
- Validate page/per_page query params in /api/leaderboard endpoint
- Return 400 for invalid page parameter
- Return default per_page=20 for invalid per_page parameter
- Return 429 (Too Many Requests) instead of 200 for sync cooldown enforcement