### PR TITLE
perf: batch github stats fetches

### DIFF
--- a/app/platforms/fetchers.py
+++ b/app/platforms/fetchers.py
@@ -237,48 +237,44 @@ def fetch_github(username):
         if token:
             auth_headers["Authorization"] = f"token {token}"
 
-        def github_search_json(url, extra_headers=None):
-            headers = {**auth_headers, **(extra_headers or {})}
-            search_response = _get_http_session().get(
-                url,
-                headers=headers,
-                timeout=GITHUB_REQUEST_TIMEOUT_SECONDS,
-            )
-            if search_response.status_code in (403, 429):
-                return "rate_limited", None
-            if search_response.status_code != 200:
-                return "api_error", None
-            return None, search_response.json()
+        graphql_query = """
+        query GitHubStats($username: String!) {
+          issues: search(query: "type:issue author:$username", type: ISSUE, first: 1) {
+            totalCount
+          }
+          prs: search(query: "type:pr author:$username", type: ISSUE, first: 1) {
+            totalCount
+          }
+          mergedPrs: search(query: "type:pr is:merged author:$username", type: ISSUE, first: 1) {
+            totalCount
+          }
+          commits: search(query: "author:$username", type: COMMIT, first: 1) {
+            totalCount
+          }
+        }
+        """
+        search_response = _get_http_session().post(
+            "https://api.github.com/graphql",
+            headers={**auth_headers, "Content-Type": "application/json"},
+            json={"query": graphql_query, "variables": {"username": username}},
+            timeout=GITHUB_REQUEST_TIMEOUT_SECONDS,
+        )
+        if search_response.status_code in (403, 429):
+            return {"error": "rate_limited", "calendar": result_calendar, "stats": None}
+        if search_response.status_code != 200:
+            return {"error": "api_error", "calendar": result_calendar, "stats": None}
 
-        searches = [
-            (
-                "issues",
-                f"https://api.github.com/search/issues?q=type:issue+author:{username}",
-                None,
-            ),
-            (
-                "prs",
-                f"https://api.github.com/search/issues?q=type:pr+author:{username}",
-                None,
-            ),
-            (
-                "merged_prs",
-                f"https://api.github.com/search/issues?q=type:pr+is:merged+author:{username}",
-                None,
-            ),
-            (
-                "commits",
-                f"https://api.github.com/search/commits?q=author:{username}",
-                {"Accept": "application/vnd.github.cloak-preview+json"},
-            ),
-        ]
+        payload = search_response.json()
+        if payload.get("errors"):
+            return {"error": "api_error", "calendar": result_calendar, "stats": None}
 
-        stats = {}
-        for key, url, extra_headers in searches:
-            error, payload = github_search_json(url, extra_headers)
-            if error:
-                return {"error": error, "calendar": result_calendar, "stats": None}
-            stats[key] = payload.get("total_count", 0)
+        stats_data = payload.get("data", {})
+        stats = {
+            "issues": stats_data.get("issues", {}).get("totalCount", 0),
+            "prs": stats_data.get("prs", {}).get("totalCount", 0),
+            "merged_prs": stats_data.get("mergedPrs", {}).get("totalCount", 0),
+            "commits": stats_data.get("commits", {}).get("totalCount", 0),
+        }
 
         return {"calendar": result_calendar, "stats": stats}
     except requests.exceptions.RequestException as exc:

--- a/tests/test_github_fetcher.py
+++ b/tests/test_github_fetcher.py
@@ -12,9 +12,12 @@ def make_response(status_code=200, json_data=None, text=""):
     return r
 
 
-def set_session_responses(mock_session_factory, responses):
+def set_session_responses(mock_session_factory, get_responses=None, post_responses=None):
     fake_session = Mock()
-    fake_session.get.side_effect = responses
+    if get_responses is not None:
+        fake_session.get.side_effect = get_responses
+    if post_responses is not None:
+        fake_session.post.side_effect = post_responses
     mock_session_factory.return_value = fake_session
     return fake_session
 
