### PR TITLE
perf: cache leaderboard snapshots

### DIFF
--- a/app/leaderboard/cache.py
+++ b/app/leaderboard/cache.py
@@ -32,5 +32,9 @@ def api_leaderboard_cache_key():
     return f"leaderboard:v{_leaderboard_cache_version()}:api:{request.path}:{args}"
 
 
+def leaderboard_snapshot_cache_key():
+    return f"leaderboard:v{_leaderboard_cache_version()}:snapshot"
+
+
 # GSSoC Leaderboard cache TTL window
 # Cache leaderboard statistics for 5 minutes max to save Redis compute.

--- a/app/leaderboard/routes.py
+++ b/app/leaderboard/routes.py
@@ -4,10 +4,8 @@ from flask_login import current_user, login_required
 from app.extensions import limiter, cache
 from app.leaderboard.cache import LEADERBOARD_CACHE_TIMEOUT, api_leaderboard_cache_key, leaderboard_page_cache_key
 from app.leaderboard.service import (
-    build_college_leaderboard_data,
-    build_leaderboard_data,
     get_user_rank_by_c_score,
-    sort_leaderboard_entries_by_c_score,
+    get_leaderboard_snapshots,
 )
 
 
@@ -18,22 +16,12 @@ leaderboard_bp = Blueprint("leaderboard", __name__)
 @limiter.limit("20 per minute")
 @cache.cached(timeout=LEADERBOARD_CACHE_TIMEOUT, make_cache_key=leaderboard_page_cache_key)
 def leaderboard():
-    entries = build_leaderboard_data()
-
-    by_cscore = sort_leaderboard_entries_by_c_score(entries)
-    by_questions = sorted(entries, key=lambda item: item["total_solved"], reverse=True)
-    by_rating = sorted(entries, key=lambda item: item["lc_rating"], reverse=True)
-    by_college = build_college_leaderboard_data(entries)
-
-    def assign_ranks(sorted_list, key):
-        for index, entry in enumerate(sorted_list):
-            entry[f"rank_{key}"] = index + 1
-        return sorted_list
-
-    assign_ranks(by_cscore, "cscore")
-    assign_ranks(by_questions, "questions")
-    assign_ranks(by_rating, "rating")
-    assign_ranks(by_college, "college")
+    snapshots = get_leaderboard_snapshots()
+    entries = snapshots["entries"]
+    by_cscore = snapshots["by_cscore"]
+    by_questions = snapshots["by_questions"]
+    by_rating = snapshots["by_rating"]
+    by_college = snapshots["by_college"]
 
     current_user_id = str(current_user.id) if current_user.is_authenticated else None
     current_user_rank = get_user_rank_by_c_score(current_user_id, by_cscore)
@@ -134,16 +122,19 @@ def api_leaderboard():
     page = int(request.args.get("page", 1))
     per_page = min(int(request.args.get("per_page", 20)), 100)
     
-    entries = build_leaderboard_data()
+    snapshots = get_leaderboard_snapshots()
+    entries = snapshots["entries"]
 
     if mode == "questions":
-        entries.sort(key=lambda item: item["total_solved"], reverse=True)
+        entries = snapshots["by_questions"]
     elif mode == "rating":
-        entries.sort(key=lambda item: item["lc_rating"], reverse=True)
+        entries = snapshots["by_rating"]
     elif mode == "college":
-        entries = build_college_leaderboard_data(entries)
+        entries = snapshots["by_college"]
     else:
-        entries.sort(key=lambda item: item["c_score"], reverse=True)
+        entries = snapshots["by_cscore"]
+
+    entries = [dict(entry) for entry in entries]
 
     # Assign ranks
     for index, entry in enumerate(entries):
@@ -178,7 +169,7 @@ def api_leaderboard():
 @login_required
 def compare(user_id):
     """Show a head-to-head comparison between the current user and another public user."""
-    entries = build_leaderboard_data()
+    entries = get_leaderboard_snapshots()["by_cscore"]
     other = next((e for e in entries if e.get("user_id") == user_id), None)
     current_user_id = str(current_user.id) if current_user.is_authenticated else None
     current_entry = next((e for e in entries if e.get("user_id") == current_user_id), None)

--- a/app/leaderboard/service.py
+++ b/app/leaderboard/service.py
@@ -1,5 +1,6 @@
 from flask import current_app
-from app.extensions import db
+from app.extensions import cache, db
+from app.leaderboard.cache import LEADERBOARD_CACHE_TIMEOUT, leaderboard_snapshot_cache_key
 from app.utils import compute_c_score
 
 
