### PR TITLE
fix: use POST + CSRF protection for logout

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,10 @@ load_dotenv()
 app = Flask(__name__)
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'supersecretkey')
 
+@app.context_processor
+def inject_csrf():
+    return dict(csrf_token=session.get('csrf_token', ''))
+
 # Connect to MongoDB
 MONGO_URI = os.environ.get('MONGO_URI', 'mongodb://localhost:27017/dsa_tracker')
 client = MongoClient(MONGO_URI)
@@ -357,6 +361,8 @@ def before_request():
     if not _db_initialized:
         init_db()
         _db_initialized = True
+    if 'csrf_token' not in session:
+        session['csrf_token'] = os.urandom(16).hex()
 
 @app.route('/login', methods=['GET', 'POST'])
 def login():
@@ -396,9 +402,16 @@ def register():
             flash('An error occurred during registration.', 'danger')
     return render_template('register.html')
 
-@app.route('/logout')
+@app.route('/logout', methods=['GET', 'POST'])
 def logout():
+    if request.method == 'GET':
+        flash('Please use the logout button to sign out.', 'info')
+        return redirect(url_for('index'))
+    if request.form.get('csrf_token') != session.get('csrf_token'):
+        flash('Invalid request. Please try again.', 'danger')
+        return redirect(url_for('index'))
     logout_user()
+    session.pop('csrf_token', None)
     return redirect(url_for('login'))
 
 @app.route('/login/github')

--- a/templates/base.html
+++ b/templates/base.html
@@ -557,10 +557,13 @@
         </nav>
         <div class="sidebar-bottom">
             {% if current_user.is_authenticated %}
-            <a href="{{ url_for('logout') }}" class="sidebar-link" title="Logout" id="nav-logout">
-                <i class="bi bi-box-arrow-right"></i>
-                <span class="tooltip-label">Logout</span>
-            </a>
+            <form action="{{ url_for('logout') }}" method="POST" style="display:inline">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                <button type="submit" class="sidebar-link" title="Logout" id="nav-logout" style="background:none;border:none;cursor:pointer;width:100%">
+                    <i class="bi bi-box-arrow-right"></i>
+                    <span class="tooltip-label">Logout</span>
+                </button>
+            </form>
             {% else %}
             <a href="{{ url_for('login') }}" class="sidebar-link" id="nav-login">
                 <i class="bi bi-box-arrow-in-right"></i>


### PR DESCRIPTION

## Changes

- **CSRF-protected logout route**: `/logout` now only accepts POST requests. GET requests are redirected with an informational flash message.
- **Sidebar template updated**: Replaced anchor link with a POST form containing a hidden CSRF token.
- **Automatic CSRF token**: Generated per-session via `before_request` and injected into all templates via context processor.

Closes #229
