### PR TITLE
perf: denormalize question platform fields

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -29,6 +29,7 @@ from app.utils import (
     platform_color_filter,
     platform_name_filter,
     platform_profile_url,
+    question_platform_fields,
     question_editorial_links,
     safe_url_filter,
 )
@@ -59,32 +60,62 @@ def _mongo_client_options(app):
         "maxPoolSize": app.config["MONGO_MAX_POOL_SIZE"],
         "minPoolSize": app.config["MONGO_MIN_POOL_SIZE"],
     }
+    def _dedupe_seeded_questions():
+        if not all(hasattr(db.question, attr) for attr in ("aggregate", "delete_many")):
+            return
 
+        duplicate_groups = db.question.aggregate(
+            [
+                {
+                    "$group": {
+                        "_id": {
+                            "topic": "$topic",
+                            "problem": "$problem",
+                            "url": "$url",
+                        },
+                        "ids": {"$push": "$_id"},
+                        "count": {"$sum": 1},
+                    }
+                },
+                {"$match": {"count": {"$gt": 1}}},
+            ]
+        )
+        for group in duplicate_groups:
+            duplicate_ids = group["ids"][1:]
+            if duplicate_ids:
+                db.question.delete_many({"_id": {"$in": duplicate_ids}})
 
-def _dedupe_seeded_questions():
-    if not all(hasattr(db.question, attr) for attr in ("aggregate", "delete_many")):
-        return
+    def _backfill_question_platform_fields():
+        if not hasattr(db.question, "bulk_write"):
+            return
 
-    duplicate_groups = db.question.aggregate(
-        [
-            {
-                "$group": {
-                    "_id": {
-                        "topic": "$topic",
-                        "problem": "$problem",
-                        "url": "$url",
-                    },
-                    "ids": {"$push": "$_id"},
-                    "count": {"$sum": 1},
-                }
-            },
-            {"$match": {"count": {"$gt": 1}}},
-        ]
-    )
-    for group in duplicate_groups:
-        duplicate_ids = group["ids"][1:]
-        if duplicate_ids:
-            db.question.delete_many({"_id": {"$in": duplicate_ids}})
+        from pymongo import UpdateOne
+
+        try:
+            questions = db.question.find(
+                {},
+                {"_id": 1, "url": 1, "url2": 1, "primary_platform": 1, "secondary_platform": 1},
+            )
+        except Exception:
+            return
+
+        updates = []
+        for question in questions:
+            platform_fields = question_platform_fields(question)
+            if (
+                question.get("primary_platform") == platform_fields["primary_platform"]
+                and question.get("secondary_platform") == platform_fields["secondary_platform"]
+            ):
+                continue
+            updates.append(
+                UpdateOne(
+                    {"_id": question["_id"]},
+                    {"$set": platform_fields},
+                )
+            )
+
+        if updates:
+            db.question.bulk_write(updates)
 
 
 def create_app(config_class=None):
@@ -197,6 +228,7 @@ def create_app(config_class=None):
                             "editorial_links": question_editorial_links(question),
                             "difficulty": difficulty,
                         }
+                        q_data.update(question_platform_fields(q_data))
                         if "hints" in question:
                             q_data["hints"] = question["hints"]
                         questions.append(q_data)
@@ -232,6 +264,7 @@ def create_app(config_class=None):
                     "editorial_links": question_editorial_links(question),
                     "difficulty": difficulty,
                 }
+                set_fields.update(question_platform_fields(question))
                 if "hints" in question:
                     set_fields["hints"] = question["hints"]
                 question_updates.append(
@@ -249,6 +282,7 @@ def create_app(config_class=None):
                 )
         if question_updates:
             db.question.bulk_write(question_updates)
+        _backfill_question_platform_fields()
 
     def _precompute_static_data(app):
         """Precompute static question/topic metadata and store in app config."""

