### PR TITLE
perf: cache progress card fonts

### DIFF
--- a/card_generator.py
+++ b/card_generator.py
@@ -1,5 +1,30 @@
 import io
+from functools import lru_cache
+
 from PIL import Image, ImageDraw, ImageFont
+
+
+@lru_cache(maxsize=1)
+def _load_font_set():
+    """Load the card fonts once per process and reuse them."""
+    try:
+        return (
+            ImageFont.truetype("arialbd.ttf", 40),
+            ImageFont.truetype("arialbd.ttf", 60),
+            ImageFont.truetype("arial.ttf", 24),
+            ImageFont.truetype("arial.ttf", 20),
+        )
+    except IOError:
+        try:
+            return (
+                ImageFont.truetype("DejaVuSans-Bold.ttf", 40),
+                ImageFont.truetype("DejaVuSans-Bold.ttf", 60),
+                ImageFont.truetype("DejaVuSans.ttf", 24),
+                ImageFont.truetype("DejaVuSans.ttf", 20),
+            )
+        except IOError:
+            default_font = ImageFont.load_default()
+            return default_font, default_font, default_font, default_font
 
 
 def generate_progress_card(name, c_score, dsa_progress, current_streak, platforms):
@@ -7,26 +32,9 @@ def generate_progress_card(name, c_score, dsa_progress, current_streak, platform
     bg_color = (24, 24, 27) # zinc-900
     card = Image.new('RGB', (width, height), color=bg_color)
     draw = ImageDraw.Draw(card)
-    
-    # Attempt to load a truetype font, fallback to default if not found on OS
-    try:
-        font_title = ImageFont.truetype("arialbd.ttf", 40)
-        font_metric = ImageFont.truetype("arialbd.ttf", 60)
-        font_label = ImageFont.truetype("arial.ttf", 24)
-        font_small = ImageFont.truetype("arial.ttf", 20)
-    except IOError:
-        try:
-            # Unix-like typical font paths
-            font_title = ImageFont.truetype("DejaVuSans-Bold.ttf", 40)
-            font_metric = ImageFont.truetype("DejaVuSans-Bold.ttf", 60)
-            font_label = ImageFont.truetype("DejaVuSans.ttf", 24)
-            font_small = ImageFont.truetype("DejaVuSans.ttf", 20)
-        except IOError:
-            font_title = ImageFont.load_default()
-            font_metric = ImageFont.load_default()
-            font_label = ImageFont.load_default()
-            font_small = ImageFont.load_default()
-            
+
+    font_title, font_metric, font_label, font_small = _load_font_set()
+
     text_color = (255, 255, 255)
     accent_color = (59, 130, 246) # blue-500
     

--- a/tests/test_progress_card.py
+++ b/tests/test_progress_card.py
@@ -110,6 +110,41 @@ def test_card_generator_returns_bytesio():
     assert png_header == b'\x89PNG\r\n\x1a\n', "BytesIO should contain valid PNG data"
 
 
+def test_progress_card_reuses_loaded_fonts(monkeypatch):
+    """Test that card font loading is cached across renders."""
+    import card_generator
+
+    card_generator._load_font_set.cache_clear()
+
+    original_truetype = card_generator.ImageFont.truetype
+    call_count = {"count": 0}
+
+    def counting_truetype(*args, **kwargs):
+        call_count["count"] += 1
+        return original_truetype(*args, **kwargs)
+
+    monkeypatch.setattr(card_generator.ImageFont, "truetype", counting_truetype)
+
+    card_generator.generate_progress_card(
+        name="Test User",
+        c_score=100,
+        dsa_progress=75,
+        current_streak=10,
+        platforms={"LeetCode": 50}
+    )
+    first_pass_calls = call_count["count"]
+
+    card_generator.generate_progress_card(
+        name="Test User",
+        c_score=100,
+        dsa_progress=75,
+        current_streak=10,
+        platforms={"LeetCode": 50}
+    )
+
+    assert call_count["count"] == first_pass_calls
+
+
 def test_public_card_valid_user(client, app):
     """Test that /u/<user_id>/card.png returns 200 with valid user."""
     user_id = ObjectId()


### PR DESCRIPTION
Closes #323\n\nCache the progress card font set once per process so repeated renders do not reparse font files. Fallback behavior is unchanged if Arial or DejaVu fonts are unavailable.\n\nValidation:\n- ..........................                                               [100%]
26 passed in 0.52s\n- 