### PR TITLE
[codex] add shared external link badge macro

### DIFF
--- a/templates/_macros.html
+++ b/templates/_macros.html
@@ -9,3 +9,9 @@
   </div>
 </div>
 {%- endmacro %}
+
+{% macro external_link_badge(href, label, color_class='badge-link', icon_class='bi-box-arrow-up-right', aria_label='', extra_class='') -%}
+<a class="q-badge {{ color_class }}{{ ' ' ~ extra_class if extra_class }}" href="{{ href }}" target="_blank" rel="noopener noreferrer" aria-label="{{ aria_label or (label ~ ' (opens in new tab)') }}">
+  <i class="bi {{ icon_class }}" aria-hidden="true"></i>{{ label }}
+</a>
+{%- endmacro %}

--- a/templates/bookmarks.html
+++ b/templates/bookmarks.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "macros/modals.html" import notes_modal %}
+{% from "_macros.html" import external_link_badge %}
 {% block content %}
 <style>
   .page-title {
@@ -127,12 +128,14 @@
         <td>
           <div class="q-name">{{ q.problem }}</div>
           <div class="q-links">
-            {% if q.url %}<a href="{{ q.url }}" target="_blank" rel="noopener noreferrer"
-              class="q-badge {% if 'leetcode' in q.url %}badge-lc{% elif 'geeksforgeeks' in q.url %}badge-gfg{% else %}badge-link{% endif %}"><i
-                class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{ q.url|platform_name }}</a>{% endif %}
-            {% if q.url2 %}<a href="{{ q.url2 }}" target="_blank" rel="noopener noreferrer"
-              class="q-badge badge-link"><i class="bi bi-box-arrow-up-right" style="font-size:.7rem"></i> {{
-              q.url2|platform_name }}</a>{% endif %}
+            {% if q.url %}
+              {% set q1 = q.url|platform_name %}
+              {{ external_link_badge(q.url, q1, 'badge-lc' if 'leetcode' in q.url else 'badge-gfg' if 'geeksforgeeks' in q.url else 'badge-link', 'bi-box-arrow-up-right', 'Solve on ' ~ q1 ~ ' (opens in new tab)') }}
+            {% endif %}
+            {% if q.url2 %}
+              {% set q2 = q.url2|platform_name %}
+              {{ external_link_badge(q.url2, q2, 'badge-link', 'bi-box-arrow-up-right', 'Solve on ' ~ q2 ~ ' (opens in new tab)') }}
+            {% endif %}
           </div>
         </td>
         <td>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "_macros.html" import modal_shell %}