--- a/app/search/service.py
+++ b/app/search/service.py
@@ -165,11 +165,17 @@ def search_dsa_questions(raw_query, limit=40, db_handle=None, filters=None, prog
     platform_name = PLATFORM_FILTER_MAP.get(platform_filter, "")
     if platform_name:
         url_keyword = PLATFORM_URL_KEYWORDS.get(platform_name, "")
+        mongo_query["$or"] = [
+            {"primary_platform": platform_name},
+            {"secondary_platform": platform_name},
+        ]
         if url_keyword:
-            mongo_query["$or"] = [
-                {"url": {"$regex": url_keyword, "$options": "i"}},
-                {"url2": {"$regex": url_keyword, "$options": "i"}},
-            ]
+            mongo_query["$or"].extend(
+                [
+                    {"url": {"$regex": url_keyword, "$options": "i"}},
+                    {"url2": {"$regex": url_keyword, "$options": "i"}},
+                ]
+            )
 
     if status_filter in ("done", "bookmarked"):
         flag = "done" if status_filter == "done" else "bookmark"
@@ -263,5 +269,4 @@ def platform_name_filter(url):
             if domain in url:
                 return meta["name"]
     return "Link"
-
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -178,6 +178,14 @@ def platform_from_question_url(url):
     return "Other"
 
 
+def question_platform_fields(question):
+    """Return denormalized platform fields for a question document."""
+    return {
+        "primary_platform": platform_from_question_url(question.get("url")),
+        "secondary_platform": platform_from_question_url(question.get("url2")),
+    }
+
+
 def coerce_non_negative_number(value):
     """Return a safe finite non-negative numeric value for persisted stats."""
     if isinstance(value, bool) or value is None:

--- a/tests/test_search_utils.py
+++ b/tests/test_search_utils.py
@@ -1,4 +1,5 @@
 import app.utils as utils
+import app.search.service as search_service
 
 
 class FakeCursor:
@@ -183,6 +184,31 @@ def test_search_filters_requested_platform_without_extra_collection_scan(monkeyp
     ]
 
 
+def test_search_platform_filter_uses_denormalized_platform_fields(monkeypatch):
+    fake_db = FakeDB(
+        questions=[
+            {
+                "_id": "q1",
+                "problem": "Binary Tree Paths",
+                "topic": "trees",
+                "url": "https://leetcode.com/problems/binary-tree-paths/",
+                "url2": "https://practice.geeksforgeeks.org/problems/tree-traversal/",
+                "score": 3.0,
+            }
+        ],
+        topics=[{"_id": "trees", "name": "Trees", "position": 4}],
+    )
+    monkeypatch.setattr(utils, "db", fake_db)
+
+    search_service.search_dsa_questions("binary tree", db_handle=fake_db, filters={"platform": "gfg"})
+
+    platform_query = fake_db.question.find_calls[0][0]["$or"]
+    assert platform_query[:2] == [
+        {"primary_platform": "GFG"},
+        {"secondary_platform": "GFG"},
+    ]
+
+
 def test_search_applies_platform_filter_before_final_limit(monkeypatch):
     lc_questions = [
         {
@@ -217,6 +243,18 @@ def test_search_applies_platform_filter_before_final_limit(monkeypatch):
     assert fake_db.topic.find_calls == [
         ({"_id": {"$in": ["trees"]}}, {"name": 1, "position": 1})
     ]
+
+
+def test_question_platform_fields_derives_primary_and_secondary_platforms():
+    question = {
+        "url": "https://leetcode.com/problems/two-sum/",
+        "url2": "https://practice.geeksforgeeks.org/problems/tree-traversal/",
+    }
+
+    assert utils.question_platform_fields(question) == {
+        "primary_platform": "LeetCode",
+        "secondary_platform": "GFG",
+    }
 
 
 def test_empty_query_returns_without_database_calls(monkeypatch):


### PR DESCRIPTION
Closes #328

Write `primary_platform` and `secondary_platform` onto question documents during seed/import, backfill legacy rows on startup, and use those denormalized fields in search filtering with URL fallback for older documents.

Validation:
- `python3 -m pytest tests/test_search_utils.py -q`
- `git diff --check`