@@ -138,3 +139,47 @@ def build_college_leaderboard_data(entries=None):
         key=lambda item: (item["c_score"], item["total_solved"], item["member_count"]),
         reverse=True,
     )
+
+
+def _assign_ranks(entries, key):
+    for index, entry in enumerate(entries, start=1):
+        entry[f"rank_{key}"] = index
+    return entries
+
+
+def build_leaderboard_snapshots(entries=None):
+    entries = entries if entries is not None else build_leaderboard_data()
+    by_cscore = _assign_ranks(sort_leaderboard_entries_by_c_score([dict(entry) for entry in entries]), "cscore")
+    by_questions = _assign_ranks(
+        sorted((dict(entry) for entry in entries), key=lambda item: item["total_solved"], reverse=True),
+        "questions",
+    )
+    by_rating = _assign_ranks(
+        sorted((dict(entry) for entry in entries), key=lambda item: item["lc_rating"], reverse=True),
+        "rating",
+    )
+    by_college = _assign_ranks(build_college_leaderboard_data([dict(entry) for entry in entries]), "college")
+    return {
+        "entries": entries,
+        "by_cscore": by_cscore,
+        "by_questions": by_questions,
+        "by_rating": by_rating,
+        "by_college": by_college,
+    }
+
+
+def get_leaderboard_snapshots():
+    key = leaderboard_snapshot_cache_key()
+    try:
+        cached = cache.get(key)
+    except KeyError:
+        cached = None
+    if cached is not None:
+        return cached
+
+    snapshot = build_leaderboard_snapshots()
+    try:
+        cache.set(key, snapshot, timeout=LEADERBOARD_CACHE_TIMEOUT)
+    except KeyError:
+        pass
+    return snapshot

--- a/tests/test_leaderboard_cache.py
+++ b/tests/test_leaderboard_cache.py
@@ -4,6 +4,7 @@ from bson import ObjectId
 
 import app.auth.routes as auth_routes
 import app.profile.routes as profile_routes
+import app.leaderboard.service as leaderboard_service
 import app.tracker.routes as tracker_routes
 from app.leaderboard.cache import (
     LEADERBOARD_CACHE_VERSION_KEY,
@@ -12,6 +13,7 @@ from app.leaderboard.cache import (
     invalidate_leaderboard_cache,
     leaderboard_page_cache_key,
 )
+from app.leaderboard.service import get_leaderboard_snapshots
 from conftest import build_test_app, csrf_headers
 
 
@@ -55,6 +57,44 @@ def test_leaderboard_page_cache_key_varies_by_authenticated_user(monkeypatch):
     assert first_user_key != second_user_key
     assert first_user_key.endswith(":user:user-1")
     assert second_user_key.endswith(":user:user-2")
+
+
+def test_leaderboard_snapshots_are_cached_until_invalidation(monkeypatch):
+    flask_app, _ = build_test_app(monkeypatch)
+    calls = []
+
+    monkeypatch.setattr(
+        leaderboard_service,
+        "build_leaderboard_data",
+        lambda: calls.append("built") or [
+            {
+                "user_id": "user-1",
+                "name": "Saurabh",
+                "profile_photo": "",
+                "college": "Test College",
+                "c_score": 100,
+                "total_solved": 50,
+                "dsa_done": 45,
+                "lc_total": 20,
+                "gfg_total": 10,
+                "cn_total": 5,
+                "hr_total": 0,
+                "lc_rating": 1800,
+            }
+        ],
+    )
+
+    cache.clear()
+    with flask_app.app_context():
+        first = get_leaderboard_snapshots()
+        second = get_leaderboard_snapshots()
+        invalidate_leaderboard_cache()
+        third = get_leaderboard_snapshots()
+
+    assert calls == ["built", "built"]
+    assert first["by_cscore"][0]["rank_cscore"] == 1
+    assert second["by_cscore"][0]["rank_cscore"] == 1
+    assert third["by_cscore"][0]["rank_cscore"] == 1
 
 
 def test_update_question_invalidates_leaderboard_cache(monkeypatch):


### PR DESCRIPTION
Closes #308

Cache the computed leaderboard snapshots for cscore, questions, rating, and college rankings under the existing leaderboard cache version key. The render and API routes now reuse those snapshots until invalidation, so repeated leaderboard reads avoid rebuilding and resorting the same data.

Validation:
- `python3 -m pytest tests/test_leaderboard_cache.py -q`
- `git diff --check`