+{% from "_macros.html" import modal_shell, external_link_badge %}
 {% block head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/profile.css') }}">
 {% endblock %}
@@ -140,19 +140,19 @@
     <div class="platform-row">
       <span><i class="bi bi-terminal" style="color:#00bd6c;margin-right:6px" aria-hidden="true"></i>HackerRank</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.hackerrank_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="{{ user.hackerrank_username | platform_url('hackerrank') }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="HackerRank profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect HackerRank account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.hackerrank_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ external_link_badge(user.hackerrank_username | platform_url('hackerrank'), 'HackerRank', 'badge-link', 'bi-box-arrow-up-right', 'HackerRank profile (opens in new tab)') }}{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect HackerRank account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
       </span>
     </div>
     <div class="platform-row">
       <span><i class="bi bi-trophy" style="color:#f97316;margin-right:6px" aria-hidden="true"></i>AtCoder</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.atcoder_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="{{ user.atcoder_username | platform_url('atcoder') }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="AtCoder profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect AtCoder account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.atcoder_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ external_link_badge(user.atcoder_username | platform_url('atcoder'), 'AtCoder', 'badge-link', 'bi-box-arrow-up-right', 'AtCoder profile (opens in new tab)') }}{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect AtCoder account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
       </span>
     </div>
     <div class="platform-row">
       <span><i class="bi bi-fire" style="color:#b1361e;margin-right:6px" aria-hidden="true"></i>Codewars</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.codewars_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="{{ user.codewars_username | platform_url('codewars') }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="Codewars profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect Codewars account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.codewars_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ external_link_badge(user.codewars_username | platform_url('codewars'), 'Codewars', 'badge-link', 'bi-box-arrow-up-right', 'Codewars profile (opens in new tab)') }}{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect Codewars account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
       </span>
     </div>
     <button class="add-btn ui-btn ui-btn-secondary ui-btn-block" onclick="openSyncModal()" aria-label="Add or connect coding platform accounts"><i class="bi bi-plus" aria-hidden="true"></i> Add Platform</button>
@@ -160,7 +160,7 @@
     <div class="platform-row">
       <span><i class="bi bi-github" style="margin-right:6px" aria-hidden="true"></i>GitHub</span>
       <span style="display:flex;align-items:center;gap:6px">
-        {% if user.github_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i><a href="{{ user.github_username | platform_url('github') }}" target="_blank" rel="noopener noreferrer" class="link-out" aria-label="GitHub profile (opens in new tab)"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect GitHub account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
+        {% if user.github_username %}<i class="bi bi-check-circle-fill check-ok" aria-hidden="true"></i>{{ external_link_badge(user.github_username | platform_url('github'), 'GitHub', 'badge-link', 'bi-box-arrow-up-right', 'GitHub profile (opens in new tab)') }}{% else %}<a href="#" class="link-out" onclick="openSyncModal();return false;" aria-label="Connect GitHub account"><i class="bi bi-box-arrow-up-right" aria-hidden="true"></i></a>{% endif %}
       </span>
     </div>
   </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros.html" import external_link_badge %}
 {% block content %}
 <style>
 .search-shell { max-width: 980px; }
@@ -331,10 +332,12 @@
 {% endblock %}
 
 {% block scripts %}
+{% set external_badge_template = external_link_badge('__HREF__', '__LABEL__', '__COLOR__', '__ICON__', '__ARIA__') %}
 <script>
 const endpointConfig = {{ {
   "searchQuestions": url_for('search.api_search_questions'),
 }|tojson }};
+const badgeMarkupTemplate = {{ external_badge_template|tojson }};
 const input = document.getElementById('searchInput');
 const results = document.getElementById('results');
 const meta = document.getElementById('searchMeta');
@@ -358,6 +361,15 @@ const platformLabels = {
   cn: 'Coding Ninjas',
   hackerrank: 'HackerRank'
 };
+
+function renderExternalBadge({ href, label, color = 'badge-link', icon = 'bi-box-arrow-up-right', ariaLabel = '' }) {
+  return badgeMarkupTemplate
+    .replaceAll('__HREF__', escapeHtml(href))
+    .replaceAll('__LABEL__', escapeHtml(label))
+    .replaceAll('__COLOR__', escapeHtml(color))
+    .replaceAll('__ICON__', escapeHtml(icon))
+    .replaceAll('__ARIA__', escapeHtml(ariaLabel || `${label} (opens in new tab)`));
+}
 
 function getFilters() {
   return {
@@ -530,9 +542,13 @@ function renderResults(payload) {
 
   if (!count) {
     const external = (payload.external_searches || []).map(link =>
-      `<a class="q-badge ${badgeClass(link.color)}" href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="Search ${escapeHtml(link.platform)} for your query (opens new tab)">
-        <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>${escapeHtml(link.platform)}
-      </a>`
+      renderExternalBadge({
+        href: link.url,
+        label: link.platform,
+        color: badgeClass(link.color),
+        icon: 'bi-box-arrow-up-right',
+        ariaLabel: `Search ${link.platform} for your query (opens new tab)`
+      })
     ).join('');
     results.innerHTML = `<div class="empty-search"><i class="bi bi-search-heart" aria-hidden="true"></i><p>No sheet match found.</p><div class="link-row" style="justify-content:center">${external}</div></div>`;
     return;
@@ -540,19 +556,31 @@ function renderResults(payload) {
 
   results.innerHTML = payload.results.map(item => {
     const directLinks = (item.links || []).map(link =>
-      `<a class="q-badge ${badgeClass(link.color)}" href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="View on ${escapeHtml(link.platform)} (opens new tab)">
-        <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>${escapeHtml(link.platform)}
-      </a>`
+      renderExternalBadge({
+        href: link.url,
+        label: link.platform,
+        color: badgeClass(link.color),
+        icon: 'bi-box-arrow-up-right',
+        ariaLabel: `View on ${link.platform} (opens new tab)`
+      })
     ).join('');
     const editorialLinks = (item.editorial_links || []).map(link =>
-      `<a class="q-badge badge-link" href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="Read ${escapeHtml(link.label)} (opens new tab)">
-        <i class="bi bi-journal-text" aria-hidden="true"></i>${escapeHtml(link.label)}
-      </a>`
+      renderExternalBadge({
+        href: link.url,
+        label: link.label,
+        color: 'badge-link',
+        icon: 'bi-journal-text',
+        ariaLabel: `Read ${link.label} (opens new tab)`
+      })
     ).join('');
     const platformSearches = (item.external_searches || []).map(link =>
-      `<a class="q-badge ${badgeClass(link.color)}" href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="Search ${escapeHtml(link.platform)} for this problem (opens new tab)">
-        <i class="bi bi-search" aria-hidden="true"></i>${escapeHtml(link.platform)}
-      </a>`
+      renderExternalBadge({
+        href: link.url,
+        label: link.platform,
+        color: badgeClass(link.color),
+        icon: 'bi-search',
+        ariaLabel: `Search ${link.platform} for this problem (opens new tab)`
+      })
     ).join('');
     const topicUrl = `/topic/${encodeURIComponent(item.topic_id)}`;
 

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "macros/modals.html" import notes_modal %}
+{% from "_macros.html" import external_link_badge %}
 {% block content %}
 <style>
 .topic-title { font-size: 1.6rem; font-weight: 800; margin-bottom: 6px; }
@@ -164,26 +165,14 @@
                     <div class="q-links">
                         {% if q.url %}
                             {% set p1 = q.url|platform_name %}
-                            <a href="{{ q.url }}" target="_blank" rel="noopener noreferrer"
-                               class="q-badge {{ p1 | platform_badge }}"
-                               aria-label="Solve on {{ p1 }} (opens in new tab)">
-                               <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i> {{ p1 }}
-                            </a>
+                            {{ external_link_badge(q.url, p1, p1 | platform_badge, 'bi-box-arrow-up-right', 'Solve on ' ~ p1 ~ ' (opens in new tab)') }}
                         {% endif %}
                         {% if q.url2 %}
                             {% set p2 = q.url2|platform_name %}
-                            <a href="{{ q.url2 }}" target="_blank" rel="noopener noreferrer"
-                               class="q-badge {{ p2 | platform_badge }}"
-                               aria-label="Solve on {{ p2 }} (opens in new tab)">
-                               <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i> {{ p2 }}
-                            </a>
+                            {{ external_link_badge(q.url2, p2, p2 | platform_badge, 'bi-box-arrow-up-right', 'Solve on ' ~ p2 ~ ' (opens in new tab)') }}
                         {% endif %}
                         {% for editorial in q.editorial_links %}
-                            <a href="{{ editorial.url }}" target="_blank" rel="noopener noreferrer"
-                               class="q-badge badge-link"
-                               aria-label="Read {{ editorial.label }} (opens in new tab)">
-                               <i class="bi bi-journal-text" aria-hidden="true"></i> {{ editorial.label }}
-                            </a>
+                            {{ external_link_badge(editorial.url, editorial.label, 'badge-link', 'bi-journal-text', 'Read ' ~ editorial.label ~ ' (opens in new tab)') }}
                         {% endfor %}
                     </div>
                     {% if q.hints %}

--- a/tests/test_external_link_badges.py
+++ b/tests/test_external_link_badges.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "templates"
+
+
+def test_external_link_badge_macro_is_shared_across_templates():
+    macros = (TEMPLATE_DIR / "_macros.html").read_text(encoding="utf-8")
+    topic = (TEMPLATE_DIR / "topic.html").read_text(encoding="utf-8")
+    bookmarks = (TEMPLATE_DIR / "bookmarks.html").read_text(encoding="utf-8")
+    profile = (TEMPLATE_DIR / "profile.html").read_text(encoding="utf-8")
+    search = (TEMPLATE_DIR / "search.html").read_text(encoding="utf-8")
+
+    assert "macro external_link_badge(" in macros
+    assert "rel=\"noopener noreferrer\"" in macros
+
+    assert "{% from \"_macros.html\" import external_link_badge %}" in topic
+    assert "external_link_badge(q.url, p1" in topic
+    assert "external_link_badge(editorial.url, editorial.label" in topic
+
+    assert "{% from \"_macros.html\" import external_link_badge %}" in bookmarks
+    assert "external_link_badge(q.url, q1" in bookmarks
+    assert "external_link_badge(q.url2, q2" in bookmarks
+
+    assert "{% from \"_macros.html\" import modal_shell, external_link_badge %}" in profile
+    assert "external_link_badge(user.hackerrank_username | platform_url('hackerrank'), 'HackerRank'" in profile
+    assert "external_link_badge(user.github_username | platform_url('github'), 'GitHub'" in profile
+
+    assert "{% from \"_macros.html\" import external_link_badge %}" in search
+    assert "badgeMarkupTemplate" in search
+    assert "renderExternalBadge({" in search

--- a/tests/test_progress_card_copy.py
+++ b/tests/test_progress_card_copy.py
@@ -33,5 +33,5 @@ def test_profile_template_uses_shared_toast_and_button_busy_helpers():
 def test_profile_template_uses_shared_modal_macro():
     template = PROFILE_TEMPLATE.read_text(encoding="utf-8")
 
-    assert '{% from "_macros.html" import modal_shell %}' in template
+    assert '{% from "_macros.html" import modal_shell, external_link_badge %}' in template
     assert template.count("{% call modal_shell(") == 3


### PR DESCRIPTION
Closes #418

Summary:
- add a reusable external_link_badge Jinja macro for external problem and editorial links
- replace repeated badge markup in topic, bookmarks, profile, and search result rendering with the shared helper
- keep the search page dynamic by rendering its badge HTML from the same macro-shaped template string

Validation:
- python3 -m pytest tests/test_external_link_badges.py tests/test_button_utility_classes.py tests/test_progress_card_copy.py -q
- git diff --check