### PR TITLE
[codex] expand JSON progress export

### DIFF
--- a/app/tracker/routes.py
+++ b/app/tracker/routes.py
@@ -510,6 +510,26 @@ def export_json():
 
     progress = current_user.progress
     exported_progress = []
+    exported_profile = {
+        "name": getattr(current_user, "name", "") or "",
+        "headline": getattr(current_user, "headline", "") or "",
+        "bio": getattr(current_user, "bio", "") or "",
+        "location": getattr(current_user, "location", "") or "",
+        "college": getattr(current_user, "college", "") or "",
+        "profile_visibility": getattr(current_user, "profile_visibility", "public") or "public",
+        "profile_photo": getattr(current_user, "profile_photo", "") or "",
+        "linkedin_url": getattr(current_user, "linkedin_url", "") or "",
+        "twitter_url": getattr(current_user, "twitter_url", "") or "",
+        "website_url": getattr(current_user, "website_url", "") or "",
+        "resume_url": getattr(current_user, "resume_url", "") or "",
+        "leetcode_username": getattr(current_user, "leetcode_username", "") or "",
+        "github_username": getattr(current_user, "github_username", "") or "",
+        "gfg_username": getattr(current_user, "gfg_username", "") or "",
+        "hackerrank_username": getattr(current_user, "hackerrank_username", "") or "",
+        "codingninjas_username": getattr(current_user, "codingninjas_username", "") or "",
+        "atcoder_username": getattr(current_user, "atcoder_username", "") or "",
+        "codewars_username": getattr(current_user, "codewars_username", "") or "",
+    }
 
     for question in questions:
         question_id = str(question.get('_id'))
@@ -524,14 +544,17 @@ def export_json():
             ):
             topic_name = topic_lookup.get(question.get('topic'), 'Unknown')
             exported_progress.append({
+                "question_id": question_id,
                 "topic": topic_name,
                 "problem": question.get('problem', ''),
+                "difficulty": question.get('difficulty', 'Medium'),
                 "done": bool(item_progress.get('done', False)),
                 "bookmark": bool(item_progress.get('bookmark', False)),
                 "skipped": bool(item_progress.get('skipped', False)),
                 "notes": item_progress.get('notes', ''),
                 "url": question.get('url', ''),
                 "url2": question.get('url2', ''),
+                "tags": list(item_progress.get('tags', [])) if isinstance(item_progress.get('tags'), list) else [],
                 "revision_status":
                 item_progress.get(
                     "revision_status",
@@ -549,6 +572,7 @@ def export_json():
     backup_data = {
         "version": "1.0",
         "exported_at": utc_now().isoformat(),
+        "profile": exported_profile,
         "progress": exported_progress
     }
 

--- a/tests/test_progress_import.py
+++ b/tests/test_progress_import.py
@@ -87,6 +87,7 @@ def test_export_json_route(monkeypatch):
     question_id = test_db.question.insert_one({
         "topic": topic_id,
         "problem": "Two Sum",
+        "difficulty": "Easy",
         "url": "https://leetcode.com/problems/two-sum/",
         "url2": ""
     }).inserted_id
@@ -95,13 +96,36 @@ def test_export_json_route(monkeypatch):
     str(question_id): {
         "done": True,
         "bookmark": True,
+        "tags": ["arrays", "hashmap"],
         "notes": "Good notes",
         "revision_status": "Reviewed",
         "last_reviewed": tracker_routes.utc_now()
     }
 }
 
-    user_id = test_db.user.insert_one({"email": "user@example.com", "progress": progress, "is_admin": False}).inserted_id
+    user_id = test_db.user.insert_one({
+        "email": "user@example.com",
+        "name": "Test User",
+        "headline": "Problem Solver",
+        "bio": "Enjoys building things",
+        "location": "India",
+        "college": "Codex University",
+        "profile_visibility": "public",
+        "profile_photo": "https://example.com/avatar.png",
+        "linkedin_url": "https://linkedin.com/in/test-user",
+        "twitter_url": "https://x.com/test-user",
+        "website_url": "https://example.com",
+        "resume_url": "https://example.com/resume.pdf",
+        "leetcode_username": "test-lc",
+        "github_username": "test-gh",
+        "gfg_username": "test-gfg",
+        "hackerrank_username": "test-hr",
+        "codingninjas_username": "test-cn",
+        "atcoder_username": "test-ac",
+        "codewars_username": "test-cw",
+        "progress": progress,
+        "is_admin": False,
+    }).inserted_id
 
     with flask_app.test_client() as client:
         login_test_user(client, user_id)
@@ -112,10 +136,15 @@ def test_export_json_route(monkeypatch):
     
     data = json.loads(response.data)
     assert data["version"] == "1.0"
+    assert data["profile"]["name"] == "Test User"
+    assert data["profile"]["leetcode_username"] == "test-lc"
     assert len(data["progress"]) == 1
+    assert data["progress"][0]["question_id"] == str(question_id)
     assert data["progress"][0]["problem"] == "Two Sum"
+    assert data["progress"][0]["difficulty"] == "Easy"
     assert data["progress"][0]["done"] is True
     assert data["progress"][0]["notes"] == "Good notes"
+    assert data["progress"][0]["tags"] == ["arrays", "hashmap"]
     assert data["progress"][0]["revision_status"] == "Reviewed"
     assert data["progress"][0]["last_reviewed"] is not None
 


### PR DESCRIPTION
## Summary
- expand the JSON backup export with profile metadata and platform usernames
- include richer per-question progress fields such as question id, difficulty, and tags when present
- keep the export free of secrets while preserving the existing download flow

Closes #278

## Validation
- `python3 -m pytest tests/test_progress_import.py -q`
- `git diff --check`