### PR TITLE
[codex] replace profile badge prints with logging

### DIFF
--- a/app/profile/routes.py
+++ b/app/profile/routes.py
@@ -517,12 +517,12 @@ def profile():
     try:
         lc_badges = json.loads(user.lc_badges_json or "[]")
     except json.JSONDecodeError:
-        print("Unable to handle leetcode badges")
+        current_app.logger.warning("Unable to handle leetcode badges", exc_info=True)
 
     try:
         hr_badges = [badge for badge in json.loads(user.hr_badges_json or "[]") if int(badge.get("stars", 0)) > 0]
     except (json.JSONDecodeError, ValueError):
-        print("Unable to handle hackerrank badges")
+        current_app.logger.warning("Unable to handle hackerrank badges", exc_info=True)
 
     leaderboard_entries = build_leaderboard_data()
     profile_leaderboard_rank = get_user_rank_by_c_score(user.id, leaderboard_entries)

--- a/tests/test_profile_rank_card.py
+++ b/tests/test_profile_rank_card.py
@@ -94,3 +94,29 @@ def test_profile_page_displays_real_local_leaderboard_rank(monkeypatch):
     assert response.status_code == 200
     assert "Current User" in html
     assert '<span class="rank-num">2</span>' in html
+
+
+def test_profile_page_logs_badge_parse_failures_instead_of_printing(monkeypatch, caplog):
+    flask_app, test_db = build_test_app(
+        monkeypatch,
+        extra_db_targets=(profile_routes, leaderboard_service),
+    )
+
+    user_id = test_db.user.insert_one(
+        {
+            "name": "Badge Parser",
+            "email": "badge@example.com",
+            "progress": {},
+            "lc_badges_json": "{not-json",
+            "hr_badges_json": "[{\"name\": \"Problem Solving\", \"stars\": \"bad\"}]",
+        }
+    ).inserted_id
+
+    with flask_app.test_client() as client:
+        login_test_user(client, user_id)
+        caplog.set_level("WARNING")
+        response = client.get("/profile")
+
+    assert response.status_code == 200
+    assert "Unable to handle leetcode badges" in caplog.text
+    assert "Unable to handle hackerrank badges" in caplog.text


### PR DESCRIPTION
Closes #30

Summary:
- replace the two profile badge parsing print calls with current_app.logger.warning()
- keep the profile page resilient when LeetCode or HackerRank badge JSON is malformed
- add a focused profile route test that asserts warnings are logged instead of crashing

Validation:
- python3 -m pytest tests/test_profile_rank_card.py -q
- git diff --check