### PR TITLE
perf: cache static faq pages

### DIFF
--- a/app/faq/routes.py
+++ b/app/faq/routes.py
@@ -8,26 +8,32 @@ def faq():
     return render_template("faq.html")
 
 @faq_bp.route("/contact")
+@cache.cached(timeout=900)
 def contact():
     return render_template("placeholder.html", title="Contact Us")
 
 @faq_bp.route("/privacy")
+@cache.cached(timeout=900)
 def privacy():
     return render_template("placeholder.html", title="Privacy Policy")
 
 @faq_bp.route("/timeline")
+@cache.cached(timeout=900)
 def timeline():
     return render_template("placeholder.html", title="Timeline")
 
 @faq_bp.route("/terms")
+@cache.cached(timeout=900)
 def terms():
     return render_template("placeholder.html", title="Terms of Service")
 
 @faq_bp.route("/refund")
+@cache.cached(timeout=900)
 def refund():
     return render_template("placeholder.html", title="Refund Policy")
 
 @faq_bp.route("/monthly-rewind")
+@cache.cached(timeout=900)
 def monthly_rewind():
     return render_template("placeholder.html", title="Monthly Rewind")
 

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -175,6 +175,37 @@ def test_create_app_caches_faq_page_render(monkeypatch):
     assert rendered_templates == ["faq.html"]
 
 
+def test_create_app_caches_placeholder_static_pages(monkeypatch):
+    rendered_templates = []
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
+    monkeypatch.setattr(app_module, "db", FakeDB())
+    monkeypatch.setattr(app_module.mongo, "init_app", lambda flask_app, **kwargs: None)
+    monkeypatch.setattr(app_module.bcrypt, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.login_manager, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.limiter, "init_app", lambda flask_app: None)
+    monkeypatch.setattr(app_module.oauth, "register", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        faq_routes,
+        "render_template",
+        lambda template_name, **context: rendered_templates.append((template_name, context.get("title"))) or "page",
+    )
+
+    flask_app = app_module.create_app()
+    app_module.cache.clear()
+    client = flask_app.test_client()
+
+    first_response = client.get("/contact")
+    second_response = client.get("/contact")
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert first_response.get_data(as_text=True) == "page"
+    assert second_response.get_data(as_text=True) == "page"
+    assert rendered_templates == [("placeholder.html", "Contact Us")]
+
+
 def test_create_app_sets_secure_session_cookie_defaults(monkeypatch):
     monkeypatch.setenv("SECRET_KEY", "test-secret-key")
     monkeypatch.delenv("FLASK_ENV", raising=False)


### PR DESCRIPTION
Closes #330

Cache the static FAQ-style placeholder pages (`/contact`, `/privacy`, `/timeline`, `/terms`, `/refund`, and `/monthly-rewind`) the same way `/faq` is cached, so repeated hits do not re-render the same template responses.

Validation:
- `python3 -m pytest tests/test_app_factory.py -q`
- `git diff --check`
