### PR TITLE
perf: trim flask login user loader

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -24,6 +24,29 @@ COMMON_WEAK_PASSWORDS = {
     "letmein",
     "welcome1",
 }
+USER_SESSION_PROJECTION = {
+    "name": 1,
+    "email": 1,
+    "is_admin": 1,
+    "progress": 1,
+    "profile_visibility": 1,
+    "profile_photo": 1,
+    "avatar_url": 1,
+    "college": 1,
+    "streak": 1,
+    "current_streak": 1,
+    "c_score": 1,
+    "total_solved": 1,
+    "google_id": 1,
+    "github_id": 1,
+    "leetcode_id": 1,
+    "codeforces_id": 1,
+    "codechef_id": 1,
+    "hackerrank_id": 1,
+    "in_sheet_platform_counts": 1,
+    "created_at": 1,
+    "updated_at": 1,
+}
 
 
 def resolve_oauth_user(provider_field, provider_id, name, email=None):
@@ -143,7 +166,7 @@ def reactivate_user_if_needed(user_doc):
 @login_manager.user_loader
 def load_user(user_id):
     try:
-        doc = db.user.find_one({"_id": ObjectId(user_id)})
+        doc = db.user.find_one({"_id": ObjectId(user_id)}, USER_SESSION_PROJECTION)
         return UserWrapper(doc) if doc else None
     except Exception:
         return None

--- a/tests/test_auth_user_loader_projection.py
+++ b/tests/test_auth_user_loader_projection.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+from bson import ObjectId
+
+import app.auth.routes as auth_routes
+
+
+def test_load_user_uses_projection_for_session_loading(monkeypatch):
+    user_id = ObjectId()
+    captured = {}
+
+    class FakeUserCollection:
+        def find_one(self, query, projection=None):
+            captured["query"] = query
+            captured["projection"] = projection
+            return {
+                "_id": user_id,
+                "name": "Test User",
+                "email": "user@example.com",
+                "is_admin": False,
+                "progress": {},
+            }
+
+    monkeypatch.setattr(auth_routes, "db", SimpleNamespace(user=FakeUserCollection()))
+
+    user = auth_routes.load_user(str(user_id))
+
+    assert captured["query"] == {"_id": user_id}
+    assert captured["projection"] == auth_routes.USER_SESSION_PROJECTION
+    assert user is not None
+    assert user.id == user_id
+    assert user.name == "Test User"


### PR DESCRIPTION
Closes #324\n\nUse a bounded projection in the Flask-Login user loader so session hydration fetches only the fields needed by authenticated requests instead of a full user document.\n\nValidation:\n- .                                                                        [100%]
1 passed in 0.07s\n- 