@@ -23,10 +26,15 @@ def set_session_responses(mock_session_factory, responses):
 def test_fetch_github_success(mock_session_factory):
     fake_session = set_session_responses(mock_session_factory, [
         make_response(text="5 contributions on 2024-01-01 No contributions on 2024-01-02"),
-        make_response(json_data={"total_count": 3}),
-        make_response(json_data={"total_count": 4}),
-        make_response(json_data={"total_count": 2}),
-        make_response(json_data={"total_count": 10}),
+    ], [
+        make_response(json_data={
+            "data": {
+                "issues": {"totalCount": 3},
+                "prs": {"totalCount": 4},
+                "mergedPrs": {"totalCount": 2},
+                "commits": {"totalCount": 10},
+            }
+        }),
     ])
 
     with patch.dict(os.environ, {"GITHUB_TOKEN": "test-token"}, clear=False):
@@ -35,7 +43,10 @@ def test_fetch_github_success(mock_session_factory):
     assert "error" not in result
     assert result["stats"] == {"issues": 3, "prs": 4, "merged_prs": 2, "commits": 10}
     assert result["calendar"] == {"2024-01-01": 5, "2024-01-02": 0}
-    for call in fake_session.get.call_args_list[1:]:
+    assert fake_session.get.call_count == 1
+    assert fake_session.post.call_count == 1
+    assert fake_session.post.call_args.kwargs["headers"]["Authorization"] == "token test-token"
+    for call in [fake_session.post.call_args]:
         assert call.kwargs["headers"]["Authorization"] == "token test-token"
 
 
@@ -45,6 +56,7 @@ def test_fetch_github_rate_limited_403(mock_session_factory):
     rate_limited.json.side_effect = AssertionError("json() must not be called on 403")
     set_session_responses(mock_session_factory, [
         make_response(text="2 contributions on 2024-01-01"),
+    ], [
         rate_limited,
     ])
 
@@ -61,6 +73,7 @@ def test_fetch_github_rate_limited_429(mock_session_factory):
     rate_limited.json.side_effect = AssertionError("json() must not be called on 429")
     set_session_responses(mock_session_factory, [
         make_response(text="1 contributions on 2024-01-01"),
+    ], [
         rate_limited,
     ])
 
@@ -75,10 +88,15 @@ def test_fetch_github_rate_limited_429(mock_session_factory):
 def test_fetch_github_no_token(mock_session_factory):
     fake_session = set_session_responses(mock_session_factory, [
         make_response(text="7 contributions on 2024-01-03"),
-        make_response(json_data={"total_count": 1}),
-        make_response(json_data={"total_count": 2}),
-        make_response(json_data={"total_count": 3}),
-        make_response(json_data={"total_count": 4}),
+    ], [
+        make_response(json_data={
+            "data": {
+                "issues": {"totalCount": 1},
+                "prs": {"totalCount": 2},
+                "mergedPrs": {"totalCount": 3},
+                "commits": {"totalCount": 4},
+            }
+        }),
     ])
 
     env_without_token = {k: v for k, v in os.environ.items() if k != "GITHUB_TOKEN"}
@@ -87,5 +105,6 @@ def test_fetch_github_no_token(mock_session_factory):
 
     assert "error" not in result
     assert result["stats"] == {"issues": 1, "prs": 2, "merged_prs": 3, "commits": 4}
-    for call in fake_session.get.call_args_list[1:]:
-        assert "Authorization" not in call.kwargs.get("headers", {})
+    assert fake_session.get.call_count == 1
+    assert fake_session.post.call_count == 1
+    assert "Authorization" not in fake_session.post.call_args.kwargs.get("headers", {})


### PR DESCRIPTION
Closes #320

Batch the GitHub stats portion of the sync into a single authenticated GraphQL request instead of four separate search requests. The contributions calendar request stays as-is, so the sync still produces the same fields with fewer API round trips.

Validation:
- `python3 -m pytest tests/test_github_fetcher.py -q`
- `git diff --check`
