### PR TITLE
[codex] make profile card share button real

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -19,12 +19,17 @@
 .link-out{color:var(--text-muted);font-size:0.85rem;text-decoration:none}
 .link-out:hover{color:var(--accent)}
 .add-btn{margin-top:4px}
-.rank-card{background:linear-gradient(135deg,rgba(255,107,0,.08),rgba(255,55,95,.06));border:1px solid var(--border-color);border-radius:14px;padding:14px}
+.rank-card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:14px}
 .rank-num{font-size:2rem;font-weight:900;color:var(--text-primary)}
 .rank-label{font-size:0.75rem;color:var(--text-secondary)}
 .view-lb-btn{margin-top:10px}
 .meta-footer{font-size:0.72rem;color:var(--text-muted);display:flex;flex-direction:column;gap:4px;margin-top:8px}
 .meta-footer span{display:flex;justify-content:space-between}
+.profile-card-shell{background:var(--bg-card);border:1px solid var(--border-color);border-radius:16px;padding:24px;text-align:center;color:var(--text-primary)}
+.profile-card-stats{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px;margin-bottom:14px}
+.profile-card-stat{background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:10px;padding:10px}
+.profile-card-share-btn{width:100%;margin-top:14px;padding:10px;background:var(--accent);border:none;border-radius:10px;color:#fff;font-weight:700;font-size:.85rem;cursor:pointer;font-family:inherit;transition:background .2s}
+.profile-card-share-btn:hover{background:var(--accent-hover)}
 /* stat cards */
 .stat-row{display:grid;grid-template-columns:1fr 1fr 1fr 2fr;gap:12px;min-width:0}
 .stat-card{background:var(--bg-card);border:1px solid var(--border-color);border-radius:14px;padding:16px;color:var(--text-primary)}
@@ -39,12 +44,12 @@
 .contest-grid{display:grid;grid-template-columns:1fr 2fr;gap:12px;min-height:160px}
 .empty-chart{display:flex;flex-direction:column;align-items:center;justify-content:center;height:110px;color:var(--text-muted);font-size:.8rem;gap:6px}
 .chart-shell{position:relative;min-height:130px}
-.chart-shell .chart-skeleton{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;border-radius:12px;background:rgba(255,255,255,.04);overflow:hidden}
+.chart-shell .chart-skeleton{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;border-radius:12px;background:var(--bg-card-hover);overflow:hidden}
 .chart-shell .chart-skeleton::after{content:"";position:absolute;inset:0;transform:translateX(-100%);background:linear-gradient(90deg,transparent,rgba(255,255,255,.12),transparent);animation:skeleton-shimmer 1.15s linear infinite}
 .chart-shell canvas{position:relative;z-index:1}
 .chart-shell.is-ready .chart-skeleton{display:none}
 .awards-grid{display:flex;gap:10px;flex-wrap:wrap;margin-top:4px}
-.award-badge{width:64px;height:74px;background:linear-gradient(135deg,rgba(255,107,0,.15),rgba(255,55,95,.1));border:1px solid var(--border-color);border-radius:12px;display:flex;flex-direction:column;align-items:center;justify-content:center;font-size:1.6rem;cursor:pointer;transition:all .2s;position:relative;overflow:hidden;padding:4px}
+.award-badge{width:64px;height:74px;background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:12px;display:flex;flex-direction:column;align-items:center;justify-content:center;font-size:1.6rem;cursor:pointer;transition:all .2s;position:relative;overflow:hidden;padding:4px}
 .award-badge:hover{border-color:var(--accent);transform:translateY(-2px)}
 .award-badge .a-lbl{font-size:.58rem;color:var(--text-muted);margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:58px;text-align:center}
 .hr-stars{display:flex;gap:1px;align-items:center;justify-content:center;flex-wrap:nowrap;line-height:1}
@@ -189,6 +194,8 @@
   .award-badge{width:44px;height:52px;font-size:1rem;border-radius:8px;padding:2px}
   .award-badge .a-lbl{font-size:.44rem;max-width:40px;margin-top:2px}
   .award-badge:hover{transform:translateY(-1px)}
+  .profile-card-stats{grid-template-columns:1fr;gap:8px}
+  .profile-card-shell{padding:18px;border-radius:12px}
   .donut-wrap{width:80px;height:80px;margin-bottom:8px}
   .donut-inner{font-size:.9rem}
   .shield-icon{font-size:2rem}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -420,19 +420,19 @@
 {% endcall %}
 
 <!-- Codolio Card Modal -->
-{% call modal_shell('cardModal', 'Your Profile Card', 'cardModalTitle', "document.getElementById('cardModal').classList.remove('open')", box_style='max-width:400px;background:linear-gradient(135deg,#1a1a2e,#16213e);border-color:#2a2a4a') %}
-    <div style="background:linear-gradient(135deg,rgba(255,107,0,.2),rgba(255,55,95,.15));border:1px solid rgba(255,107,0,.3);border-radius:16px;padding:24px;text-align:center">
+{% call modal_shell('cardModal', 'Your Profile Card', 'cardModalTitle', "document.getElementById('cardModal').classList.remove('open')", box_style='max-width:400px') %}
+    <div class="profile-card-shell">
       <div style="width:70px;height:70px;border-radius:50%;background:linear-gradient(135deg,var(--accent),#ff375f);display:flex;align-items:center;justify-content:center;font-size:1.8rem;font-weight:900;color:#fff;margin:0 auto 12px">{{ user.name[0]|upper }}</div>
       <div style="font-size:1.1rem;font-weight:800;margin-bottom:2px">{{ user.name }}</div>
       <div style="font-size:.8rem;color:var(--accent);margin-bottom:14px">@{{ user.leetcode_username or user.name|lower|replace(' ','') }}</div>
-      <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px;margin-bottom:14px">
-        <div style="background:rgba(255,255,255,.05);border-radius:10px;padding:10px"><div style="font-size:1.2rem;font-weight:900">{{ global_total_solved }}</div><div style="font-size:.65rem;color:var(--text-secondary)">Questions</div></div>
-        <div style="background:rgba(255,255,255,.05);border-radius:10px;padding:10px"><div style="font-size:1.2rem;font-weight:900">{{ total_active_days }}</div><div style="font-size:.65rem;color:var(--text-secondary)">Active Days</div></div>
-        <div style="background:rgba(255,255,255,.05);border-radius:10px;padding:10px"><div style="font-size:1.2rem;font-weight:900">{{ lc_rating or dsa_done }}</div><div style="font-size:.65rem;color:var(--text-secondary)">{{ 'LC Rating' if lc_rating else 'DSA Done' }}</div></div>
+      <div class="profile-card-stats">
+        <div class="profile-card-stat"><div style="font-size:1.2rem;font-weight:900">{{ global_total_solved }}</div><div style="font-size:.65rem;color:var(--text-secondary)">Questions</div></div>
+        <div class="profile-card-stat"><div style="font-size:1.2rem;font-weight:900">{{ total_active_days }}</div><div style="font-size:.65rem;color:var(--text-secondary)">Active Days</div></div>
+        <div class="profile-card-stat"><div style="font-size:1.2rem;font-weight:900">{{ lc_rating or dsa_done }}</div><div style="font-size:.65rem;color:var(--text-secondary)">{{ 'LC Rating' if lc_rating else 'DSA Done' }}</div></div>
       </div>
       <div style="font-size:.72rem;color:var(--text-muted)">450 DSA Cracker • {{ 2026 }}</div>
     </div>
-    <button onclick="showToast('Profile card copied! 📋')" style="width:100%;margin-top:14px;padding:10px;background:var(--accent);border:none;border-radius:10px;color:#fff;font-weight:700;font-size:.85rem;cursor:pointer;font-family:inherit">Share Card</button>
+    <button type="button" class="profile-card-share-btn" onclick="copyProfileCardUrl()" aria-label="Copy your public profile card link">Share Card</button>
 {% endcall %}
 
 <!-- Edit Profile Modal -->
@@ -782,6 +782,15 @@ if('IntersectionObserver'in window&&chartShells.length){const io=new Intersectio
 function openSyncModal(){document.getElementById('syncModal').classList.add('open')}
 function closeSyncModal(){document.getElementById('syncModal').classList.remove('open')}
 function showCodelioCard(){document.getElementById('cardModal').classList.add('open')}
+function copyProfileCardUrl(){
+  const url=window.location.origin+endpointConfig.publicCardPath;
+  const onSuccess=()=>{if(typeof showToast==='function')showToast('Profile card link copied!','success')};
+  if(!navigator.clipboard||typeof navigator.clipboard.writeText!=='function'){
+    window.prompt('Copy your profile card link',url);
+    return;
+  }
+  navigator.clipboard.writeText(url).then(onSuccess).catch(()=>window.prompt('Copy your profile card link',url));
+}
 function openEditProfile(){document.getElementById('editProfileModal').classList.add('open')}
 function closeEditProfile(){document.getElementById('editProfileModal').classList.remove('open')}
 

--- a/tests/test_button_utility_classes.py
+++ b/tests/test_button_utility_classes.py
@@ -19,6 +19,16 @@ def test_base_template_defines_shared_button_utility_classes():
     assert ".ui-btn-block {" in stylesheet
 
 
+def test_profile_cards_use_theme_safe_surfaces():
+    stylesheet = (STATIC_DIR / "css" / "profile.css").read_text(encoding="utf-8")
+
+    assert ".rank-card{background:var(--bg-card);" in stylesheet
+    assert ".award-badge{width:64px;height:74px;background:var(--bg-secondary);" in stylesheet
+    assert ".chart-shell .chart-skeleton{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;border-radius:12px;background:var(--bg-card-hover);" in stylesheet
+    assert ".profile-card-shell{background:var(--bg-card);" in stylesheet
+    assert ".profile-card-share-btn{width:100%;margin-top:14px;padding:10px;background:var(--accent);" in stylesheet
+
+
 def test_profile_and_topic_templates_use_button_utilities():
     profile_template = (TEMPLATE_DIR / "profile.html").read_text(encoding="utf-8")
     topic_template = (TEMPLATE_DIR / "topic.html").read_text(encoding="utf-8")

--- a/tests/test_progress_card_copy.py
+++ b/tests/test_progress_card_copy.py
@@ -35,3 +35,15 @@ def test_profile_template_uses_shared_modal_macro():
 
     assert '{% from "_macros.html" import modal_shell %}' in template
     assert template.count("{% call modal_shell(") == 3
+
+
+def test_profile_card_modal_uses_theme_safe_surface_and_real_copy_action():
+    template = PROFILE_TEMPLATE.read_text(encoding="utf-8")
+
+    assert 'class="profile-card-shell"' in template
+    assert 'class="profile-card-stats"' in template
+    assert 'class="profile-card-stat"' in template
+    assert 'class="profile-card-share-btn"' in template
+    assert "copyProfileCardUrl()" in template
+    assert "showToast('Profile card copied! 📋')" not in template
+    assert "background:linear-gradient(135deg,#1a1a2e,#16213e)" not in template


### PR DESCRIPTION
Closes #32

## Summary
- replace the fake profile card toast with a real clipboard copy action for the public profile card URL
- move the profile card modal off hardcoded dark-only surfaces onto theme variables so light mode renders correctly
- add focused template/style assertions to keep the share flow and theme-safe surfaces from regressing

## Validation
- ...........                                                              [100%]
11 passed in 0.13s
- 