### PR TITLE
perf: project public card question reads

### DIFF
--- a/app/profile/card_service.py
+++ b/app/profile/card_service.py
@@ -79,7 +79,7 @@ def get_public_card_image(user_id, object_id=None, db_handle=None):
     if user.get("in_sheet_platform_counts"):
         platforms = merge_platform_counts(user.get("in_sheet_platform_counts"), user.get("external_totals", {}))
     else:
-        all_questions = list(db_handle.question.find())
+        all_questions = list(db_handle.question.find({}, {"_id": 1, "url": 1}))
         solved_items = {qid: progress for qid, progress in progress_data.items() if progress.get("done")}
         platforms = compute_user_platforms(solved_items, user.get("external_totals", {}), all_questions)
     etag = _build_card_etag(name, c_score, dsa_progress, current_streak, platforms)

--- a/tests/test_public_card_service.py
+++ b/tests/test_public_card_service.py
@@ -29,11 +29,13 @@ class FakeUserCollection:
 class FakeQuestionCollection:
     def __init__(self, questions):
         self.questions = list(questions)
+        self.find_calls = []
 
     def count_documents(self, query):
         return len(self.questions)
 
-    def find(self, *args, **kwargs):
+    def find(self, query=None, projection=None):
+        self.find_calls.append((query, projection))
         return list(self.questions)
 
 
@@ -77,6 +79,7 @@ def test_get_public_card_image_builds_and_caches(monkeypatch):
     assert first_etag == second_etag
     assert first_etag.startswith("progress-card-")
     assert first_last_modified == second_last_modified
+    assert fake_db.question.find_calls == [({}, {"_id": 1, "url": 1}), ({}, {"_id": 1, "url": 1})]
 
 
 def test_get_public_card_image_raises_for_missing_user(monkeypatch):


### PR DESCRIPTION
Closes #325\n\nRead only  and  for the question set used while building public progress cards. That keeps card generation behavior the same while shrinking the document payload pulled from MongoDB.\n\nValidation:\n- ..                                                                       [100%]
2 passed in 0.07s\n- 