### PR TITLE
[codex] share modal shell across dialogs

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -94,14 +94,17 @@
     const pageInput = document.getElementById("delete-page");
 
     function openModal() {
-        modal.style.display = "flex";
+        modal.classList.add("open");
         modal.setAttribute("aria-hidden", "false");
     }
 
     function closeModal() {
-        modal.style.display = "none";
+        modal.classList.remove("open");
         modal.setAttribute("aria-hidden", "true");
     }
+
+    window.openDeleteModal = openModal;
+    window.closeDeleteModal = closeModal;
 
     document.querySelectorAll(".js-delete-user").forEach((button) => {
         button.addEventListener("click", function () {

--- a/templates/_macros.html
+++ b/templates/_macros.html
@@ -9,3 +9,15 @@
   </div>
 </div>
 {%- endmacro %}
+
+{% macro app_modal_shell(modal_id, title, title_id, close_action, dialog_style='', header_style='') -%}
+<div class="app-modal" id="{{ modal_id }}" role="dialog" aria-modal="true" aria-labelledby="{{ title_id }}">
+  <div class="app-modal__dialog" style="{{ dialog_style }}">
+    <div style="{{ header_style or 'display:flex;justify-content:space-between;align-items:center;margin-bottom:16px' }}">
+      <h3 class="app-modal__title" id="{{ title_id }}" style="margin-bottom:0">{{ title|safe }}</h3>
+      <button type="button" onclick="{{ close_action }}" style="background:none;border:none;color:var(--text-muted);font-size:1.2rem;cursor:pointer" aria-label="Close dialog">✕</button>
+    </div>
+    {{ caller() }}
+  </div>
+</div>
+{%- endmacro %}

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros.html" import app_modal_shell %}
 
 {% block content %}
 <style>
@@ -430,21 +431,18 @@
     </article>
 </section>
 
-<div class="modal-backdrop" id="delete-modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="delete-modal-title">
-    <div class="modal-card">
-        <h3 class="modal-title" id="delete-modal-title">Delete User Account</h3>
-        <p class="modal-copy" id="delete-modal-copy">This action is permanent.</p>
-        <form id="delete-user-form" method="POST">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <input type="hidden" id="delete-q" name="q" value="">
-            <input type="hidden" id="delete-page" name="page" value="1">
-            <div class="modal-actions">
-                <button type="button" class="action-btn" id="cancel-delete-btn">Cancel</button>
-                <button type="submit" class="action-btn danger"><i class="bi bi-trash3-fill"></i> Confirm Delete</button>
-            </div>
-        </form>
-    </div>
-</div>
+{% call app_modal_shell('delete-modal', 'Delete User Account', 'delete-modal-title', 'closeDeleteModal()', dialog_style='max-width:420px') %}
+    <p id="delete-modal-copy" style="color:var(--text-secondary);font-size:0.9rem;margin-bottom:16px">This action is permanent.</p>
+    <form id="delete-user-form" method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" id="delete-q" name="q" value="">
+        <input type="hidden" id="delete-page" name="page" value="1">
+        <div style="display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap">
+            <button type="button" class="action-btn" id="cancel-delete-btn">Cancel</button>
+            <button type="submit" class="action-btn danger"><i class="bi bi-trash3-fill"></i> Confirm Delete</button>
+        </div>
+    </form>
+{% endcall %}
 {% endblock %}
 
 {% block scripts %}

--- a/templates/macros/modals.html
+++ b/templates/macros/modals.html
@@ -1,16 +1,12 @@
+{% from "_macros.html" import app_modal_shell %}
+
 {% macro notes_modal(modal_id='notesModal', title_id='notesModalTitle', textarea_id='notesTextarea', question_id_input='currentQuestionId', cancel_id='modalCancel', save_id='saveNotesBtn', textarea_label='Notes for this question', textarea_placeholder='Write your notes here...') -%}
-<div class="app-modal" id="{{ modal_id }}" role="dialog" aria-modal="true" aria-labelledby="{{ title_id }}">
-  <div class="app-modal__dialog">
-    <h3 class="app-modal__title" id="{{ title_id }}">
-      <i class="bi bi-journal-text" aria-hidden="true"></i>
-      <span>Notes</span>
-    </h3>
-    <textarea class="app-modal__textarea" id="{{ textarea_id }}" placeholder="{{ textarea_placeholder }}" aria-label="{{ textarea_label }}"></textarea>
-    <input type="hidden" id="{{ question_id_input }}">
-    <div class="app-modal__actions">
-      <button class="ui-btn ui-btn-secondary" id="{{ cancel_id }}" aria-label="Cancel editing notes">Cancel</button>
-      <button class="ui-btn ui-btn-primary" id="{{ save_id }}" aria-label="Save notes">Save Notes</button>
-    </div>
+{% call app_modal_shell(modal_id, '<i class="bi bi-journal-text" aria-hidden="true"></i> Notes', title_id, "document.getElementById('" ~ modal_id ~ "').classList.remove('open')") %}
+  <textarea class="app-modal__textarea" id="{{ textarea_id }}" placeholder="{{ textarea_placeholder }}" aria-label="{{ textarea_label }}"></textarea>
+  <input type="hidden" id="{{ question_id_input }}">
+  <div class="app-modal__actions">
+    <button class="ui-btn ui-btn-secondary" id="{{ cancel_id }}" aria-label="Cancel editing notes">Cancel</button>
+    <button class="ui-btn ui-btn-primary" id="{{ save_id }}" aria-label="Save notes">Save Notes</button>
   </div>
-</div>
+{% endcall %}
 {%- endmacro %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "_macros.html" import modal_shell %}
+{% from "_macros.html" import modal_shell, app_modal_shell %}
 {% block head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/profile.css') }}">
 {% endblock %}
@@ -490,66 +490,60 @@
 {% endcall %}
 
 <!-- Import Progress Modal -->
-<div class="modal-ov" id="importModal" role="dialog" aria-modal="true" aria-labelledby="importModalTitle">
-  <div class="modal-bx" style="max-width:500px">
-    <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:20px">
-      <h3 id="importModalTitle" style="margin-bottom:0"><i class="bi bi-upload" style="color:var(--accent)"></i> Import Progress</h3>
-      <button type="button" onclick="closeImportModal()" style="background:none;border:none;color:var(--text-muted);font-size:1.2rem;cursor:pointer" aria-label="Close dialog">✕</button>
-    </div>
-    <p style="font-size:.8rem;color:var(--text-secondary);margin-bottom:15px">Upload a previously exported CSV or JSON progress backup file.</p>
-    
-    <div style="margin-bottom:15px">
-      <label class="m-lbl">Choose Backup File (.csv, .json)</label>
-      <input type="file" id="importFile" accept=".csv,.json" class="m-inp" onchange="handleImportFileSelect(event)" style="padding:10px">
+{% call app_modal_shell('importModal', '<i class="bi bi-upload" style="color:var(--accent)"></i> Import Progress', 'importModalTitle', 'closeImportModal()', dialog_style='max-width:500px') %}
+  <p style="font-size:.8rem;color:var(--text-secondary);margin-bottom:15px">Upload a previously exported CSV or JSON progress backup file.</p>
+
+  <div style="margin-bottom:15px">
+    <label class="m-lbl">Choose Backup File (.csv, .json)</label>
+    <input type="file" id="importFile" accept=".csv,.json" class="m-inp" onchange="handleImportFileSelect(event)" style="padding:10px">
+  </div>
+
+  <!-- Preview Container -->
+  <div id="importPreviewContainer" style="display:none;margin-top:15px;background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:10px;padding:12px;max-height:300px;overflow-y:auto">
+    <h4 style="margin:0 0 8px 0;font-size:0.9rem">Dry-Run Preview Summary</h4>
+    <table style="width:100%;font-size:0.8rem;border-collapse:collapse;margin-bottom:10px">
+      <tr>
+        <td style="padding:4px 0;color:var(--text-secondary)">Total Parsed:</td>
+        <td><strong id="previewTotal" style="float:right">0</strong></td>
+      </tr>
+      <tr>
+        <td style="padding:4px 0;color:var(--text-secondary)">Matched:</td>
+        <td><strong id="previewMatched" style="float:right">0</strong></td>
+      </tr>
+      <tr>
+        <td style="padding:4px 0;color:var(--text-secondary)">Unmatched (Skipped):</td>
+        <td><strong id="previewUnmatched" style="float:right">0</strong></td>
+      </tr>
+      <tr>
+        <td style="padding:4px 0;color:var(--text-secondary)">Changes Detected:</td>
+        <td><strong id="previewChanges" style="float:right;color:var(--accent)">0</strong></td>
+      </tr>
+      <tr>
+        <td style="padding:4px 0;color:var(--text-secondary)">Conflicts (e.g. notes):</td>
+        <td><strong id="previewConflicts" style="float:right;color:var(--warning)">0</strong></td>
+      </tr>
+    </table>
+
+    <!-- Option for Import Mode -->
+    <div style="margin:15px 0 10px 0;border-top:1px solid var(--border-color);padding-top:10px">
+      <label class="m-lbl" style="margin-bottom:5px">Import Mode</label>
+      <div style="display:flex;gap:15px;align-items:center">
+        <label style="font-size:0.8rem;cursor:pointer;display:flex;align-items:center;gap:4px">
+          <input type="radio" name="importMode" value="merge" checked> Merge (Safe append)
+        </label>
+        <label style="font-size:0.8rem;cursor:pointer;display:flex;align-items:center;gap:4px">
+          <input type="radio" name="importMode" value="replace"> Replace (Overwrite)
+        </label>
+      </div>
+      <div style="font-size:0.7rem;color:var(--text-muted);margin-top:4px" id="importModeHelp">
+        Merge will add new progress and combine note differences. Replace will overwrite only the questions found in your import file (unmatched existing progress is preserved).
+      </div>
     </div>
 
-    <!-- Preview Container -->
-    <div id="importPreviewContainer" style="display:none;margin-top:15px;background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:10px;padding:12px;max-height:300px;overflow-y:auto">
-      <h4 style="margin:0 0 8px 0;font-size:0.9rem">Dry-Run Preview Summary</h4>
-      <table style="width:100%;font-size:0.8rem;border-collapse:collapse;margin-bottom:10px">
-        <tr>
-          <td style="padding:4px 0;color:var(--text-secondary)">Total Parsed:</td>
-          <td><strong id="previewTotal" style="float:right">0</strong></td>
-        </tr>
-        <tr>
-          <td style="padding:4px 0;color:var(--text-secondary)">Matched:</td>
-          <td><strong id="previewMatched" style="float:right">0</strong></td>
-        </tr>
-        <tr>
-          <td style="padding:4px 0;color:var(--text-secondary)">Unmatched (Skipped):</td>
-          <td><strong id="previewUnmatched" style="float:right">0</strong></td>
-        </tr>
-        <tr>
-          <td style="padding:4px 0;color:var(--text-secondary)">Changes Detected:</td>
-          <td><strong id="previewChanges" style="float:right;color:var(--accent)">0</strong></td>
-        </tr>
-        <tr>
-          <td style="padding:4px 0;color:var(--text-secondary)">Conflicts (e.g. notes):</td>
-          <td><strong id="previewConflicts" style="float:right;color:var(--warning)">0</strong></td>
-        </tr>
-      </table>
-
-      <!-- Option for Import Mode -->
-      <div style="margin:15px 0 10px 0;border-top:1px solid var(--border-color);padding-top:10px">
-        <label class="m-lbl" style="margin-bottom:5px">Import Mode</label>
-        <div style="display:flex;gap:15px;align-items:center">
-          <label style="font-size:0.8rem;cursor:pointer;display:flex;align-items:center;gap:4px">
-            <input type="radio" name="importMode" value="merge" checked> Merge (Safe append)
-          </label>
-          <label style="font-size:0.8rem;cursor:pointer;display:flex;align-items:center;gap:4px">
-            <input type="radio" name="importMode" value="replace"> Replace (Overwrite)
-          </label>
-        </div>
-        <div style="font-size:0.7rem;color:var(--text-muted);margin-top:4px" id="importModeHelp">
-          Merge will add new progress and combine note differences. Replace will overwrite only the questions found in your import file (unmatched existing progress is preserved).
-        </div>
-      </div>
-      
-      <!-- Change items preview list -->
-      <div id="previewItemsList" style="margin-top:10px;font-size:0.75rem;border-top:1px solid var(--border-color);padding-top:10px">
-        <div style="font-weight:700;margin-bottom:5px">Change Log (First 50 items):</div>
-        <ul id="previewList" style="padding-left:15px;margin:0;max-height:100px;overflow-y:auto;color:var(--text-secondary)"></ul>
-      </div>
+    <!-- Change items preview list -->
+    <div id="previewItemsList" style="margin-top:10px;font-size:0.75rem;border-top:1px solid var(--border-color);padding-top:10px">
+      <div style="font-weight:700;margin-bottom:5px">Change Log (First 50 items):</div>
+      <ul id="previewList" style="padding-left:15px;margin:0;max-height:100px;overflow-y:auto;color:var(--text-secondary)"></ul>
     </div>
 
     <div class="m-actions" style="margin-top:20px">
@@ -560,8 +554,7 @@
         </span>
       </button>
     </div>
-  </div>
-</div>
+{% endcall %}
 
 <!-- Sync Loading Overlay -->
 <div id="syncOverlay" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.75);z-index:10000;flex-direction:column;align-items:center;justify-content:center;gap:20px">

--- a/tests/test_modal_macro.py
+++ b/tests/test_modal_macro.py
@@ -8,9 +8,10 @@ STATIC_DIR = Path(__file__).resolve().parents[1] / "static"
 def test_modal_macro_exists_and_defines_notes_modal():
     template = (TEMPLATE_DIR / "macros" / "modals.html").read_text(encoding="utf-8")
 
+    assert 'from "_macros.html" import app_modal_shell' in template
     assert "macro notes_modal" in template
-    assert 'class="app-modal"' in template
-    assert 'class="app-modal__dialog"' in template
+    assert "{% call app_modal_shell(" in template
+    assert 'class="app-modal__textarea"' in template
     assert 'class="app-modal__actions"' in template
 
 
@@ -37,3 +38,13 @@ def test_topic_and_bookmarks_use_shared_notes_modal_macro():
 
     assert "modal-overlay" not in topic_template
     assert "modal-ov" not in bookmarks_template
+
+
+def test_profile_and_admin_use_shared_app_modal_shell():
+    profile_template = (TEMPLATE_DIR / "profile.html").read_text(encoding="utf-8")
+    admin_template = (TEMPLATE_DIR / "admin" / "dashboard.html").read_text(encoding="utf-8")
+
+    assert 'app_modal_shell' in profile_template
+    assert "{% call app_modal_shell('importModal'" in profile_template
+    assert 'app_modal_shell' in admin_template
+    assert "{% call app_modal_shell('delete-modal'" in admin_template


### PR DESCRIPTION
## Summary
- introduce a shared `app_modal_shell` helper
- route notes modal, profile import modal, and admin delete modal through the shared shell
- keep the existing profile-specific shell for the complex profile dialogs

Closes #419

## Validation
- `python3 -m pytest tests/test_modal_macro.py -q`
- `python3 - <<'PY'` Jinja parse check for `templates/_macros.html`, `templates/macros/modals.html`, `templates/profile.html`, and `templates/admin/dashboard.html`
- `node -c static/js/admin.js`
- `git diff --check`