### PR TITLE
[codex] theme the topic table controls in day mode

### DIFF
--- a/templates/bookmarks.html
+++ b/templates/bookmarks.html
@@ -81,6 +81,19 @@
     font-size: .78rem;
   }
 
+  .q-checkbox {
+    accent-color: var(--accent);
+  }
+
+  .revision-select {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 6px 10px;
+    font: inherit;
+  }
+
   @media(max-width:640px) {
 
     .q-table thead th:nth-child(1),

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -14,6 +14,15 @@
 
 .q-table { width: 100%; border-collapse: collapse; min-width: 600px; }
 .q-table tbody tr.row-done { background: rgba(34,197,94,0.04); }
+.q-checkbox { accent-color: var(--accent); }
+.revision-select {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 6px 10px;
+    font: inherit;
+}
 .q-num { color: var(--text-muted); font-weight: 600; font-size: 0.8rem; min-width: 32px; }
 .topic-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 24px; }
 .topic-header-main { min-width: 0; }

--- a/tests/test_button_utility_classes.py
+++ b/tests/test_button_utility_classes.py
@@ -23,6 +23,7 @@ def test_profile_and_topic_templates_use_button_utilities():
     profile_template = (TEMPLATE_DIR / "profile.html").read_text(encoding="utf-8")
     topic_template = (TEMPLATE_DIR / "topic.html").read_text(encoding="utf-8")
     base_template = (TEMPLATE_DIR / "base.html").read_text(encoding="utf-8")
+    bookmarks_template = (TEMPLATE_DIR / "bookmarks.html").read_text(encoding="utf-8")
 
     assert "class=\"card-btn ui-btn ui-btn-primary ui-btn-block\"" in profile_template
     assert "class=\"card-btn ui-btn ui-btn-success ui-btn-block\"" in profile_template
@@ -36,6 +37,11 @@ def test_profile_and_topic_templates_use_button_utilities():
     assert "class=\"pill-btn ui-btn ui-btn-secondary ui-btn-pill\"" in base_template
     assert "class=\"pill-btn accent ui-btn ui-btn-primary ui-btn-pill\"" in base_template
     assert "class=\"icon-btn ui-btn ui-btn-secondary ui-btn-icon\"" in base_template
+
+    assert ".q-checkbox { accent-color: var(--accent);" in topic_template
+    assert ".revision-select {" in topic_template
+    assert ".q-checkbox {" in bookmarks_template
+    assert "background: var(--bg-secondary);" in bookmarks_template
 
 
 def test_app_styles_load_after_bootstrap_for_theme_overrides():


### PR DESCRIPTION
Closes #778

## Summary
- theme the topic-page revision select and checklist checkbox so they follow the active color palette
- apply the same control styling in bookmarks for consistency
- add a focused template assertion so the theme-safe controls do not regress

## Validation
- ...                                                                      [100%]
3 passed in 0.07s
- 